### PR TITLE
Remove blank menu entries for API 11 onwards

### DIFF
--- a/res/menu-v11/connection_menu.xml
+++ b/res/menu-v11/connection_menu.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/exit_mnu" android:title="@string/exit"></item>
+    <item android:id="@+id/preferences_mnu" android:title="@string/preferences"></item>
+    <item android:id="@+id/about_mnu" android:title="@string/about"></item>
+    <item android:id="@+id/ClearconnList" android:title="@string/ClearConnList"></item>
+</menu> 

--- a/res/menu-v11/routes_menu.xml
+++ b/res/menu-v11/routes_menu.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/throttle_mnu" android:title="@string/throttle"></item>
+    <item android:id="@+id/turnouts_mnu" android:title="@string/turnouts"></item>
+    <item android:id="@+id/web_mnu" android:title="@string/web"></item>
+    <item android:id="@+id/exit_mnu" android:title="@string/exit"></item>
+    <item android:id="@+id/power_control_mnu" android:title="@string/power"></item>
+    <item android:id="@+id/preferences_mnu" android:title="@string/preferences"></item>
+    <item android:id="@+id/about_mnu" android:title="@string/about"></item>
+    <item android:id="@+id/power_layout_button" android:showAsAction="ifRoom" android:title="@string/PowerButtonBar" android:visible="false"></item>
+    <item android:id="@+id/EmerStop" android:title="@string/EStop" android:visible="false" android:showAsAction="ifRoom"></item>
+    <!-- android:showAsAction="ifRoom" -->
+</menu> 

--- a/res/menu-v11/turnouts_menu.xml
+++ b/res/menu-v11/turnouts_menu.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/throttle_mnu" android:title="@string/throttle"></item>
+    <item android:id="@+id/routes_mnu" android:title="@string/routes"></item>
+    <item android:id="@+id/web_mnu" android:title="@string/web"></item>
+    <item android:id="@+id/exit_mnu" android:title="@string/exit"></item>
+    <item android:id="@+id/power_control_mnu" android:title="@string/power"></item>
+    <item android:id="@+id/preferences_mnu" android:title="@string/preferences"></item>
+    <item android:id="@+id/about_mnu" android:title="@string/about"></item>
+    <item android:id="@+id/power_layout_button" android:showAsAction="ifRoom" android:title="@string/PowerButtonBar" android:visible="false"></item>
+    <item android:id="@+id/EmerStop" android:title="@string/EStop"  android:visible="false" android:showAsAction="ifRoom"></item>
+</menu> 

--- a/res/menu-v11/web_menu.xml
+++ b/res/menu-v11/web_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/throttle_mnu" android:title="@string/throttle"></item>
+    <item android:id="@+id/turnouts_mnu" android:title="@string/turnouts"></item>
+    <item android:id="@+id/routes_mnu" android:title="@string/routes"></item>
+    <item android:id="@+id/exit_mnu" android:title="@string/exit"></item>
+    <item android:id="@+id/power_control_mnu" android:title="@string/power"></item>
+    <item android:id="@+id/preferences_mnu" android:title="@string/preferences"></item>
+    <item android:id="@+id/about_mnu" android:title="@string/about"></item>
+    <item android:id="@+id/EmerStop" android:title="@string/EStop"  android:visible="false" android:showAsAction="ifRoom"></item>
+</menu> 


### PR DESCRIPTION
This changes menus for API 11 devices upwards to no longer include blank entries.