### PR TITLE
New Pref to control display of Turnouts/Routes with no user name

### DIFF
--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -23,6 +23,7 @@
     <bool name="prefHideRecentLocosDefaultValue">false</bool>
     <bool name="prefRosterRecentLocosDefaultValue">false</bool>
     <bool name="prefHideSystemRouteNamesDefaultValue">false</bool>
+    <bool name="prefHideIfNoUserNameDefaultValue">true</bool>
     <bool name="prefShowEmergencyStopButtonDefaultValue">false</bool>
     <bool name="prefLayoutPowerButtonDefaultValue">false</bool>
     <bool name="prefConnectToFirstServer">false</bool>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -139,6 +139,8 @@
     <string name="prefSwipeThroughTurnoutsSummary">Include Turnouts screen when swiping between screens.</string>
     <string name="prefDropOnAcquireTitle">Drop Loco Before Acquire?</string>
     <string name="prefDropOnAcquireSummary">Drop current loco before acquiring new loco.</string>
+    <string name="prefHideIfNoUserNameTitle">Hide If No User Name?</string>
+    <string name="prefHideIfNoUserNameSummary">Omit Turnout/Route from list if the user name is empty.</string>
     <string name="prefHideRecentLocosTitle">Hide Recent Locos panel?</string>
     <string name="prefHideRecentLocosSummary">Leave more room for roster locos.</string>
     <string name="prefRosterRecentLocosTitle">Roster in Recent Locos?</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -224,6 +224,12 @@
             android:title="@string/prefDelimiterTitle" >
         </EditTextPreference>
         <CheckBoxPreference
+            android:defaultValue="@bool/prefHideIfNoUserNameDefaultValue"
+            android:key="HideIfNoUserNamePreference"
+            android:summary="@string/prefHideIfNoUserNameSummary"
+            android:title="@string/prefHideIfNoUserNameTitle" >
+        </CheckBoxPreference>
+        <CheckBoxPreference
             android:defaultValue="@bool/prefSwipeThroughTurnoutsDefaultValue"
             android:key="swipe_through_turnouts_preference"
             android:summary="@string/prefSwipeThroughTurnoutsSummary"

--- a/src/jmri/enginedriver/message_type.java
+++ b/src/jmri/enginedriver/message_type.java
@@ -52,5 +52,6 @@ interface message_type
   public static final int CURRENT_TIME=28;		// ta -> activities  updates current time
   public static final int CLOCK_DISPLAY=29;		// pref -> ta  clock display preference changed
   public static final int ESTOP=30;				// ta(sendeStopMsg) -> ta  estop requested
+  public static final int HIDE_IF_NO_USER_NAME=31;// pref -> turnouts or routes  hide if no user name preference changed
   
 }

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -157,6 +157,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 		else if(key.equals("DelimiterPreference")) {
 			mainapp.alert_activities(message_type.LOCATION_DELIMITER,"");
 		}
+		else if(key.equals("HideIfNoUserNamePreference")) {
+			mainapp.alert_activities(message_type.HIDE_IF_NO_USER_NAME,"");
+		}
 		else if(key.equals("ClockDisplayTypePreference")) {
 			mainapp.sendMsg(mainapp.comm_msg_handler, message_type.CLOCK_DISPLAY);
 		}

--- a/src/jmri/enginedriver/routes.java
+++ b/src/jmri/enginedriver/routes.java
@@ -93,8 +93,10 @@ public class routes extends Activity  implements OnGestureListener {
 			if (mainapp.rt_user_names != null) { //none defined
 				int pos = 0;
 				String del = prefs.getString("DelimiterPreference", getApplicationContext().getResources().getString(R.string.prefDelimiterDefaultValue));
+				boolean hideIfNoUserName = prefs.getBoolean("HideIfNoUserNamePreference", getResources().getBoolean(R.bool.prefHideIfNoUserNameDefaultValue));
 				for (String username : mainapp.rt_user_names) {
-					if (username != null && !username.equals(""))  {  //skip routes without usernames
+					boolean hasUserName = (username != null && !username.equals(""));
+					if (hasUserName || !hideIfNoUserName)  {  //skip routes without usernames if pref is set
 						//get values from global array
 						String systemname = mainapp.rt_system_names[pos];
 						String currentstate = mainapp.rt_states[pos];
@@ -105,7 +107,10 @@ public class routes extends Activity  implements OnGestureListener {
 
 						//put values into temp hashmap
 						HashMap<String, String> hm=new HashMap<String, String>();
-						hm.put("rt_user_name", username);
+						if (hasUserName)
+							hm.put("rt_user_name", username);
+						else
+							hm.put("rt_user_name", systemname);
 						hm.put("rt_system_name_hidden", systemname);
 						if (!hidesystemroutes) {  //check prefs for show or not show this
 							hm.put("rt_system_name", systemname);
@@ -114,7 +119,7 @@ public class routes extends Activity  implements OnGestureListener {
 						routesFullList.add(hm);
 
 						//if location is new, add to list
-						if(del.length() > 0) {
+						if(del.length() > 0 && hasUserName) {
 							int delim = username.indexOf(del);
 							if(delim >= 0) {
 								String loc = username.substring(0, delim);
@@ -212,6 +217,7 @@ public class routes extends Activity  implements OnGestureListener {
 			}
 			break;
 			case message_type.LOCATION_DELIMITER:
+			case message_type.HIDE_IF_NO_USER_NAME:
 				refresh_route_view();
 				break;
 			case message_type.WIT_CON_RETRY:
@@ -466,8 +472,7 @@ public class routes extends Activity  implements OnGestureListener {
 			}
 			// right to left swipe goes to turnouts if enabled in prefs
 			else {
-				boolean swipeTurnouts = prefs.getBoolean("swipe_through_turnouts_preference", 
-						getResources().getBoolean(R.bool.prefSwipeThroughTurnoutsDefaultValue));
+				boolean swipeTurnouts = prefs.getBoolean("swipe_through_turnouts_preference", getResources().getBoolean(R.bool.prefSwipeThroughTurnoutsDefaultValue));
 				if(swipeTurnouts == true) {
 					Intent in=new Intent().setClass(this, turnouts.class);
 					startActivity(in);

--- a/src/jmri/enginedriver/turnouts.java
+++ b/src/jmri/enginedriver/turnouts.java
@@ -93,8 +93,10 @@ public class turnouts extends Activity implements OnGestureListener {
 			if (mainapp.to_user_names != null) { //none defined
 				int pos = 0;
 				String del = prefs.getString("DelimiterPreference", getApplicationContext().getResources().getString(R.string.prefDelimiterDefaultValue));
+				boolean hideIfNoUserName = prefs.getBoolean("HideIfNoUserNamePreference", getResources().getBoolean(R.bool.prefHideIfNoUserNameDefaultValue));
 				for (String username : mainapp.to_user_names) {
-					if (username != null && !username.equals(""))  {  //skip turnouts without usernames
+					boolean hasUserName = (username != null && !username.equals(""));
+					if (hasUserName || !hideIfNoUserName)  {  //skip turnouts without usernames if pref is set
 						//get values from global array
 						String systemname = mainapp.to_system_names[pos];
 						String currentstate = mainapp.to_states[pos];
@@ -105,13 +107,16 @@ public class turnouts extends Activity implements OnGestureListener {
 
 						//put values into temp hashmap
 						HashMap<String, String> hm = new HashMap<String, String>();
-						hm.put("to_user_name", username);
+						if (hasUserName)
+							hm.put("to_user_name", username);
+						else
+							hm.put("to_user_name", systemname);
 						hm.put("to_system_name", systemname);
 						hm.put("to_current_state_desc", currentstatedesc);
 						turnoutsFullList.add(hm);
 
 						//if location is new, add to list
-						if(del.length() > 0) {
+						if(del.length() > 0 && hasUserName) {
 							int delim = username.indexOf(del);
 							if(delim >= 0) {
 								String loc = username.substring(0, delim);
@@ -225,6 +230,7 @@ public class turnouts extends Activity implements OnGestureListener {
 				}
 				break;
 			case message_type.LOCATION_DELIMITER:
+			case message_type.HIDE_IF_NO_USER_NAME:
 				refresh_turnout_view();
 				break;
 			case message_type.WIT_CON_RETRY:


### PR DESCRIPTION
Added a preference to omit a Turnout or Route from their respective list
if the username is missing or empty.  The preference defaults to true
for consistency with the current behavior.  If the preference is set to
false, all Turnouts and Routes are shown.