### PR TITLE
fix+new - Magicsee R1 gamepad support + fix

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -132,6 +132,7 @@
         <item >VRBoxC-rotate</item>
         <item >VRBoxiC</item>
         <item >VRBoxiC-rotate</item>
+        <item>MagicseeR1B</item>
     </string-array>
 
     <string-array name="prefSwipeUpOptions">
@@ -313,6 +314,19 @@
         <item>@integer/KeyCode_R</item>
         <item>@integer/KeyCode_N</item>
         <item>@integer/KeyCode_T</item>
+    </integer-array>
+    <integer-array name="prefGamePadMagicseeR1B">
+        <item>0</item> //not used
+        <item>@integer/KeyCode_Button_R1</item> // Return button - upper front button
+        <item>0</item> //not used gamepadDpadUp
+        <item>0</item> //not used gamepadDpadDown
+        <item>0</item> //not used gamepadDpadLeft
+        <item>0</item> //not used gamepadDpadRight
+        <item>@integer/KeyCode_Button_L1</item> //gamepad Trigger/Ok - lower front button
+        <item>@integer/KeyCode_Button_L2</item> //gamepadC
+        <item>@integer/KeyCode_Button_B</item> //gamepadD
+        <item>@integer/KeyCode_Button_R2</item> //gamepadA
+        <item>@integer/KeyCode_Button_A</item> //gamepadB
     </integer-array>
 
     <string-array name="prefImportExportOptions">

--- a/res/values/integers.xml
+++ b/res/values/integers.xml
@@ -74,4 +74,10 @@
     <integer name="KeyCode_Button_Y"> 100</integer>
     <integer name="KeyCode_Button_Start"> 108</integer>
     <integer name="KeyCode_Mute"> 164</integer>
+
+    <integer name="KeyCode_Button_L1"> 102</integer>
+    <integer name="KeyCode_Button_R1"> 103</integer>
+    <integer name="KeyCode_Button_L2"> 104</integer>
+    <integer name="KeyCode_Button_R2"> 105</integer>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -154,11 +154,12 @@
     <string name="prefGamePadSpeedButtonsRepeatDefaultValue">300</string>
 
     <!--    Gamepad button preferences   -->
-    <string name="prefGamePadButton1Title">Gamepad Button X action</string>
+    <string name="prefGamePadButton1Title">Gamepad Button X(C) action</string>
     <string name="prefGamePadButton2Title">Gamepad Button A action</string>
-    <string name="prefGamePadButton3Title">Gamepad Button Y action</string>
+    <string name="prefGamePadButton3Title">Gamepad Button Y(D) action</string>
     <string name="prefGamePadButton4Title">Gamepad Button B action</string>
-    <string name="prefGamePadButtonStartTitle">Gamepad Start Button action</string>
+    <string name="prefGamePadButtonStartTitle">Gamepad Start(Lower) Button action</string>
+    <string name="prefGamePadButtonReturnTitle">Gamepad Return(Upper) Button action</string>
     <string name="prefGamePadButtonUpTitle">Gamepad Button DPAD Up action</string>
     <string name="prefGamePadButtonRightTitle">Gamepad Button DPAD Right action</string>
     <string name="prefGamePadButtonDownTitle">Gamepad Button DPAD Down action</string>
@@ -169,6 +170,7 @@
     <string name="prefGamePadButton3DefaultValue">Function 01/Bell</string>
     <string name="prefGamePadButton4DefaultValue">Function 02/Horn</string>
     <string name="prefGamePadButtonStartDefaultValue">Next Throttle</string>
+    <string name="prefGamePadButtonReturnDefaultValue">All Stop</string>
     <string name="prefGamePadButtonUpDefaultValue">Increase Speed</string>
     <string name="prefGamePadButtonRightDefaultValue">Reverse</string>
     <string name="prefGamePadButtonDownDefaultValue">Decrease Speed</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -244,6 +244,13 @@
                 android:summary="@string/prefGamePadButtonSummary"
                 android:title="@string/prefGamePadButtonStartTitle" />
             <ListPreference
+                android:defaultValue="@string/prefGamePadButtonReturnDefaultValue"
+                android:entries="@array/prefGamePadKeyOptions"
+                android:entryValues="@array/prefGamePadKeyOptions"
+                android:key="prefGamePadButtonReturn"
+                android:summary="@string/prefGamePadButtonSummary"
+                android:title="@string/prefGamePadButtonReturnTitle" />
+            <ListPreference
                 android:defaultValue="@string/prefGamePadButtonUpDefaultValue"
                 android:entries="@array/prefGamePadKeyOptions"
                 android:entryValues="@array/prefGamePadKeyOptions"

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -73,7 +73,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
     private static final String EXAMPLE_HOST = "jmri.mstevetodd.com";
     private String[] prefHostImportExportOptionsFound = {"None"};
-    private static final String IMPORT_PREFIX = "Import- "; // these two have to bee the same length
+    private static final String IMPORT_PREFIX = "Import- "; // these two have to be the same length
     private static final String EXPORT_PREFIX = "Export- ";
 
     private static final String OPTION_NONE = "None";

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -37,6 +37,7 @@ import android.provider.Settings;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -63,6 +64,7 @@ import java.util.LinkedHashMap;
 
 import jmri.enginedriver.logviewer.ui.LogViewerActivity;
 
+import static android.view.InputDevice.getDevice;
 import static android.view.KeyEvent.ACTION_DOWN;
 import static android.view.KeyEvent.ACTION_UP;
 import static android.view.KeyEvent.KEYCODE_A;
@@ -271,9 +273,9 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
     // Gamepad Button preferences
     private String[] prefGamePadButtons = {"Next Throttle","Stop", "Function 00/Light", "Function 01/Bell", "Function 02/Horn",
-                                            "Increase Speed", "Reverse", "Decrease Speed", "Forward"};
+                                            "Increase Speed", "Reverse", "Decrease Speed", "Forward", "All Stop"};
 
-    //                              none     NextThr  Speed+    Speed-      Fwd         Rev         EStop       F2      F1          F0          Stop
+    //                              none     NextThr  Speed+    Speed-      Fwd         Rev       All Stop    F2         F1          F0        Stop
     private int[] gamePadKeys =     {0,        0,   KEYCODE_W, KEYCODE_X,   KEYCODE_A, KEYCODE_D, KEYCODE_V, KEYCODE_T, KEYCODE_N, KEYCODE_R, KEYCODE_F};
     private int[] gamePadKeys_Up =  {0,        0,   KEYCODE_W,  KEYCODE_X, KEYCODE_A, KEYCODE_D, KEYCODE_V, KEYCODE_T, KEYCODE_N, KEYCODE_R, KEYCODE_F};
 
@@ -1426,13 +1428,6 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     }
 
 
-    // listener for the joystick events
-    @Override
-    public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
-//        Log.d("Engine_Driver", "dgme " + event.getAction());
-        return super.dispatchGenericMotionEvent(event);
-    }
-
     // setup the appropriate keycodes for the type of gamepad that has been selected in the preferences
     private void setGamepadKeys() {
         whichGamePadMode = prefs.getString("prefGamePadType", getApplicationContext().getResources().getString(R.string.prefGamePadTypeDefaultValue));
@@ -1440,6 +1435,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
 
         // Gamepad button Preferences
         prefGamePadButtons[0] = prefs.getString("prefGamePadButtonStart", getApplicationContext().getResources().getString(R.string.prefGamePadButtonStartDefaultValue));
+        prefGamePadButtons[9] = prefs.getString("prefGamePadButtonReturn", getApplicationContext().getResources().getString(R.string.prefGamePadButtonReturnDefaultValue));
         prefGamePadButtons[1] = prefs.getString("prefGamePadButton1", getApplicationContext().getResources().getString(R.string.prefGamePadButton1DefaultValue));
         prefGamePadButtons[2] = prefs.getString("prefGamePadButton2", getApplicationContext().getResources().getString(R.string.prefGamePadButton2DefaultValue));
         prefGamePadButtons[3] = prefs.getString("prefGamePadButton3", getApplicationContext().getResources().getString(R.string.prefGamePadButton3DefaultValue));
@@ -1489,6 +1485,10 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
             case "VRBoxiC-rotate":
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC);
                 bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC_UpCodes);
+                break;
+            case "MagicseeR1B":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadMagicseeR1B);
+                bGamePadKeysUp = bGamePadKeys;
                 break;
             default: // "iCade" or iCade-rotate
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadiCade);
@@ -1559,16 +1559,14 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
     }
 
     // work out a) if we need to look for multiple gamepads b) workout which gamepad we received the key event from
-    private int findWhichGamePadEventIsFrom(KeyEvent event) {
+    private int findWhichGamePadEventIsFrom(int eventDeviceId, int eventKeyCode) {
         int whichGamePad = -2;  // default to the event not from a gamepad
         int whichGamePadDeviceId = -1;
         int j;
 
-        if ((event.getKeyCode()!=KEYCODE_VOLUME_UP)&&(event.getKeyCode()!=KEYCODE_VOLUME_DOWN)&&(event.getKeyCode()!=KEYCODE_BACK)) { // if it is a volume key or the back assume it did not come form a gamepad
+//        if ((eventKeyCode!=KEYCODE_VOLUME_UP)&&(eventKeyCode!=KEYCODE_VOLUME_DOWN)&&(eventKeyCode!=KEYCODE_BACK)) { // if it is a volume key or the back assume it did not come form a gamepad
             if (prefGamePadMultipleDevices) {  // deal with multiple devices if the preference is set
-                int gamePadDeviceId = event.getDeviceId();
-
-                if (gamePadDeviceId >= 0) { // event is from a gamepad (or at least not from a screen touch)
+                if (eventDeviceId >= 0) { // event is from a gamepad (or at least not from a screen touch)
                     whichGamePad = -1;  // gamepad
 
                     String reassigningGamepad = "X";
@@ -1576,7 +1574,7 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     int numThrottles = allThrottleLetters.length;
                     // find out if this gamepad is alread assigned
                     for (i = 0; i < numThrottles; i++) {
-                        if (gamePadIds[i] == gamePadDeviceId) {
+                        if (gamePadIds[i] == eventDeviceId) {
                             if (getConsist(allThrottleLetters[i]).isActive()) { //found the throttle and it is active
                                 whichGamePad = i;
                             } else { // currently assigned to this throttle, but the throttle is not active
@@ -1593,21 +1591,21 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     if (whichGamePad == -1) { //didn't find it OR is known, but unassigned
 
                         for (j = 0; j < gamepadCount; j++) {
-                            if (gamePadDeviceIds[j] == gamePadDeviceId) { // known, but unassigned
+                            if (gamePadDeviceIds[j] == eventDeviceId) { // known, but unassigned
                                 whichGamePadDeviceId = j;
                                 break;
                             }
                         }
                         if (whichGamePadDeviceId == -1) { // previously unseen gamepad
                             gamepadCount++;
-                            gamePadDeviceIds[gamepadCount - 1] = gamePadDeviceId;
+                            gamePadDeviceIds[gamepadCount - 1] = eventDeviceId;
                             whichGamePadDeviceId = gamepadCount - 1;
                         }
 
                         for (i = 0; i < numThrottles; i++) {
                             if (gamePadIds[i] == 0) {  // throttle is not assigned a gamepad
                                 if (getConsist(allThrottleLetters[i]).isActive()) { // found next active throttle
-                                    gamePadIds[i] = gamePadDeviceId;
+                                    gamePadIds[i] = eventDeviceId;
                                     if (reassigningGamepad.equals("X")) { // not a reassignment
                                         gamePadThrottleAssignment[i] = GAMEPAD_INDICATOR[whichGamePadDeviceId];
                                     } else { // reasigning
@@ -1625,12 +1623,13 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
                     usingMultiplePads = true;
                 }
             }
-        }
+//        }
         return whichGamePad;
     }
 
     // map the button pressed to the user selected action for that button on the gamepad
     private void performButtonAction(int buttonNo, int action, boolean isActive, char whichThrottle, int whichGamePadIsEventFrom, int repeatCnt) {
+
         String x =prefGamePadButtons[buttonNo];
 
         if (prefGamePadButtons[buttonNo].equals(PREF_GAMEPAD_BUTTON_OPTION_ALL_STOP)) {  // All Stop
@@ -1709,91 +1708,161 @@ public class throttle extends Activity implements android.gesture.GestureOverlay
         }
     }
 
-        // listener for physical keyboard events
+    // listener for the joystick events
+    @Override
+    public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
+        //Log.d("Engine_Driver", "dgme " + event.getAction());
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB_MR1) {
+            if (!whichGamePadMode.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
+                int action;
+                char whichThrottle;
+                int repeatCnt = 0;
+                int whichGamePadIsEventFrom = findWhichGamePadEventIsFrom(event.getDeviceId(), 0); // dummy eventKeyCode
+
+                float xAxis = 0;
+                    xAxis = event.getAxisValue(MotionEvent.AXIS_X);
+                float yAxis = event.getAxisValue(MotionEvent.AXIS_Y);
+
+                if ((xAxis!=0) || (yAxis!=0)) {
+                    action = ACTION_DOWN;
+                } else {
+                    action = ACTION_UP;
+                }
+                if ((usingMultiplePads) && (whichGamePadIsEventFrom >= -1)) { // we have multiple gamepads AND the preference is set to make use of them AND the event came for a gamepad
+                    if (whichGamePadIsEventFrom >= 0) {
+                        whichThrottle = allThrottleLetters[whichGamePadIsEventFrom];
+                    } else {
+                        GamepadFeedbackSound(true);
+                        return (true);
+                    }
+                } else {
+                    whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol... and use that one
+                }
+
+                boolean isActive = getConsist(whichThrottle).isActive();
+
+                if (action == ACTION_UP) {
+                    mGamepadAutoIncrement = false;
+                    mGamepadAutoDecrement = false;
+                    GamepadFeedbackSoundStop();
+                }
+
+                if (yAxis == -1) { // DPAD Up Button
+                    performButtonAction(5, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
+
+                } else if (yAxis == 1) { // DPAD Down Button
+                    performButtonAction(7, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
+
+                } else if (xAxis == -1) { // DPAD Left Button
+                    performButtonAction(8, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
+
+                } else if (xAxis == 1) { // DPAD Right Button
+                    performButtonAction(6, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
+                }
+            }
+        }
+        return super.dispatchGenericMotionEvent(event);
+    }
+
+    // listener for physical keyboard events
     // used to support the gamepad only   DPAD and key events
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (!whichGamePadMode.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
-            int action = event.getAction();
-            int keyCode = event.getKeyCode();
-            int repeatCnt = event.getRepeatCount();
-            char whichThrottle;
-            int whichGamePadIsEventFrom = findWhichGamePadEventIsFrom(event);
 
-            if ((usingMultiplePads) && (whichGamePadIsEventFrom >= -1)) { // we have multiple gamepads AND the preference is set to make use of them AND the event came for a gamepad
-                if (whichGamePadIsEventFrom >= 0) {
-                    whichThrottle = allThrottleLetters[whichGamePadIsEventFrom];
+        boolean isExternal = false;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+            InputDevice idev = getDevice(event.getDeviceId());
+            if( idev.toString().contains("Location: external")) isExternal = true;
+        }
+
+        if (isExternal) { // if has come from the phone itself, don't try to process it here
+            if (!whichGamePadMode.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
+                int action = event.getAction();
+                int keyCode = event.getKeyCode();
+                int repeatCnt = event.getRepeatCount();
+                char whichThrottle;
+                int whichGamePadIsEventFrom = findWhichGamePadEventIsFrom(event.getDeviceId(), event.getKeyCode());
+
+                if ((usingMultiplePads) && (whichGamePadIsEventFrom >= -1)) { // we have multiple gamepads AND the preference is set to make use of them AND the event came for a gamepad
+                    if (whichGamePadIsEventFrom >= 0) {
+                        whichThrottle = allThrottleLetters[whichGamePadIsEventFrom];
+                    } else {
+                        GamepadFeedbackSound(true);
+                        return (true);
+                    }
                 } else {
-                    GamepadFeedbackSound(true);
-                    return (true);
+                    whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol... and use that one
                 }
-            } else {
-                whichThrottle = whichVolume;  // work out which throttle the volume keys are currently set to contol... and use that one
-            }
 
-            boolean isActive = getConsist(whichThrottle).isActive();
+                boolean isActive = getConsist(whichThrottle).isActive();
 
-            if (keyCode != 0) {
-                Log.d("Engine_Driver", "keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
-            }
+                if (keyCode != 0) {
+                    Log.d("Engine_Driver", "keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
+                }
 
-            if (action == ACTION_UP) {
-                mGamepadAutoIncrement = false;
-                mGamepadAutoDecrement = false;
-                GamepadFeedbackSoundStop();
-            }
+                if (action == ACTION_UP) {
+                    mGamepadAutoIncrement = false;
+                    mGamepadAutoDecrement = false;
+                    GamepadFeedbackSoundStop();
+                }
 
-            if (keyCode == gamePadKeys[2]) { // DPAD Up Button
-                performButtonAction(5, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                if (keyCode == gamePadKeys[2]) { // DPAD Up Button
+                    performButtonAction(5, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
-                performButtonAction(7, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
+                    performButtonAction(7, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
-                performButtonAction(8, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
+                    performButtonAction(8, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
-                performButtonAction(6, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
+                    performButtonAction(6, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[7]) { // ios button
-                performButtonAction(1, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys[7]) { // ios button
+                    performButtonAction(1, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys_Up[8]) { // X button
-                performButtonAction(3, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys_Up[8]) { // X button
+                    performButtonAction(3, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
-                performButtonAction(2, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
+                    performButtonAction(2, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys_Up[10]) { // @ button
-                performButtonAction(4, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys_Up[10]) { // @ button
+                    performButtonAction(4, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[6]) { // start button
-                performButtonAction(0, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
-                return (true); // stop processing this key
+                } else if (keyCode == gamePadKeys[6]) { // start button
+                    performButtonAction(0, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
 
-            } else if (keyCode == gamePadKeys[1]) {
-                // NextThrottle
-                if ((action == ACTION_DOWN) && (repeatCnt == 0)) {
+                } else if (keyCode == gamePadKeys[1]) { // Return button
+                    // NextThrottle
+                /* if ((action == ACTION_DOWN) && (repeatCnt == 0)) {
                     if (usingMultiplePads && whichGamePadIsEventFrom >= 0) {
                         whichGamePadIsEventFrom = swapToNextAvilableThrottleForGamePad(whichGamePadIsEventFrom, false);
                     } else {
                         setNextActiveThrottle(true);
                     }
-                }
-                return (true); // stop processing this key
+                } */
+                    performButtonAction(9, action, isActive, whichThrottle, whichGamePadIsEventFrom, repeatCnt);
+                    return (true); // stop processing this key
                 }
 //  for now pass all keystrokes not in gamePadKeys[] to super
 //  if problems occur, we can uncomment the next 2 lines
 //            else if (!((keyCode == KEYCODE_BACK) || (keyCode == KEYCODE_VOLUME_DOWN) || (keyCode == KEYCODE_VOLUME_UP) || (keyCode == KEYCODE_MENU)))
 //            return (true); // swallow all other keystrokes except back, menu and the volume keys
+            }
         }
         return super.dispatchKeyEvent(event);
     }


### PR DESCRIPTION
NEW - support Magicsee R1 gamepad - Mode B  
      (e.g. https://www.ebay.com.au/itm/NEW-Mini-Bluetooth-Remote-Controller-Wireless-Gamepad-for-Mobile-Phone-3D-VR-XR/122876742616?hash=item1c9c064bd8:g:kAQAAOSwBD9ZlWxO )

FIX - the previous gamepad fix to ignore the volume keys will stop the VR BOX gamepads from working correctly.  Now works out if the event comes from an internal or external device.