### PR TITLE
Refactor theme switcher to single shared method

### DIFF
--- a/src/jmri/enginedriver/ConsistEdit.java
+++ b/src/jmri/enginedriver/ConsistEdit.java
@@ -173,15 +173,7 @@ public class ConsistEdit extends Activity implements OnGestureListener {
             return;
         }
 
-        SharedPreferences prefs;
-        String prefTheme;
-        prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.consist);
         //put pointer to this activity's handler in main app's shared variable

--- a/src/jmri/enginedriver/ConsistLightsEdit.java
+++ b/src/jmri/enginedriver/ConsistLightsEdit.java
@@ -177,13 +177,7 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
             return;
         }
 
-        SharedPreferences prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        String prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.consist_lights);
         //put pointer to this activity's handler in main app's shared variable

--- a/src/jmri/enginedriver/about_page.java
+++ b/src/jmri/enginedriver/about_page.java
@@ -42,13 +42,7 @@ public class about_page extends Activity {
         super.onCreate(savedInstanceState);
         mainapp = (threaded_application) this.getApplication();
 
-        SharedPreferences prefs;
-        String prefTheme;
-        prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.about_page);
 

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -308,13 +308,7 @@ public class connection_activity extends Activity {
 
         }
 
-        String prefTheme;
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.connection);
 

--- a/src/jmri/enginedriver/function_settings.java
+++ b/src/jmri/enginedriver/function_settings.java
@@ -68,13 +68,7 @@ public class function_settings extends Activity {
 
         //setTitleToIncludeThrotName();
 
-        SharedPreferences prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        String prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.function_settings);
         orientationChange = false;

--- a/src/jmri/enginedriver/power_control.java
+++ b/src/jmri/enginedriver/power_control.java
@@ -129,13 +129,7 @@ public class power_control extends Activity {
             return;
         }
 
-        SharedPreferences prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        String prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.power_control);
 

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -94,16 +94,11 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
         ListPreference preference;
 
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        String prefTheme;
-        prefTheme = sharedPreferences.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+
+        mainapp = (threaded_application) getApplication();
+        mainapp.applyTheme(this);
 
         super.onCreate(savedInstanceState);
-        mainapp = (threaded_application) getApplication();
         addPreferencesFromResource(R.xml.preferences);
         if (!mainapp.isPowerControlAllowed()) {
             getPreferenceScreen().findPreference("show_layout_power_button_preference").setSelectable(false);

--- a/src/jmri/enginedriver/reconnect_status.java
+++ b/src/jmri/enginedriver/reconnect_status.java
@@ -112,13 +112,7 @@ public class reconnect_status extends Activity {
             return;
         }
 
-        SharedPreferences prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
-        String prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.reconnect_page);
 

--- a/src/jmri/enginedriver/routes.java
+++ b/src/jmri/enginedriver/routes.java
@@ -299,13 +299,7 @@ public class routes extends Activity implements OnGestureListener {
 
 //      setTitleToIncludeThrotName();
 
-        String prefTheme;
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.routes);
         //put pointer to this activity's handler in main app's shared variable

--- a/src/jmri/enginedriver/select_loco.java
+++ b/src/jmri/enginedriver/select_loco.java
@@ -583,13 +583,7 @@ public class select_loco extends Activity {
             return;
         }
 
-        String prefTheme;
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.select_loco);
 

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -2478,6 +2478,29 @@ public class threaded_application extends Application {
     }
 
     /**
+     * Applies the chosen theme from preferences to the specified activity
+     *
+     * @param activity the activity to set the theme for
+     */
+    public void applyTheme(Activity activity) {
+        String prefTheme = getCurrentTheme();
+        if (prefTheme.equals("Black")) {
+            activity.setTheme(R.style.app_theme_black);
+        } else if (prefTheme.equals("Outline")) {
+            activity.setTheme(R.style.app_theme_outline);
+        }
+    }
+
+    /**
+     * Retrieve the currently configure theme from preferences
+     *
+     * @return a String representation of the selected theme
+     */
+    public String getCurrentTheme() {
+        return prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
+    }
+
+    /**
      * Set activity screen orientation based on prefs, check to avoid sending change when already there.
      * checks "auto Web on landscape" preference and returns false if orientation requires activity switch
      *

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -327,8 +327,6 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     private ThrottleScale esuThrottleScaleS = new ThrottleScale(10, 127);
     private ThrottleScale esuThrottleScaleG = new ThrottleScale(10, 127);
 
-    private String prefTheme;
-
     private enum EsuMc2Led {
         RED (MobileControl2.LED_RED),
         GREEN (MobileControl2.LED_GREEN);
@@ -2904,12 +2902,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             return;
         }
 
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.throttle);
 
@@ -3514,7 +3507,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                     String bt = function_labels_temp.get(func);
                     fbtl = new function_button_touch_listener(func, whichThrottle, bt);
                     b.setOnTouchListener(fbtl);
-                    if ((prefTheme.equals("Default"))) {
+                    if ((mainapp.getCurrentTheme().equals("Default"))) {
                         bt = bt + "        ";  // pad with spaces, and limit to 7 characters
                         b.setText(bt.substring(0, 7));
                     } else {

--- a/src/jmri/enginedriver/turnouts.java
+++ b/src/jmri/enginedriver/turnouts.java
@@ -323,13 +323,7 @@ public class turnouts extends Activity implements OnGestureListener {
             return;
         }
 
-        String prefTheme;
-        prefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
-        if (prefTheme.equals("Black")) {
-            setTheme(R.style.app_theme_black);
-        } else if (prefTheme.equals("Outline")) {
-            setTheme(R.style.app_theme_outline);
-        }
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.turnouts);
 

--- a/src/jmri/enginedriver/web_activity.java
+++ b/src/jmri/enginedriver/web_activity.java
@@ -137,6 +137,8 @@ public class web_activity extends Activity {
         }
         setContentView(R.layout.web_activity);
 
+        mainapp.applyTheme(this);
+
         webView = (WebView) findViewById(R.id.webview);
         String databasePath = webView.getContext().getDir("databases", Context.MODE_PRIVATE).getPath();
         webView.getSettings().setDatabasePath(databasePath);


### PR DESCRIPTION
This is an alternate solution to the theme switcher prompted by #141 as I noticed the same bunch of conditionals being repeated in essentially every activity class.

By refactoring these into one single method allows the conditional to only be maintained once meaning that any future additional themes need only be checked for in that one place rather than multiple.

Use of this could also allow us to permit theme changes without exiting the app.