### PR TITLE
New Gamepad repeat handling and sound feedback.  Activity result defined.  Some code refactoring.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -142,6 +142,9 @@
     <string name="prefGamePadTypeSummary">Choose the option that best supports your gamepad.</string>
     <string name="prefGamePadStartButtonTitle">Gamepad Start Button action</string>
     <string name="prefGamePadStartButtonSummary">Choose the action when you press the Start button.</string>
+    <string name="prefGamePadFeedbackVolumeTitle">Gamepad Button Click Volume %</string>
+    <string name="prefGamePadFeedbackVolumeSummary">Set the volume percent for gamepad button clicks.</string>
+    <string name="prefGamePadFeedbackVolumeDefaultValue">100</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -178,6 +178,14 @@
                 android:key="prefGamePadStartButton"
                 android:summary="@string/prefGamePadStartButtonSummary"
                 android:title="@string/prefGamePadStartButtonTitle" />
+            <EditTextPreference
+                android:defaultValue="@string/prefGamePadFeedbackVolumeDefaultValue"
+                android:dialogTitle="@string/prefGamePadFeedbackVolumeTitle"
+                android:key="prefGamePadFeedbackVolume"
+                android:maxLength="3"
+                android:numeric="integer"
+                android:summary="@string/prefGamePadFeedbackVolumeSummary"
+                android:title="@string/prefGamePadFeedbackVolumeTitle" />
         </PreferenceScreen>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/prefThrottleTitle" >

--- a/src/jmri/enginedriver/ConsistEdit.java
+++ b/src/jmri/enginedriver/ConsistEdit.java
@@ -17,13 +17,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Set;
-
-import jmri.enginedriver.Consist.ConLoco;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
@@ -51,7 +44,14 @@ import android.widget.SimpleAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import jmri.enginedriver.Consist.ConLoco;
+
 public class ConsistEdit extends Activity implements OnGestureListener {
+    static public final int RESULT_CON_EDIT = RESULT_FIRST_USER;
 
     private threaded_application mainapp;  // hold pointer to mainapp
     private Menu CEMenu;
@@ -95,7 +95,7 @@ public class ConsistEdit extends Activity implements OnGestureListener {
             }
         }
         consistListAdapter.notifyDataSetChanged();
-        result = RESULT_FIRST_USER;
+        result = RESULT_CON_EDIT;
     }
 
 

--- a/src/jmri/enginedriver/select_loco.java
+++ b/src/jmri/enginedriver/select_loco.java
@@ -20,23 +20,45 @@ package jmri.enginedriver;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
-import android.widget.ImageView;
-import android.widget.RelativeLayout;
-import android.widget.Spinner;
-import android.widget.ArrayAdapter;
-import android.widget.TextView;
-import android.widget.Toast;
 import android.os.Message;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.RelativeLayout;
+import android.widget.SimpleAdapter;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.TextView.OnEditorActionListener;
+import android.widget.Toast;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -45,40 +67,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import android.widget.SimpleAdapter;
-import android.widget.ListView;
-
-import java.io.File;
-
-import android.view.View;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
-import android.os.Environment;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-
-import android.text.Editable;
-import android.text.TextWatcher;
-import android.util.Log;
-import android.util.TypedValue;
-
-import java.io.FileReader;
-
-import android.widget.EditText;
-import android.content.Context;
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.widget.Button;
-import android.widget.AdapterView;
-import android.widget.TextView.OnEditorActionListener;
-
-import java.io.PrintWriter;
-
 import jmri.enginedriver.Consist.ConLoco;
 import jmri.jmrit.roster.RosterEntry;
 
 public class select_loco extends Activity {
+    static public final int RESULT_LOCO_EDIT = RESULT_FIRST_USER;
+
     private static final int GONE = 8;
     private static final int VISIBLE = 0;
 
@@ -410,7 +404,7 @@ public class select_loco extends Activity {
                 Intent consistEdit = new Intent().setClass(this, ConsistEdit.class);
                 consistEdit.putExtra("whichThrottle", whichThrottle);
                 navigatingAway = true;
-                startActivityForResult(consistEdit, 1);
+                startActivityForResult(consistEdit, throttle.ACTIVITY_CONSIST);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             }
         }
@@ -418,11 +412,11 @@ public class select_loco extends Activity {
 
     //handle return from ConsistEdit
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == 1) {                          // edit consist
+        if (requestCode == throttle.ACTIVITY_CONSIST) {                          // edit consist
             if (newEngine) {
                 updateRecentEngines(saveUpdateList);
             }
-            result = RESULT_FIRST_USER;                 //tell Throttle to update loco directions
+            result = RESULT_LOCO_EDIT;                 //tell Throttle to update loco directions
         }
         end_this_activity();
     }


### PR DESCRIPTION
Added Gamepad speed button repeat handling so now the effective repeat
rate and speed step size are the same as for the Increase/Decrease speed
buttons.  Previously the only option was the repeat rate generated by
the Gamepad itself, which I found was too high.  (For safety the Gamepad
speed autorepeat uses a separate (but similar) mechansim from the screen
Up/Down keys, although this could be revisited later.)

Added more audible Gamepad keypress sound feedback by using the
ToneGenerator instead of playing the SoundEffect CLICK.  The sound
generation is now encapsulated to make future changes easier.  A
different tone is used when Throttle hits hi/lo limits or on an invalid
press (for instance Next Throttle is pressed when only one throttle is
active).  The feedback volume level will track the device volume setting
but there is also a feedback volume preference which can be used to
reduce keypress sound relative to the device volume setting if desired.

Added Activity result code definitions for clearer handling of results.
Gamepad settings are now only updated when preferences are changed, instead
of in OnResume.

Refactoring of some code in Throttle and Preference classes to improve
code modularity and simplify methods.