### PR TITLE
Volume throttle fixes

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -198,7 +198,7 @@
     </integer-array>
     <integer-array name="prefGamePadMKT">
         <item>0</item> //not used
-        <item>0</item> //not used
+        <item>@integer/KeyCode_5</item> //gamepadSelect
         <item>@integer/KeyCode_Dpad_Up</item> //gamepadDpadUp = KEYCODE_DPAD_UP;
         <item>@integer/KeyCode_Dpad_Down</item> //gamepadDpadDown = KEYCODE_DPAD_DOWN;
         <item>@integer/KeyCode_Dpad_Left</item> //gamepadDpadLeft = KEYCODE_DPAD_LEFT;


### PR DESCRIPTION
Prevent assigning Volume to inactive throttle via touch action.  Move
Volume to next throttle if current Volume throttle consist is released.
Removed sleep() from SetNextThrottle method (because it runs on UI
thread).