### PR TITLE
Gamepad minor updates

### DIFF
--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -59,6 +59,10 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
             getPreferenceScreen().findPreference("prefThrottleViewImmersiveMode").setSelectable(false);
             getPreferenceScreen().findPreference("prefThrottleViewImmersiveMode").setEnabled(false);
         }
+        if (mainapp.androidVersion < mainapp.minGamepadVersion) {
+            getPreferenceScreen().findPreference("gamepad_preferences").setSelectable(false);
+            getPreferenceScreen().findPreference("gamepad_preferences").setEnabled(false);
+        }
         result = RESULT_OK;
     }
 

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -27,15 +27,22 @@ import android.app.AlertDialog;
 import android.app.Application;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.os.SystemClock;
-
-import java.net.*;
-import java.io.*;
-
 import android.support.v4.app.NotificationCompat;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
@@ -44,8 +51,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.webkit.CookieSyncManager;
 import android.widget.Toast;
-
-import javax.jmdns.*;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
@@ -56,14 +61,19 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import de.tavendo.autobahn.WebSocketConnection;
-import de.tavendo.autobahn.WebSocketHandler;
-
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiInfo;
-
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -71,17 +81,17 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceEvent;
+import javax.jmdns.ServiceInfo;
+import javax.jmdns.ServiceListener;
+
+import de.tavendo.autobahn.WebSocketConnection;
+import de.tavendo.autobahn.WebSocketHandler;
 import jmri.enginedriver.Consist.ConLoco;
 import jmri.enginedriver.threaded_application.comm_thread.comm_handler;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterLoader;
-
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
 
 //The application will start up a thread that will handle network communication in order to ensure that the UI is never blocked.
 //This thread will only act upon messages sent to it. The network communication needs to persist across activities, so that is why
@@ -127,6 +137,7 @@ public class threaded_application extends Application {
     public final int minWebSocketVersion = android.os.Build.VERSION_CODES.HONEYCOMB;
     public final int minImmersiveModeVersion = android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
     public final int minToolbarButtonVersion = android.os.Build.VERSION_CODES.HONEYCOMB;
+    public final int minGamepadVersion = Build.VERSION_CODES.KITKAT;
 
     static final int DEFAULT_HEARTBEAT_INTERVAL = 10;       //interval for heartbeat when WiT heartbeat is disabled
     static final int MIN_OUTBOUND_HEARTBEAT_INTERVAL = 2;   //minimum allowed interval for outbound heartbeat generator

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -116,7 +116,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
     private static String VOLUME_INDICATOR = "v";
     private static String[] GAMEPAD_INDICATOR = {"1", "2", "3"};
--
+
     private SeekBar sbT; // seekbars
     private SeekBar sbS;
     private SeekBar sbG;
@@ -150,9 +150,6 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private TextView tvVolT; // volume indicators
     private TextView tvVolS;
     private TextView tvVolG;
-    private View vVolT; // volume indicators
-    private View vVolS;
-    private View vVolG;
     private LinearLayout llT; // throttles
     private LinearLayout llS;
     private LinearLayout llG;
@@ -270,7 +267,6 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private boolean prefGamePadMultipleDevices = false;
     private boolean usingMultiplePads = false;
     private int gamepadCount = 0;
-
     // preference to chnage the consist's on long clicks
     boolean prefConsistLightsLongClick;
 
@@ -1326,14 +1322,12 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private void setGamepadKeys() {
         whichGamePadMode = prefs.getString("prefGamePadType", getApplicationContext().getResources().getString(R.string.prefGamePadTypeDefaultValue));
         prefThrottleGameStartButton = prefs.getString("prefGamePadStartButton", getApplicationContext().getResources().getString(R.string.prefGamePadStartButtonDefaultValue));
-
         prefGamePadMultipleDevices = prefs.getBoolean("prefGamePadMultipleDevices", getResources().getBoolean(R.bool.prefGamePadMultipleDevicesDefaultValue));
 
         if (!whichGamePadMode.equals("None")) {
             // make sure the Softkeyboard is hidden
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM,
                     WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
-
         }
 
         int[] bGamePadKeys;

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -114,6 +114,9 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private static double displayUnitScaleG;
     private static double displayUnitScaleS;
 
+    private static String VOLUME_INDICATOR = "v";
+    private static String[] GAMEPAD_INDICATOR = {"1", "2", "3"};
+-
     private SeekBar sbT; // seekbars
     private SeekBar sbS;
     private SeekBar sbG;
@@ -144,6 +147,9 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private TextView tvSpdValG;
     private TextView tvSpdLabS;
     private TextView tvSpdValS;
+    private TextView tvVolT; // volume indicators
+    private TextView tvVolS;
+    private TextView tvVolG;
     private View vVolT; // volume indicators
     private View vVolS;
     private View vVolG;
@@ -260,8 +266,10 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private boolean mGamepadAutoDecrement = false;
 
     private int[] gamePadIds = {0,0,0};
+    private String[] gamePadThrottleAssignment = {"","",""};
     private boolean prefGamePadMultipleDevices = false;
     private boolean usingMultiplePads = false;
+    private int gamepadCount = 0;
 
     // preference to chnage the consist's on long clicks
     boolean prefConsistLightsLongClick;
@@ -1256,18 +1264,15 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
     private void setVolumeIndicator() {
         // hide or display volume control indicator based on variable
+        tvVolT.setText(gamePadThrottleAssignment[0]);
+        tvVolS.setText(gamePadThrottleAssignment[1]);
+        tvVolG.setText(gamePadThrottleAssignment[2]);
         if (whichVolume == 'T') {
-            vVolT.setVisibility(View.VISIBLE);
-            vVolS.setVisibility(View.GONE);
-            vVolG.setVisibility(View.GONE);
-        } else if (whichVolume == 'G') {
-            vVolT.setVisibility(View.GONE);
-            vVolS.setVisibility(View.GONE);
-            vVolG.setVisibility(View.VISIBLE);
+            tvVolT.setText(VOLUME_INDICATOR+gamePadThrottleAssignment[0]);
+        } else if (whichVolume == 'S') {
+            tvVolS.setText(VOLUME_INDICATOR+gamePadThrottleAssignment[1]);
         } else {
-            vVolT.setVisibility(View.GONE);
-            vVolS.setVisibility(View.VISIBLE);
-            vVolG.setVisibility(View.GONE);
+            tvVolG.setText(VOLUME_INDICATOR+gamePadThrottleAssignment[2]);
         }
     }
 
@@ -1393,24 +1398,22 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private int swapToNextAvilableThrottleForGamePad(int fromThrottle) {
         int whichThrottle = -1;
         if (prefGamePadMultipleDevices) {  // deal with multiple devices if the preference is set
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                for (int i = 0; i < allThrottleLetters.length; i++) {
-                    if (gamePadIds[i] == 0) {  // unassigned
-                        if (getConsist(allThrottleLetters[i]).isActive()) { // found next active throttle
-                            if (gamePadIds[i] <= 0) { //not currently assigned
-                                whichThrottle = i;
-                                break;  // done
-                            }
+            for (int i = 0; i < allThrottleLetters.length; i++) {
+                if (gamePadIds[i] == 0) {  // unassigned
+                    if (getConsist(allThrottleLetters[i]).isActive()) { // found next active throttle
+                        if (gamePadIds[i] <= 0) { //not currently assigned
+                            whichThrottle = i;
+                            break;  // done
                         }
                     }
                 }
-                if (whichThrottle>=0) {
-                    gamePadIds[whichThrottle] = gamePadIds[fromThrottle];
-                    gamePadThrottleAssignment[whichThrottle] = gamePadThrottleAssignment[fromThrottle];
-                    gamePadIds[fromThrottle] = 0;
-                    gamePadThrottleAssignment[fromThrottle] = "";
-                    setVolumeIndicator();
-                }
+            }
+            if (whichThrottle>=0) {
+                gamePadIds[whichThrottle] = gamePadIds[fromThrottle];
+                gamePadThrottleAssignment[whichThrottle] = gamePadThrottleAssignment[fromThrottle];
+                gamePadIds[fromThrottle] = 0;
+                gamePadThrottleAssignment[fromThrottle] = "";
+                setVolumeIndicator();
             }
         }
         if (whichThrottle==-1) {
@@ -1441,7 +1444,6 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                         gamepadCount--;
                         setVolumeIndicator(); // need to clear the indicator
                     }
-
                     break;
                 }
             }
@@ -1481,7 +1483,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
             int action = event.getAction();
             int keyCode = event.getKeyCode();
             int repeatCnt = event.getRepeatCount();
-            char whichThrottle = ' ';
+            char whichThrottle;
             int whichGamePad = whichGamePad(event);
 
             if (usingMultiplePads && whichGamePad >= 0) { // we have multiple gamepads AND the preference is set to make use of them
@@ -2213,9 +2215,9 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         // SPDHT
 
         // volume indicators
-        vVolT = findViewById(R.id.volume_indicator_T);
-        vVolS = findViewById(R.id.volume_indicator_S);
-        vVolG = findViewById(R.id.volume_indicator_G);
+        tvVolT =(TextView) findViewById(R.id.volume_indicator_T);
+        tvVolS =(TextView) findViewById(R.id.volume_indicator_S);
+        tvVolG =(TextView) findViewById(R.id.volume_indicator_G);
 
         // set_default_function_labels();
         tvSpdLabT = (TextView) findViewById(R.id.speed_label_T);
@@ -2596,7 +2598,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         int height_G;// height of third throttle area
 
         // avoid NPE by not letting this run too early (reported to Play Store)
-        if (vVolT == null) return;
+        if (tvVolT == null) return;
 
         // hide or display volume control indicator based on variable
         setVolumeIndicator();

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -60,7 +60,6 @@ import android.widget.Toast;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.Set;
 
 import jmri.enginedriver.logviewer.ui.LogViewerActivity;
 
@@ -1395,33 +1394,31 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     private int whichGamePad(KeyEvent event) {
         int whichGamePad = -1;
         if (prefGamePadMultipleDevices) {  // deal with multiple devices if the preference is set
+            int gamePadDeviceId = event.getDeviceId();
 
-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR2) {
-
-                int gamePadDeviceId = event.getDeviceId();
-
-                if ((gamePadIds[0] == 0) || (gamePadIds[0] == gamePadDeviceId)) {
-                    // key event from the first gamepad.  May not know at this point IF there are more gamepads
-                    gamePadIds[0] = gamePadDeviceId;
-                    whichGamePad = 0;
+            if ((gamePadIds[0] == 0) || (gamePadIds[0] == gamePadDeviceId)) {
+                // key event from the first gamepad.  May not know at this point IF there are more gamepads
+                gamePadIds[0] = gamePadDeviceId;
+                whichGamePad = 0;
+            } else {
+                if ((gamePadIds[1] == 0) || (gamePadIds[1] == gamePadDeviceId)) {
+                    // just got a key event from a second gamepad.  We now know there at multiple gamepads
+                    gamePadIds[1] = gamePadDeviceId;
+                    whichGamePad = 1;
+                    usingMultiplePads = true;
                 } else {
-                    if ((gamePadIds[1] == 0) || (gamePadIds[1] == gamePadDeviceId)) {
-                        // just got a key event from a second gamepad.  We now know there at multiple gamepads
-                        gamePadIds[1] = gamePadDeviceId;
-                        whichGamePad = 1;
+                    if ((gamePadIds[2] == 0) || (gamePadIds[2] == gamePadDeviceId)) {
+                        // just got a key event from a third gamepad.
+                        gamePadIds[2] = gamePadDeviceId;
+                        whichGamePad = 2;
                         usingMultiplePads = true;
                     } else {
-                        if ((gamePadIds[2] == 0) || (gamePadIds[2] == gamePadDeviceId)) {
-                            // just got a key event from a third gamepad.
-                            gamePadIds[2] = gamePadDeviceId;
-                            whichGamePad = 2;
-                            usingMultiplePads = true;
-                        }
+                        // got a key event from an additional gamepad, just treat as is gamePad 0
+                        whichGamePad = 0;
                     }
                 }
             }
-    }
-
+        }
         return whichGamePad;
     }
 
@@ -1436,7 +1433,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
             char whichThrottle = ' ';
             int whichGamePad = whichGamePad(event);
 
-            if ( usingMultiplePads && whichGamePad >= 0) { // we have multiple gamepads AND the preference is set to make use of them
+            if (usingMultiplePads && whichGamePad >= 0) { // we have multiple gamepads AND the preference is set to make use of them
                 whichThrottle = allThrottleLetters[whichGamePad];
             } else {
                 whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol... and use that one


### PR DESCRIPTION
Disable Gamepad Preferences menu if pre-KitKat and remove Android
version check from whichGamePad().

If more than 3 GamePads, treat extras as if GamePad 0.