### PR TITLE
Modification - Increased the minimum requirement for Immersive Mode to Android KitKat

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -125,7 +125,7 @@
     <string name="prefIncreaseWebViewSizeTitle">Increase Web View Size?</string>
     <string name="prefIncreaseWebViewSizeSummary">Increase web view size to 60% for small screens.</string>
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
-    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down on the any part of the page, other than a speed slider, to temporarily disable (to see the menu and eStop) WARNING: Requires Android KitKat (5.1.1) or later.</string>
+    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down on the any part of the page, other than a speed slider, to temporarily disable (to see the menu and eStop) WARNING: Requires Android Marshmallow (5.1.1) or later.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use the default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster. Note: Requires a restart of EngineDriver.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -125,7 +125,7 @@
     <string name="prefIncreaseWebViewSizeTitle">Increase Web View Size?</string>
     <string name="prefIncreaseWebViewSizeSummary">Increase web view size to 60% for small screens.</string>
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
-    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down on the any part of the page, other than a speed slider, to temporarily disable (to see the menu and eStop) WARNING: Requires Android Jelly Bean (4.1.x) or later.</string>
+    <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down on the any part of the page, other than a speed slider, to temporarily disable (to see the menu and eStop) WARNING: Requires Android KitKat (5.1.1) or later.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use the default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels regardless of the labels the loco has in the Roster. Note: Requires a restart of EngineDriver.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -430,7 +430,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         immersiveModeIsOn = false;
 
         if (tvim) {   // if the preference is set use Immersive mode
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 immersiveModeIsOn = true;
                 webView.setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE
@@ -448,7 +448,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         immersiveModeIsOn = false;
 
         if (tvim) {   // if the preference is set use Immersive mode
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 webView.setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_VISIBLE);
             }
@@ -2627,7 +2627,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 }
                 // TODO: do something on swipe up (only)
                 if ((gestureStartY - event.getY()) > threaded_application.min_fling_distance) {
-//                    Toast.makeText(getApplicationContext(), "Swipe Up", Toast.LENGTH_SHORT).show();
+                    // Toast.makeText(getApplicationContext(), "Swipe Up", Toast.LENGTH_SHORT).show();
                 }
             }
             else {


### PR DESCRIPTION
Until I know more about the behaviour of Immersive Mode on Lollipop I think it is best to disable it.

(That was supposed to be Marshmallow not KitKat)