### PR TITLE
Improve handling of ESU MCII stop mode

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jmri.enginedriver"
     android:versionCode="42"
-    android:versionName="2.17-test1" android:installLocation="auto">
+    android:versionName="2.17-test2" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -7,9 +7,11 @@
 <h1>Engine Driver Throttle for Android</h1>
 <div><img src="file:///android_asset/engine_driver_icon.png" height="144" width="166"
           style="float:left;padding:0 8px 8px 0" alt=""/></div>
-<p>Engine Driver version 2.17-test1 includes:<br/>
+<p>Engine Driver version 2.17-test2 includes:<br/>
 <ul>
     <li>Add support for ESU MobileControl II throttle</li>
+    <li>Disable speed changes with ESU MobileControl II when in stop mode</li>
+    <li>Add relevant British English translations</li>
 </ul>
 </p>
 <br/><em><a
@@ -94,18 +96,18 @@
     set speed. A long press of the Stop button (default, greater than 1/2 second) will stop all
     controlled trains. The Red LED will flash slowly to denote this. On a second press of the Stop
     button, all controlled trains will remain stationary and it will be possible to again control
-    the currently selected train.
-</p>
+    the currently selected train.</p>
+<p>Whilst in stop mode, the on-screen speed change buttons and bar are disabled for currently
+    stopped throttles. Switching between controlled throttles is also disabled.</p>
 <p>It is possible to configure the device side buttons to perform various actions. The default
-    assignment is as follows:
+    assignment is as follows:</p>
     <dl>
         <dt>Top-left</dt><dd>Increase speed</dd>
         <dt>Bottom-left</dt><dd>Decrease speed</dd>
         <dt>Top-right</dt><dd>Toggle direction</dd>
         <dt>Bottom-right</dt><dd>Select next throttle</dd>
     </dl>
-    These assignments can be modified via the ESU MobileControl II Options page in Preferences.
-</p>
+<p>These assignments can be modified via the ESU MobileControl II Options page in Preferences.</p>
 <h3>Configuration:</h3>
 <p>Under Preferences, there is an extensive list of options where you can customize the screens
     and actions of EngineDriver to work best with your device, your layout and your personal style.

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,5 +1,8 @@
 **Version 2.17
  * Add support for ESU Mobile Control II throttle
+ * Add toast messages when ESU Mobile Control II in stop mode
+ * Add relevant British English translations
+ * Enable/disable speed buttons & seekbar when ESU Mobile Control II in stop mode
 **Version 2.16
  * Preference grouping
  * new gamepad repeat handling and sound feedback

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+      Copyright (C) 2018 Matthew Harris matthew.john.harris@gmail.com
+      This program is free software; you can redistribute it and/or modify it
+      under the terms of the GNU General Public License as published by the
+      Free Software Foundation;
+      either version 3 of the License, or (at your option) any later version.
+
+      This program is distributed in the hope that it will be useful, but
+      WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+      or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+      for more details. You should have received a copy of the GNU General
+      Public License along with this program; if not, write to the Free Software
+      Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+-->
+<resources>
+    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0-255.</string>
+</resources>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -14,5 +14,5 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 <resources>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0-255.</string>
+    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -202,7 +202,7 @@
     <string name="prefEsuMc2StopButtonDelayDefaultValue">500</string>
     <string name="prefEsuMc2ZeroTrimCategoryTitle">Control Knob options</string>
     <string name="prefEsuMc2ZeroTrimTitle">Control Knob Zero Trim</string>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to counter-clockwise end-stop position.\nPermitted range 0-255.</string>
+    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to counter-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
     <string name="prefEsuMc2ZeroTrimDefaultValue">10</string>
     <!-- ESU MCII preferences -->
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -178,6 +178,7 @@
     <!--    Gamepad button preferences   -->
 
     <!-- ESU MCII preferences -->
+    <string name="prefEsuMc2ThrottleNameDefaultValue">ESU MobileControl II</string>
     <string name="prefEsuMc2Title">ESU MobileControl II Options</string>
     <string name="prefEsuMc2Summary">Choose ESU MobileControl II options</string>
     <string name="prefEsuMc2ButtonsCategoryTitle">Device side button options</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -209,6 +209,7 @@
     <!-- ESU MCII Messages -->
     <string name="toastEsuMc2NoLocoChange">Loco change not allowed: Mobile Control II currently in stop mode</string>
     <string name="toastEsuMc2NoThrottleChange">Throttle change not allowed: Mobile Control II currently in stop mode</string>
+    <string name="toastEsuMc2NoButtonPresses">Button presses not allowed: Mobile Control II currently in stop mode</string>
     <!-- ESU MCII Messages -->
 
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -56,8 +56,8 @@
     <string name="fb_helptext">Enter labels and function#s in list at right.  Leave label blank to hide button.  These are used when roster functions are not available.</string>
     <string name="copy_function_labels">Copy Labels from Roster</string>
     <string name="fb_header">Edit Functions</string>
-	<string name="consist_help">Click an engine to change its direction with respect to the top of the consist.  Long press an engine to remove it from the consist.  Press Back Arrow when done.</string>
-	<string name="about">About</string>
+    <string name="consist_help">Click an engine to change its direction with respect to the top of the consist.  Long press an engine to remove it from the consist.  Press Back Arrow when done.</string>
+    <string name="about">About</string>
     <string name="web">Web</string>
     <string name="mrc_settings">MRC Settings</string>
     <string name="loco">Loco:</string>
@@ -68,7 +68,7 @@
     <string name="turnouts_direct_entry_label">Enter Turnout#</string>
     <string name="turnouts_location_label">Filter by Location</string>
     <string name="turnouts_list_label">Turnouts (click state to toggle)</string>
-	<string name="turnouts_turnout">Turnout</string>
+    <string name="turnouts_turnout">Turnout</string>
     <string name="location_all">ALL LOCATIONS</string>
     <string name="routes">Routes</string>
     <string name="routes_label">Control Routes</string>
@@ -87,10 +87,10 @@
     <string name="reconnect_label">Reconnect Attempt Status</string>
     <string name="reconnect_help">Attempting to Reconnect automatically.  Wait for Reconnection or press BackArrow to Exit.</string>
     <string name="reconnect_success">RECONNECTED.  Resuming normal operation.</string>
-    	<string name="fs_edit_notice">WARNING: changes to Default Functions Setttings will be lost on exit - No SD Card found.</string>
-	<string name="ca_recent_conn_notice">Recent Connections unavailable - No SD Card found.</string>
-	<string name="sl_recent_engine_notice">Recent Locos unavailable - No SD Card found.</string>
-	<string name="power">Power</string>
+    <string name="fs_edit_notice">WARNING: changes to Default Functions Setttings will be lost on exit - No SD Card found.</string>
+    <string name="ca_recent_conn_notice">Recent Connections unavailable - No SD Card found.</string>
+    <string name="sl_recent_engine_notice">Recent Locos unavailable - No SD Card found.</string>
+    <string name="power">Power</string>
     <string name="throttle">Throttle</string>
     <string name="on">On</string>
     <string name="off">Off</string>
@@ -198,16 +198,19 @@
     <string name="prefEsuMc2ButtonsRepeatDefaultValue">300</string>
     <string name="prefEsuMc2StopButtonCategoryTitle">Device Stop button options</string>
     <string name="prefEsuMc2StopButtonDelayTitle">Stop Button long-press delay</string>
-    <string name="prefEsuMc2StopButtonDelaySummary">How long for a \'long-press\' of the Stop button.
-        \nA \'long-press\' stops all active throttles; a \'short-press\' pauses the current throttle.\nSmaller is faster.</string>
+    <string name="prefEsuMc2StopButtonDelaySummary">How long for a \'long-press\' of the Stop button.\nA \'long-press\' stops all active throttles; a \'short-press\' pauses the current throttle.\nSmaller is faster.</string>
     <string name="prefEsuMc2StopButtonDelayDefaultValue">500</string>
     <string name="prefEsuMc2ZeroTrimCategoryTitle">Control Knob options</string>
     <string name="prefEsuMc2ZeroTrimTitle">Control Knob Zero Trim</string>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\n
-        Smaller is closer to counter-clockwise end-stop position.\nPermitted range 0-255.</string>
+    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to counter-clockwise end-stop position.\nPermitted range 0-255.</string>
     <string name="prefEsuMc2ZeroTrimDefaultValue">10</string>
     <!-- ESU MCII preferences -->
-    
+
+    <!-- ESU MCII Messages -->
+    <string name="toastEsuMc2NoLocoChange">Loco change not allowed: Mobile Control II currently in stop mode</string>
+    <string name="toastEsuMc2NoThrottleChange">Throttle change not allowed: Mobile Control II currently in stop mode</string>
+    <!-- ESU MCII Messages -->
+
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Use default function labels?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Display the default function labels instead of labels from roster entries.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Decrease Loco No. Height?</string>
@@ -308,23 +311,23 @@
 
     <string name="prefSpeedButtonsRepeatTitle">Speed button repeat delay</string>
     <string name="prefSpeedButtonsRepeatSummary">How long between repeats on speed buttons.  Smaller is faster. Excludes gamepad buttons. (See separate gamepad setting.)</string>
-	<string name="prefSpeedButtonsRepeatDefaultValue">100</string>
+    <string name="prefSpeedButtonsRepeatDefaultValue">100</string>
 
     <string name="prefSpeedButtonsSpeedStepTitle">Speed button change amount</string>
     <string name="prefSpeedButtonsSpeedStepSummary">How much Speed arrows jump throttle speed.</string>
-	<string name="prefSpeedButtonsSpeedStepDefaultValue">4</string>
+    <string name="prefSpeedButtonsSpeedStepDefaultValue">4</string>
 
     <string name="prefGamePadTypeDefaultValue">None</string>
-	<string name="prefSwipeUpOptionDefaultValue">None</string>
+    <string name="prefSwipeUpOptionDefaultValue">None</string>
     <string name="prefGamePadStartButtonDefaultValue">Next Throttle</string>
     <string name="NumThrottleDefaulValue">Two</string>
     <string name="server_address">Server address</string>
-	<string name="routes_route">Route System Name</string>
-	<string name="label_percent">%</string>
+    <string name="routes_route">Route System Name</string>
+    <string name="label_percent">%</string>
     <string name="label_14step">14</string>
-	<string name="label_27step">27</string>
+    <string name="label_27step">27</string>
     <string name="label_28step">28</string>
-	<string name="label_128step">128</string>
+    <string name="label_128step">128</string>
     <string name="throttle_name">Throttle Name: %1$s</string>
 
     <string name="prefConsistLightsLongClickTitle">Control Consist lights on long click</string>

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -202,6 +202,10 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                         Random rand = new Random();
                         deviceId = String.valueOf(rand.nextInt(9999));  //use random string
                     }
+                    if (MobileControl2.isMobileControl2()) {
+                        // Change default name for ESU MCII
+                        defaultName = getApplicationContext().getResources().getString(R.string.prefEsuMc2ThrottleNameDefaultValue);
+                    }
                     String uniqueDefaultName = defaultName + " " + deviceId;
                     sharedPreferences.edit().putString(key, uniqueDefaultName).commit();  //save new name to prefs
                 }


### PR DESCRIPTION
This improves the handling when the ESU MobileControl II is in stop mode.

It disables speed changes, blocks on-device button presses, disables loco selection and disables switch of controlled throttle. Suitable toast messages are displayed when attempting to perform these tasks.

Also included is some British English translations (only one string right now as the rest seem fine for me)