### PR TITLE
Numerous small Changes to the Throttle Preferences and Functionality

### DIFF
--- a/res/layout/throttle.xml
+++ b/res/layout/throttle.xml
@@ -100,20 +100,23 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:stretchColumns="0,1,2" >
-                    <TableRow>
+                    <TableRow android:layout_height="wrap_content">
                         <Button
                             android:id="@+id/button_fwd_T"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/forward" />
                         <Button
                             android:id="@+id/button_stop_T"
                             style="@style/stop_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/stop" />
                         <Button
                             android:id="@+id/button_rev_T"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/reverse" />
                     </TableRow>
@@ -361,20 +364,23 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:stretchColumns="0,1,2" >
-                    <TableRow>
+                    <TableRow android:layout_height="wrap_content">
                         <Button
                             android:id="@+id/button_fwd_S"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/forward" />
                         <Button
                             android:id="@+id/button_stop_S"
                             style="@style/stop_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/stop" />
                         <Button
                             android:id="@+id/button_rev_S"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/reverse" />
                     </TableRow>
@@ -633,21 +639,24 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:stretchColumns="0,1,2" >
-                    <TableRow>
+                    <TableRow android:layout_height="wrap_content">
                         <Button
                             android:id="@+id/button_fwd_G"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/forward" />
                         <Button
                             android:id="@+id/button_stop_G"
                             style="@style/stop_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/stop" />
 
                         <Button
                             android:id="@+id/button_rev_G"
                             style="@style/large_button_style"
+                            android:layout_height="wrap_content"
                             android:enabled="false"
                             android:text="@string/reverse" />
                     </TableRow>

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -33,4 +33,10 @@
     <bool name="prefSwipeThroughTurnoutsDefaultValue">true</bool>
     <bool name="prefSwipeThroughRoutesDefaultValue">true</bool>
     <bool name="prefDirChangeWhileMovingDefaultValue">true</bool>
+    <bool name="prefStopOnDirectionChangeDefaultValue">false</bool>
+    <bool name="prefDecreaseLocoNumberHeightDefaultValue">false</bool>
+    <bool name="prefShowAddressInsteadOfNameDefaultValue">false</bool>
+    <bool name="prefIncreaseWebViewSizeDefaultValue">false</bool>
+    <bool name="prefThrottleViewImmersiveModeDefaultValue">false</bool>
+    <bool name="prefAlwaysUseDefaultFunctionLabelsDefaultValue">false</bool>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  WARNING: Auto Connect preference will be ignored, as Preferences will not be available from the Throttle Page.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Always use the default labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster.</string>
+    <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>
+    <string name="prefDecreaseLocoNumberHeightSummary">Use smaller buttons for the loco Number, speed and direction buttons.</string>
     <string name="prefNumOfThrottles">Number of throttles</string>
     <string name="prefNumOfThrottlesSummary">Choose how many throttles you want to display.</string>
     <string name="prefNumOfThrottlesDefault">Two</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  WARNING: Auto Connect preference will be ignored, as Preferences will not be available from the Throttle Page.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Always use the default labels?</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster. Note: Requires a restart of EngineDriver.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Use smaller buttons for the loco Number, speed and direction buttons.</string>
     <string name="prefNumOfThrottles">Number of throttles</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -115,6 +115,16 @@
     <string name="prefHideSliderSummary">Do not show speed slider, use speed buttons instead.</string>
     <string name="prefDirChangeWhileMovingTitle">Direction change?</string>
     <string name="prefDirChangeWhileMovingSummary">Allow direction change while Moving.</string>    
+    <string name="prefStopOnDirectionChangeTitle">Stop on direction change?</string>
+    <string name="prefStopOnDirectionChangeSummary">Stop train if you change direction while moving.  Overrides ‘Allow direction change while moving’ preference.</string>
+    <string name="prefShowAddressInsteadOfNameTitle">Show Loco Address instead of Name?</string>
+    <string name="prefShowAddressInsteadOfNameSummary">Show the loco DCC Address instead of the Loco Name on the Throttle page.</string>
+    <string name="prefIncreaseWebViewSizeTitle">Increase Web View Size?</string>
+    <string name="prefIncreaseWebViewSizeSummary">Increase web view size to 60% for small screens.</string>
+    <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
+    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  WARNING: Auto Connect preference will be ignored, as Preferences will not be available from the Throttle Page.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Always use the default labels?</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster.</string>
     <string name="prefNumOfThrottles">Number of throttles</string>
     <string name="prefNumOfThrottlesSummary">Choose how many throttles you want to display.</string>
     <string name="prefNumOfThrottlesDefault">Two</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -74,6 +74,13 @@
             android:title="@string/prefIncreaseSliderHeightTitle" >
         </CheckBoxPreference>
         <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefDecreaseLocoNumberHeightDefaultValue"
+            android:key="prefDecreaseLocoNumberHeight"
+            android:summary="@string/prefDecreaseLocoNumberHeightSummary"
+            android:title="@string/prefDecreaseLocoNumberHeightTitle"></CheckBoxPreference>
+        <CheckBoxPreference
             android:defaultValue="@bool/prefDisplaySpeedArrows"
             android:key="display_speed_arrows_buttons"
             android:summary="@string/prefDisplaySpeedArrowsSummary"
@@ -141,7 +148,35 @@
             android:summary="@string/prefDirChangeWhileMovingSummary"
             android:title="@string/prefDirChangeWhileMovingTitle"></CheckBoxPreference>
         </PreferenceCategory>
-    <PreferenceCategory android:title="@string/prefSelectLocoTitle" >
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefStopOnDirectionChangeDefaultValue"
+            android:key="prefStopOnDirectionChange"
+            android:summary="@string/prefStopOnDirectionChangeSummary"
+            android:title="@string/prefStopOnDirectionChangeTitle"></CheckBoxPreference>
+       <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefShowAddressInsteadOfNameDefaultValue"
+            android:key="prefShowAddressInsteadOfName"
+            android:summary="@string/prefShowAddressInsteadOfNameSummary"
+            android:title="@string/prefShowAddressInsteadOfNameTitle"></CheckBoxPreference>
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefThrottleViewImmersiveModeDefaultValue"
+            android:key="prefThrottleViewImmersiveMode"
+            android:summary="@string/prefThrottleViewImmersiveModeSummary"
+            android:title="@string/prefThrottleViewImmersiveModeTitle"></CheckBoxPreference>
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefAlwaysUseDefaultFunctionLabelsDefaultValue"
+            android:key="prefAlwaysUseDefaultFunctionLabels"
+            android:summary="@string/prefAlwaysUseDefaultFunctionLabelsSummary"
+            android:title="@string/prefAlwaysUseDefaultFunctionLabelsTitle"></CheckBoxPreference>
+     <PreferenceCategory android:title="@string/prefSelectLocoTitle" >
         <CheckBoxPreference
             android:defaultValue="@bool/prefStopOnReleaseDefaultValue"
             android:key="stop_on_release_preference"

--- a/src/jmri/enginedriver/Consist.java
+++ b/src/jmri/enginedriver/Consist.java
@@ -235,4 +235,23 @@ public final class Consist {
 		}
 		return formatCon;
 	}
+	
+	public String formatConsistAddr() {
+		String formatCon;
+		if(con.size() > 0) {
+			formatCon = "";
+			String sep = "";
+			for(Map.Entry<String, ConLoco> l : con.entrySet()) {		// loop through locos in consist
+				if(l.getValue().isConfirmed()) {
+					formatCon += sep + l.getValue().getAddress().substring(1,l.getValue().getAddress().length());
+					sep = ",";
+				}
+			}
+		}
+		else {
+			formatCon = "Not Set";
+		}
+		return formatCon;
+	}
+
 }

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -365,7 +365,11 @@ public class connection_activity extends Activity {
 		//	    sendMsgErr(1000, message_type.SET_LISTENER, "", 1, "ERROR in ca.onResume: comm thread not started.") ;
 		mainapp.sendMsg(mainapp.comm_msg_handler, message_type.SET_LISTENER, "", 1);
 		
-		if(prefs.getBoolean("connect_to_first_server_preference", false))
+		// check if the preference is set to use immersive mode on the Throttle View
+		boolean tvim = prefs.getBoolean("prefThrottleViewImmersiveMode", getResources().getBoolean(R.bool.prefThrottleViewImmersiveModeDefaultValue));
+		// if it is set, never automatically connect
+
+		if( (prefs.getBoolean("connect_to_first_server_preference", false)) && (!tvim) )
 		{
 			connectA();
 		}

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1653,17 +1653,24 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 			tv = fbS;
 		}
 
+		// Ignore the labels for the loco in the Roster and use the defaults... if requested in preferences
+		boolean audfl = prefs.getBoolean("prefAlwaysUseDefaultFunctionLabels", getResources().getBoolean(R.bool.prefAlwaysUseDefaultFunctionLabelsDefaultValue));
+
 		// note: we make a copy of function_labels_x because TA might change it
 		// while we are using it (causing issues during button update below)
-		if (whichThrottle == 'T' && mainapp.function_labels_T != null && mainapp.function_labels_T.size() > 0) {
-			function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_T);
-		} else if (whichThrottle == 'G' && mainapp.function_labels_G != null && mainapp.function_labels_G.size() > 0) {
-			function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_G);
-		} else if (whichThrottle == 'S' && mainapp.function_labels_S != null && mainapp.function_labels_S.size() > 0) {
-			function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_S);
-		} else {
-			function_labels_temp = mainapp.function_labels_default;
-		}
+		if (!audfl) {
+			if (whichThrottle == 'T' && mainapp.function_labels_T != null && mainapp.function_labels_T.size() > 0) {
+				function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_T);
+			} else if (whichThrottle == 'G' && mainapp.function_labels_G != null && mainapp.function_labels_G.size() > 0) {
+				function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_G);
+			} else if (whichThrottle == 'S' && mainapp.function_labels_S != null && mainapp.function_labels_S.size() > 0) {
+				function_labels_temp = new LinkedHashMap<Integer, String>(mainapp.function_labels_S);
+			} else {
+				function_labels_temp = mainapp.function_labels_default;
+			}
+		} else { // Force using the Default Function Labels
+  			function_labels_temp = mainapp.function_labels_default;
+  		}
 
 		// put values in array for indexing in next step TODO: find direct way
 		// to do this

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1546,6 +1546,25 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 		}
 	}
 
+	@Override
+ 	public void onWindowFocusChanged(boolean hasFocus) {
+ 		super.onWindowFocusChanged(hasFocus);
+ 		// check if the preference is set to use immersimve mode on the Throttle View
+ 		boolean tvim = prefs.getBoolean("prefThrottleViewImmersiveMode", getResources().getBoolean(R.bool.prefThrottleViewImmersiveModeDefaultValue));
+ 
+ 		if (hasFocus) {
+ 			if (tvim) {   // if the preference is set use Immersive mode
+ 				webView.setSystemUiVisibility(
+ 					View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+ 							| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+ 							| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+ 							| View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+ 							| View.SYSTEM_UI_FLAG_FULLSCREEN
+ 							| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+ 			}
+ 		}
+ 	}
+ 
 	/** Called when the activity is finished. */
 	@SuppressWarnings("deprecation")
 	@Override

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1375,6 +1375,15 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 		llTSetSpd = (LinearLayout) findViewById(R.id.Throttle_T_SetSpeed);
 		llSSetSpd = (LinearLayout) findViewById(R.id.Throttle_S_SetSpeed);
 		llGSetSpd = (LinearLayout) findViewById(R.id.Throttle_G_SetSpeed);
+		// SPDHT
+		llTLocoId = (LinearLayout) findViewById(R.id.loco_buttons_group_T);
+		llSLocoId = (LinearLayout) findViewById(R.id.loco_buttons_group_S);
+		llGLocoId = (LinearLayout) findViewById(R.id.loco_buttons_group_G);
+		//
+		llTLocoDir = (LinearLayout) findViewById(R.id.dir_buttons_table_T);
+		llSLocoDir = (LinearLayout) findViewById(R.id.dir_buttons_table_S);
+		llGLocoDir = (LinearLayout) findViewById(R.id.dir_buttons_table_G);
+		// SPDHT
 
 		// volume indicators
 		vVolT = findViewById(R.id.volume_indicator_T);

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1806,7 +1806,11 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 		String bLabel;
 		Button b = bSelT;
 		if (mainapp.consistT.isActive()) {
-			bLabel = mainapp.consistT.toString();
+			if (!sadion) {
+				bLabel = mainapp.consistT.toString();
+			} else {
+ 				bLabel = mainapp.consistT.formatConsistAddr();
+ 			}			
 			throttle_count++;
 		} else {
 			bLabel = "Press to select";
@@ -1834,7 +1838,11 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
 		b = bSelS;
 		if (mainapp.consistS.isActive()) {
-			bLabel = mainapp.consistS.toString();
+			if (!sadion) {
+				bLabel = mainapp.consistS.toString();
+			} else {
+ 				bLabel = mainapp.consistS.formatConsistAddr();
+ 			}			
 			throttle_count++;
 		} else {
 			bLabel = "Press to select";
@@ -1856,7 +1864,11 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
 		b = bSelG;
 		if (mainapp.consistG.isActive()) {
-			bLabel = mainapp.consistG.toString();
+			if (!sadion) {
+				bLabel = mainapp.consistG.toString();
+			} else {
+ 				bLabel = mainapp.consistG.formatConsistAddr();
+ 			}			
 			throttle_count++;
 		} else {
 			bLabel = "Press to select";


### PR DESCRIPTION
1 Decrease Loco No. button Height.  (Disabled by default)
2 Show loco address instead of names (Disabled by default)
3 Immersive mode. (Which to my surprise, works on a Jelly Bean phone) (Disabled by default)
4 Increase web view size (Disabled by default)
5 Stop on direction change while moving (Disabled by default)
6 "Always use default labels".  For the Function buttons, use the defaults instead of what is in the in the Roster (Disabled by default)

Notes:
3 force disables/ignores the 'Auto Connect' preference, as you can't get to the preferences (or eStop button) from the Throttle page when it is enabled.  (To allow you to get to the preferences before you connect.)   To get to the back button when in immersive mode, swipe up from the bottom of the screen.

5 If set, it overrides the preference to disable the direction buttons while moving.

6 is useful if the lead loco in a consist does not have sound,but others do.  You need to also turn off "Selective Lead Unit Sound?"   Also useful when your sound loco is not in the roster, but another with the same DCC address is.
