### PR TITLE
Ignore /out folder and subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ local.properties
 *.DS_Store
 /bin/
 /gen/
+/out/


### PR DESCRIPTION
Android Studio creates a /out/production/EngineDriver folder under the
project and populates it with the resources, classes, etc.  This change
adds /out/ to gitignore.