### PR TITLE
Screenlock fixes, Swipe/Fling direction selection

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -135,8 +135,8 @@
     </string-array>
     <string-array name="prefSwipeUpOptions">
         <item >None</item>
-        <item >Show/Hide Web View (requires Throttle Web View option)</item>
-        <item >Lock and Dim screen</item>
+        <item >Hide Web View\n(requires \'Throttle Web View\' preference)</item>
+        <item >Lock and Dim Screen</item>
         <item >Dim Screen</item>
     </string-array>
     <string-array name="prefGamePadStartButtonOptions">

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -136,8 +136,8 @@
     <string-array name="prefSwipeUpOptions">
         <item >None</item>
         <item >Show/Hide Web View (requires Throttle Web View option)</item>
-        <item >Disable/Enable Buttons plus Dim/Brighten Screen</item>
-        <item >Dim/Brighten Screen</item>
+        <item >Lock and Dim screen</item>
+        <item >Dim Screen</item>
     </string-array>
     <string-array name="prefGamePadStartButtonOptions">
         <item >EStop</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -138,9 +138,9 @@
     <string name="prefSwipeUpOptionSummary">What should happen when you swipe up on the Throttle view. NOTE: "Webview" option requires \'Throttle Web View?\' to be set.</string>
     <string name="prefGamePadTitle">Gamepad Preferences</string>
     <string name="prefGamePadSummary">Choose the Gamepad type and other options</string>
-    <string name="prefGamePadTypeTitle">Gamepad Type?</string>
-    <string name="prefGamePadTypeSummary">Choose the option that best supports you gamepad. NOTE: Currently only supports simple gamepads \nor Keyboard:-Dir: WZAS F:123 Stop:0 EStop:9</string>
-    <string name="prefGamePadStartButtonTitle">Gamepad Start Button?</string>
+    <string name="prefGamePadTypeTitle">Gamepad type</string>
+    <string name="prefGamePadTypeSummary">Choose the option that best supports your gamepad.</string>
+    <string name="prefGamePadStartButtonTitle">Gamepad Start Button action</string>
     <string name="prefGamePadStartButtonSummary">Choose the action when you press the Start button.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -135,7 +135,7 @@
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Swipe down to temporarily disable and reach the menu.</string>
     <string name="prefSwipeUpOptionTitle">Swipe up action in the Throttle view?</string>
-    <string name="prefSwipeUpOptionSummary">What should happen when you swipe up on the Throttle view. NOTE: "Webview" option requires \'Throttle Web View?\' to be set.</string>
+    <string name="prefSwipeUpOptionSummary">What should happen when you swipe up on the Throttle view.</string>
     <string name="prefGamePadTitle">Gamepad Preferences</string>
     <string name="prefGamePadSummary">Choose the Gamepad type and other options</string>
     <string name="prefGamePadTypeTitle">Gamepad type</string>

--- a/src/jmri/enginedriver/routes.java
+++ b/src/jmri/enginedriver/routes.java
@@ -17,11 +17,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -53,8 +48,13 @@ import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 import android.widget.TextView.OnEditorActionListener;
+import android.widget.Toast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 
 public class routes extends Activity implements OnGestureListener {
 
@@ -463,11 +463,14 @@ public class routes extends Activity implements OnGestureListener {
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         if (e1 == null || e2 == null)
             return false;
-        if ((Math.abs(e2.getX() - e1.getX()) > threaded_application.min_fling_distance) &&
-                (Math.abs(velocityX) > threaded_application.min_fling_velocity)) {
+        float deltaX = e2.getX() - e1.getX();
+        float absDeltaX = Math.abs(deltaX);
+        if ((absDeltaX > threaded_application.min_fling_distance) &&
+                (Math.abs(velocityX) > threaded_application.min_fling_velocity) &&
+                (absDeltaX > Math.abs(e2.getY() - e1.getY()))) {
             navigatingAway = true;
             // left to right swipe goes to throttle
-            if (e2.getX() > e1.getX()) {
+            if (deltaX > 0.0) {
                 this.finish();
                 connection_activity.overridePendingTransition(this, R.anim.push_right_in, R.anim.push_right_out);
             }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -3136,7 +3136,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                         //Toast.makeText(getApplicationContext(), "Swipe Up - " + webViewLocation, Toast.LENGTH_SHORT).show();
 
                         this.onResume();
-                    } else if (prefSwipeUpOption.equals("Disable/Enable Buttons plus Dim/Brighten Screen")) {
+                    } else if (prefSwipeUpOption.equals("Lock and Dim Screen")) {
                         if (isScreenLocked) {
                             isScreenLocked = false;
                             Toast.makeText(getApplicationContext(), "Throttle Screen Unlocked", Toast.LENGTH_SHORT).show();
@@ -3148,7 +3148,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                             screenBrightnessOriginal = getScreenBrightness();
                             setScreenBrightness(screenBrightnessDim);
                         }
-                    } else if (prefSwipeUpOption.equals("Dim/Brighten Screen")) {
+                    } else if (prefSwipeUpOption.equals("Dim Screen")) {
                         if (screenDimmed) {
                             screenDimmed = false;
                             setScreenBrightness(screenBrightnessOriginal);

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -3125,7 +3125,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
                 //on swipe up
                 if ((gestureStartY - event.getY()) > threaded_application.min_fling_distance) {
-                    if ((prefSwipeUpOption.equals("Show-Hide Web View")) && !(keepWebViewLocation.equals("none"))) { // show the web view if the preference is set
+                    if ((prefSwipeUpOption.equals("Show/Hide Web View")) && !(keepWebViewLocation.equals("none"))) { // show the web view if the preference is set
                         if (!webViewIsOn) {
                             webViewLocation = keepWebViewLocation;
                         } else {
@@ -3136,7 +3136,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                         //Toast.makeText(getApplicationContext(), "Swipe Up - " + webViewLocation, Toast.LENGTH_SHORT).show();
 
                         this.onResume();
-                    } else if (prefSwipeUpOption.equals("Enable-Disable all buttons")) {
+                    } else if (prefSwipeUpOption.equals("Lock and Dim screen")) {
                         if (isScreenLocked) {
                             isScreenLocked = false;
                             Toast.makeText(getApplicationContext(), "Throttle Screen Unlocked", Toast.LENGTH_SHORT).show();
@@ -3148,7 +3148,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                             screenBrightnessOriginal = getScreenBrightness();
                             setScreenBrightness(screenBrightnessDim);
                         }
-                    } else if (prefSwipeUpOption.equals("Dim-Brighten Screen")) {
+                    } else if (prefSwipeUpOption.equals("Dim Screen")) {
                         if (screenDimmed) {
                             screenDimmed = false;
                             setScreenBrightness(screenBrightnessOriginal);

--- a/src/jmri/enginedriver/turnouts.java
+++ b/src/jmri/enginedriver/turnouts.java
@@ -17,11 +17,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -41,10 +36,10 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -53,8 +48,13 @@ import android.widget.ListView;
 import android.widget.SimpleAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 import android.widget.TextView.OnEditorActionListener;
+import android.widget.Toast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 
 public class turnouts extends Activity implements OnGestureListener {
 
@@ -514,11 +514,14 @@ public class turnouts extends Activity implements OnGestureListener {
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         if (e1 == null || e2 == null)
             return false;
-        if ((Math.abs(e2.getX() - e1.getX()) > threaded_application.min_fling_distance) &&
-                (Math.abs(velocityX) > threaded_application.min_fling_velocity)) {
+        float deltaX = e2.getX() - e1.getX();
+        float absDeltaX = Math.abs(deltaX);
+        if ((absDeltaX > threaded_application.min_fling_distance) &&
+                (Math.abs(velocityX) > threaded_application.min_fling_velocity) &&
+                (absDeltaX > Math.abs(e2.getY() - e1.getY()))) {
             navigatingAway = true;
             // left to right swipe goes to routes if enabled in prefs
-            if (e2.getX() > e1.getX()) {
+            if (deltaX > 0.0) {
                 boolean swipeRoutes = prefs.getBoolean("swipe_through_routes_preference",
                         getResources().getBoolean(R.bool.prefSwipeThroughRoutesDefaultValue));
                 swipeRoutes = swipeRoutes && mainapp.isRouteControlAllowed();  //also check the allowed flag


### PR DESCRIPTION
Corrected handling of start and end of gesture when the screen is locked
to fix a case where the screen could not be unlocked.

Changed gestureEnd so that left/right and up/down swipes are now
mutually exclusive. Swipes/flings are now processed for whichever
direction has the largest delta., which hopefully will suppress some
observed swipe anomalies.

Minor changes to a few pref strings.