### PR TITLE
Experimental - Change to the way of temporarily entering or exiting immersive mode 

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="prefIncreaseWebViewSizeTitle">Increase Web View Size?</string>
     <string name="prefIncreaseWebViewSizeSummary">Increase web view size to 60% for small screens.</string>
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
-    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  WARNING: Requires Android Jelly Bean (4.1.x) or later. WARNING: Auto Connect preference will be ignored, as Preferences will not be available from the Throttle Page.</string>
+    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down on the page to temporarily disable (to see the menu and eStop) WARNING: Requires Android Jelly Bean (4.1.x) or later.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Always use the default labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster. Note: Requires a restart of EngineDriver.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -365,16 +365,9 @@ public class connection_activity extends Activity {
 		//	    sendMsgErr(1000, message_type.SET_LISTENER, "", 1, "ERROR in ca.onResume: comm thread not started.") ;
 		mainapp.sendMsg(mainapp.comm_msg_handler, message_type.SET_LISTENER, "", 1);
 		
-		// check if the preference is set to use immersive mode on the Throttle View
-		boolean tvim = prefs.getBoolean("prefThrottleViewImmersiveMode", getResources().getBoolean(R.bool.prefThrottleViewImmersiveModeDefaultValue));
-		// if it is set, never automatically connect
-
-		if( (prefs.getBoolean("connect_to_first_server_preference", false)) && (!tvim) )
-		{
+		if (prefs.getBoolean("connect_to_first_server_preference", false)) {
 			connectA();
 		}
-		
-		
 	}  //end of onResume
 
 	@Override


### PR DESCRIPTION
- Enter and exit immersive mode (if enabled) by swiping down on any part of any Loco View (most of the screen)
- created new functions for entering an exiting immersive mode
- removed the old code related to the speed text
- added the new gesture for entering and exiting immersive mode
- added a toast message when you swipe down to exit immersive mode.