### PR TITLE
	Experimental - basic gamepad support

### DIFF
--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -38,5 +38,6 @@
     <bool name="prefShowAddressInsteadOfNameDefaultValue">false</bool>
     <bool name="prefIncreaseWebViewSizeDefaultValue">false</bool>
     <bool name="prefThrottleViewImmersiveModeDefaultValue">false</bool>
+    <bool name="prefThrottleGamePadDefaultValue">false</bool>
     <bool name="prefAlwaysUseDefaultFunctionLabelsDefaultValue">false</bool>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="prefIncreaseWebViewSizeSummary">Increase web view size to 60% for small screens.</string>
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down to temporarily disable and reach the menu.</string>
+    <string name="prefThrottleGamePadTitle">Enable gamepad and Keyboard support?</string>
+    <string name="prefThrottleGamePadSummary">NOTE: Currently only supports basic DPAD actions and/or the following keys:- Direction:AF Speed:WX Stop:Y F0: .</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down to temporarily disable and reach the menu.</string>
     <string name="prefThrottleGamePadTitle">Enable gamepad and Keyboard support?</string>
-    <string name="prefThrottleGamePadSummary">NOTE: Currently only supports iOS \'NewGame\' mode.  DPAD actions and/or the following keys:- Direction:AF Speed:WX Stop:Y F0: .</string>
+    <string name="prefThrottleGamePadSummary">NOTE: Currently only supports simple gampads using iOS \'NewGame\' mode - DPAD + keys:- Stop:y F0:h F1:u F2:j eStop:v \n or iOS \'iCade\' mode - DPAD + keys:- Stop:3 F0:1 F1:2 F2:4 eStop:0.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down to temporarily disable and reach the menu.</string>
     <string name="prefThrottleGamePadTitle">Enable gamepad and Keyboard support?</string>
-    <string name="prefThrottleGamePadSummary">NOTE: Currently only supports basic DPAD actions and/or the following keys:- Direction:AF Speed:WX Stop:Y F0: .</string>
+    <string name="prefThrottleGamePadSummary">NOTE: Currently only supports iOS \'NewGame\' mode.  DPAD actions and/or the following keys:- Direction:AF Speed:WX Stop:Y F0: .</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -122,6 +122,14 @@
             android:summary="@string/prefThrottleViewImmersiveModeSummary"
             android:title="@string/prefThrottleViewImmersiveModeTitle">
         </CheckBoxPreference>
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/prefThrottleGamePadDefaultValue"
+            android:key="prefThrottleGamePad"
+            android:summary="@string/prefThrottleGamePadSummary"
+            android:title="@string/prefThrottleGamePadTitle">
+        </CheckBoxPreference>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/prefThrottleTitle" >
         <ListPreference

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1033,6 +1033,12 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
             char whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol and use that one
 
+            String conAddr = mainapp.consistT.formatConsistAddr();
+            switch (whichThrottle) {
+                case 'S': { conAddr = mainapp.consistS.formatConsistAddr(); break;}
+                case 'G': { conAddr = mainapp.consistG.formatConsistAddr(); break;}
+            }
+
             int keyCode = event.getKeyCode();
 /*
             if (keyCode != 0) {
@@ -1045,7 +1051,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 //case KeyEvent.KEYCODE_E:
                 case KeyEvent.KEYCODE_DPAD_UP:
                     // Increase Speed
-                    if (action == ACTION_DOWN) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_DOWN)) {
                         increment(whichThrottle);
                         enable_disable_direction_and_loco_buttons(whichThrottle);
                     }
@@ -1056,7 +1062,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 //case KeyEvent.KEYCODE_Z:
                 case KeyEvent.KEYCODE_DPAD_DOWN:
                     // Decrease Speed
-                    if (action == ACTION_DOWN) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_DOWN)) {
                         decrement(whichThrottle);
                         enable_disable_direction_and_loco_buttons(whichThrottle);
                     }
@@ -1068,7 +1074,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_DPAD_LEFT:
                     // Forward
                     // set speed to zero on direction change while moving if the preference is set
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
                         if (stopOnDirectionChange) {
                             if ((getSpeed(whichThrottle) != 0) && (getDirection(whichThrottle) != DIRECTION_FORWARD)) {
                                 speedUpdateAndNotify(whichThrottle, 0);
@@ -1089,7 +1095,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
                     // Reverse
                     // set speed to zero on direction change while moving if the preference is set
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
                         if (stopOnDirectionChange) {
                             if ((getSpeed(whichThrottle) != 0) && (getDirection(whichThrottle) != DIRECTION_REVERSE)) {
                                 speedUpdateAndNotify(whichThrottle, 0);
@@ -1108,7 +1114,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_Y: // 'NewGame' mode
                 case KeyEvent.KEYCODE_3: // international standard gamepad
                     // stop
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
                         set_stop_button(whichThrottle, true);
                         speedUpdateAndNotify(whichThrottle, 0);
                         enable_disable_direction_and_loco_buttons(whichThrottle);
@@ -1119,12 +1125,12 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_U:
                 case KeyEvent.KEYCODE_2: // international standard gamepad
                     // F1 - Bell
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
 //                        Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': { mainapp.function_states_T[1] = ((mainapp.function_states_T[1]) ? false : true); break;}
-                            case 'G': { mainapp.function_states_G[1] = ((mainapp.function_states_G[1]) ? false : true); break;}
-                            default: { mainapp.function_states_S[1]  = ((mainapp.function_states_S[1]) ? false : true); break;}
+                            case 'T': { mainapp.function_states_T[1] = !mainapp.function_states_T[1]; break;}
+                            case 'G': { mainapp.function_states_G[1] = !mainapp.function_states_G[1]; break;}
+                            default: { mainapp.function_states_S[1]  = !mainapp.function_states_S[1]; break;}
                         }
                         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 1, 1);
                         set_function_state(whichThrottle, 1);
@@ -1135,12 +1141,12 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_J:
                 case KeyEvent.KEYCODE_4: // international standard gamepad
                     // F2 - Horn
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
                         Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': { mainapp.function_states_T[2] = ((mainapp.function_states_T[2]) ? false : true); break;}
-                            case 'G': { mainapp.function_states_G[2] = ((mainapp.function_states_G[2]) ? false : true); break;}
-                            default: { mainapp.function_states_S[2]  = ((mainapp.function_states_S[2]) ? false : true); break;}
+                            case 'T': { mainapp.function_states_T[2] = !mainapp.function_states_T[2]; break;}
+                            case 'G': { mainapp.function_states_G[2] = !mainapp.function_states_G[2]; break;}
+                            default: { mainapp.function_states_S[2]  = !mainapp.function_states_S[2]; break;}
                         }
                         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 2, 1);
                         set_function_state(whichThrottle, 2);
@@ -1151,16 +1157,28 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_H:
                 case KeyEvent.KEYCODE_1: // international standard gamepad
                     // F0 - Light
-                    if (action == ACTION_UP) {
+                    if ((!conAddr.equals("Not Set")) && (action == ACTION_UP)) {
                         //Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': { mainapp.function_states_T[0] = ((mainapp.function_states_T[0]) ? false : true); break;}
-                            case 'G': { mainapp.function_states_G[0] = ((mainapp.function_states_G[0]) ? false : true); break;}
-                            default: { mainapp.function_states_S[0]  = ((mainapp.function_states_S[0]) ? false : true); break;}
+                            case 'T': { mainapp.function_states_T[0] = !mainapp.function_states_T[0]; break;}
+                            case 'G': { mainapp.function_states_G[0] = !mainapp.function_states_G[0]; break;}
+                            default: { mainapp.function_states_S[0]  = !mainapp.function_states_S[0]; break;}
                         }
                         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 0, 1);
                         set_function_state(whichThrottle, 0);
+                    }
+                    return (true); // stop processing this key
 
+                case KeyEvent.KEYCODE_V:
+                case KeyEvent.KEYCODE_0: // international standard gamepad
+                    // F0 - EStop
+                    if (action == ACTION_UP) {
+                        speedUpdateAndNotify('T', 0);        // update requested direction indication
+                        speedUpdateAndNotify('S', 0);        // update requested direction indication
+                        speedUpdateAndNotify('G', 0);        // update requested direction indication
+                        enable_disable_direction_and_loco_buttons('T');
+                        enable_disable_direction_and_loco_buttons('S');
+                        enable_disable_direction_and_loco_buttons('G');
                     }
                     return (true); // stop processing this key
 

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -65,6 +65,7 @@ import android.graphics.Typeface;
 //import android.view.inputmethod.InputMethodManager;
 import android.view.WindowManager;
 
+import static android.view.KeyEvent.ACTION_DOWN;
 import static android.view.KeyEvent.ACTION_UP;
 /* ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
@@ -1024,30 +1025,36 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         int action = event.getAction();
 
         if (prefThrottleGamePad) { // respond to the gamepad and keyboard inputs if the preference is set
-            char whichThrottle = 'T';
+            //char whichThrottle = 'T';
+            char whichThrottle = whichVolume;
             int keyCode = event.getKeyCode();
+
             if (keyCode != 0) {
                 Log.d("Engine_Driver", "keycode " + keyCode);
             }
             switch (keyCode) {
-                case KeyEvent.KEYCODE_W:
-                case KeyEvent.KEYCODE_E:
+                //case KeyEvent.KEYCODE_W:
+                //case KeyEvent.KEYCODE_E:
                 case KeyEvent.KEYCODE_DPAD_UP:
                     // Increase Speed
-                    speedChangeAndNotify(whichThrottle, 1);
-                    enable_disable_direction_and_loco_buttons('T');
+                    if (action == ACTION_DOWN) {
+                        speedChangeAndNotify(whichThrottle, 1);
+                        enable_disable_direction_and_loco_buttons('T');
+                    }
                     return (true); // stop processing this key
 
-                case KeyEvent.KEYCODE_X:
-                case KeyEvent.KEYCODE_Z:
+                //case KeyEvent.KEYCODE_X:
+                //case KeyEvent.KEYCODE_Z:
                 case KeyEvent.KEYCODE_DPAD_DOWN:
                     // Decrease Speed
-                    speedChangeAndNotify(whichThrottle, -1);
-                    enable_disable_direction_and_loco_buttons('T');
+                    if (action == ACTION_DOWN) {
+                        speedChangeAndNotify(whichThrottle, -1);
+                        enable_disable_direction_and_loco_buttons('T');
+                    }
                     return (true); // stop processing this key
 
-                case KeyEvent.KEYCODE_A:
-                case KeyEvent.KEYCODE_Q:
+                //case KeyEvent.KEYCODE_A:
+                //case KeyEvent.KEYCODE_Q:
                 case KeyEvent.KEYCODE_DPAD_LEFT:
                     // Forward
                     // set speed to zero on direction change while moving if the preference is set
@@ -1066,8 +1073,8 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     }
                     return (true); // stop processing this key
 
-                case KeyEvent.KEYCODE_D:
-                case KeyEvent.KEYCODE_C:
+                //case KeyEvent.KEYCODE_D:
+                //case KeyEvent.KEYCODE_C:
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
                     // Reverse
                     // set speed to zero on direction change while moving if the preference is set
@@ -1097,40 +1104,45 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_U:
+                    // F1 - Bell
                     if (action == ACTION_UP) {
 //                        Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': mainapp.function_states_T[1] = ((mainapp.function_states_T[1]) ? false : true);
-                            case 'G': mainapp.function_states_G[1] = ((mainapp.function_states_G[1]) ? false : true);
-                            default: mainapp.function_states_S[1]  = ((mainapp.function_states_S[1]) ? false : true);
+                            case 'T': { mainapp.function_states_T[1] = ((mainapp.function_states_T[1]) ? false : true); break;}
+                            case 'G': { mainapp.function_states_G[1] = ((mainapp.function_states_G[1]) ? false : true); break;}
+                            default: { mainapp.function_states_S[1]  = ((mainapp.function_states_S[1]) ? false : true); break;}
                         }
-                        set_function_state(whichThrottle, 0);
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 1, 1);
+                        set_function_state(whichThrottle, 1);
 
                     }
                         return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_J:
+                    // F2 - Horn
                     if (action == ACTION_UP) {
                         Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': mainapp.function_states_T[2] = ((mainapp.function_states_T[2]) ? false : true);
-                            case 'G': mainapp.function_states_G[2] = ((mainapp.function_states_G[2]) ? false : true);
-                            default: mainapp.function_states_S[2]  = ((mainapp.function_states_S[2]) ? false : true);
+                            case 'T': { mainapp.function_states_T[2] = ((mainapp.function_states_T[2]) ? false : true); break;}
+                            case 'G': { mainapp.function_states_G[2] = ((mainapp.function_states_G[2]) ? false : true); break;}
+                            default: { mainapp.function_states_S[2]  = ((mainapp.function_states_S[2]) ? false : true); break;}
                         }
-                        set_function_state(whichThrottle, 0);
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 2, 1);
+                        set_function_state(whichThrottle, 2);
 
                     }
                     return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_H:
-                    // F0
+                    // F0 - Light
                     if (action == ACTION_UP) {
                         Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
-                            case 'T': mainapp.function_states_T[0] = ((mainapp.function_states_T[0]) ? false : true);
-                            case 'G': mainapp.function_states_G[0] = ((mainapp.function_states_G[0]) ? false : true);
-                            default: mainapp.function_states_S[0]  = ((mainapp.function_states_S[0]) ? false : true);
+                            case 'T': { mainapp.function_states_T[0] = ((mainapp.function_states_T[0]) ? false : true); break;}
+                            case 'G': { mainapp.function_states_G[0] = ((mainapp.function_states_G[0]) ? false : true); break;}
+                            default: { mainapp.function_states_S[0]  = ((mainapp.function_states_S[0]) ? false : true); break;}
                         }
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.FUNCTION, whichThrottle+"", 0, 1);
                         set_function_state(whichThrottle, 0);
 
                     }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1017,22 +1017,24 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         }
     }
 
-    /* ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-    /* ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ */
 
+    // listener for physical keyboard events
+    // used to support the gamepad in 'NewGame' mode only   DPAD and key events
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
         int action = event.getAction();
 
         if (prefThrottleGamePad) { // respond to the gamepad and keyboard inputs if the preference is set
-            //char whichThrottle = 'T';
-            char whichThrottle = whichVolume;
+
+            char whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol and use that one
+
             int keyCode = event.getKeyCode();
 
             if (keyCode != 0) {
                 Log.d("Engine_Driver", "keycode " + keyCode);
             }
             switch (keyCode) {
+                // DPAD actually produces all three of the following events.  just use one
                 //case KeyEvent.KEYCODE_W:
                 //case KeyEvent.KEYCODE_E:
                 case KeyEvent.KEYCODE_DPAD_UP:
@@ -1043,6 +1045,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     }
                     return (true); // stop processing this key
 
+                // DPAD actually produces all three of the following events.  just use one
                 //case KeyEvent.KEYCODE_X:
                 //case KeyEvent.KEYCODE_Z:
                 case KeyEvent.KEYCODE_DPAD_DOWN:
@@ -1053,6 +1056,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     }
                     return (true); // stop processing this key
 
+                // DPAD actually produces all three of the following events.  just use one
                 //case KeyEvent.KEYCODE_A:
                 //case KeyEvent.KEYCODE_Q:
                 case KeyEvent.KEYCODE_DPAD_LEFT:
@@ -1073,6 +1077,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     }
                     return (true); // stop processing this key
 
+                // DPAD actually produces all three of the following events.  just use one
                 //case KeyEvent.KEYCODE_D:
                 //case KeyEvent.KEYCODE_C:
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
@@ -1155,10 +1160,6 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
             return super.dispatchKeyEvent(event);
         }
     }
-
-   /* ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-   /* ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ */
-
 
     // Listeners for the Select Loco buttons
     public class select_function_button_touch_listener implements View.OnClickListener, View.OnTouchListener {

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1040,8 +1040,8 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_DPAD_UP:
                     // Increase Speed
                     if (action == ACTION_DOWN) {
-                        speedChangeAndNotify(whichThrottle, 1);
-                        enable_disable_direction_and_loco_buttons('T');
+                        increment(whichThrottle);
+                        enable_disable_direction_and_loco_buttons(whichThrottle);
                     }
                     return (true); // stop processing this key
 
@@ -1051,8 +1051,8 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_DPAD_DOWN:
                     // Decrease Speed
                     if (action == ACTION_DOWN) {
-                        speedChangeAndNotify(whichThrottle, -1);
-                        enable_disable_direction_and_loco_buttons('T');
+                        decrement(whichThrottle);
+                        enable_disable_direction_and_loco_buttons(whichThrottle);
                     }
                     return (true); // stop processing this key
 
@@ -1105,6 +1105,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                         set_stop_button(whichThrottle, true);
                         speedUpdateAndNotify(whichThrottle, 0);
                         enable_disable_direction_and_loco_buttons(whichThrottle);
+                        set_stop_button(whichThrottle, false);
                     }
                     return (true); // stop processing this key
 
@@ -1141,7 +1142,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                 case KeyEvent.KEYCODE_H:
                     // F0 - Light
                     if (action == ACTION_UP) {
-                        Log.d("Engine_Driver", "keycode " + keyCode);
+                        //Log.d("Engine_Driver", "keycode " + keyCode);
                         switch (whichThrottle) {
                             case 'T': { mainapp.function_states_T[0] = ((mainapp.function_states_T[0]) ? false : true); break;}
                             case 'G': { mainapp.function_states_G[0] = ((mainapp.function_states_G[0]) ? false : true); break;}

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1017,6 +1017,11 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         }
     }
 
+    @Override
+    public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
+        Log.d("Engine_Driver", "keycode " + event.getAction());
+        return super.dispatchGenericMotionEvent(event);
+    }
 
     // listener for physical keyboard events
     // used to support the gamepad in 'NewGame' mode only   DPAD and key events
@@ -1029,10 +1034,11 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
             char whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol and use that one
 
             int keyCode = event.getKeyCode();
-
+/*
             if (keyCode != 0) {
                 Log.d("Engine_Driver", "keycode " + keyCode);
             }
+*/
             switch (keyCode) {
                 // DPAD actually produces all three of the following events.  just use one
                 //case KeyEvent.KEYCODE_W:
@@ -1099,7 +1105,8 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     return (true); // stop processing this key
 
 //                case KeyEvent.KEYCODE_Q:
-                case KeyEvent.KEYCODE_Y:
+                case KeyEvent.KEYCODE_Y: // 'NewGame' mode
+                case KeyEvent.KEYCODE_3: // international standard gamepad
                     // stop
                     if (action == ACTION_UP) {
                         set_stop_button(whichThrottle, true);
@@ -1110,6 +1117,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_U:
+                case KeyEvent.KEYCODE_2: // international standard gamepad
                     // F1 - Bell
                     if (action == ACTION_UP) {
 //                        Log.d("Engine_Driver", "keycode " + keyCode);
@@ -1125,6 +1133,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                         return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_J:
+                case KeyEvent.KEYCODE_4: // international standard gamepad
                     // F2 - Horn
                     if (action == ACTION_UP) {
                         Log.d("Engine_Driver", "keycode " + keyCode);
@@ -1140,6 +1149,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     return (true); // stop processing this key
 
                 case KeyEvent.KEYCODE_H:
+                case KeyEvent.KEYCODE_1: // international standard gamepad
                     // F0 - Light
                     if (action == ACTION_UP) {
                         //Log.d("Engine_Driver", "keycode " + keyCode);


### PR DESCRIPTION
NOTE: Currently only supports simple gamepads using 
iOS 'NewGame' mode - DPAD + keys:- Stop:y F0:h F1:u F2:j eStop:v 
or iOS 'iCade' mode - DPAD + keys:- Stop:3 F0:1 F1:2 F2:4 eStop:0

Only been able to test with one of these...
http://www.ebay.com.au/itm/Wireless-Bluetooth-Selfie-Remote-Controller-Shutter-Gamepad-For-IOS-Android-A-E0-/322586771955?hash=item4b1bab81f3:g:yYAAAOSwMVdYEcV6
