### PR TITLE
CHANGED - Optional alternate labels for the throttle direction buttons

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -15,6 +15,7 @@
     <li>Optional high contrast colour theme</li>
     <li>Improved the rounding error on scale speed calulations (The throttle will zero more reliably)</li>
     <li>Optional alternate labels for the throttle direction buttons.</li>
+    <li>Optional long click or direction buttons to swap them.</li>
 </ul>
 </p>
 <br/><em><a

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -13,7 +13,8 @@
     <li>Add relevant British English translations</li>
     <li>Optional high contrast colour themes</li>
     <li>Improved the rounding error on scale speed calculations (The throttle will zero more reliably)</li>
-    <li>Optional alternate labels for the throttle direction buttons.</li>
+    <li>Optional alternate labels for the throttle direction buttons</li>
+    <li>Optional long press on the direction buttons to swap them</li>
     <li>prevent some crashes reported to Play Store</li>
 </ul>
 </p>

--- a/res/color/btn_text_states.xml
+++ b/res/color/btn_text_states.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"  android:color="@color/black_half_trans"/> <!-- disabled -->
     <item android:state_pressed="true"    android:color="@color/black"/> <!-- pressed -->
+    <item android:state_selected="true"   android:color="@color/black"/> <!-- pressed -->
     <item android:state_focused="true"   android:color="@color/grey"/> <!-- focused -->
     <item                                                       android:color="@color/black"/> <!-- default -->
 </selector>

--- a/res/color/btn_text_states_outline.xml
+++ b/res/color/btn_text_states_outline.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"  android:color="@color/buttonDisabledStroke_outline"/> <!-- disabled -->
     <item android:state_pressed="true"   android:color="@color/buttonSelectedStroke_outline"/> <!-- pressed -->
+    <item android:state_selected="true"  android:color="@color/buttonSelectedStroke_outline"/> <!-- pressed -->
     <item android:state_focused="true"   android:color="@color/buttonSelectedStroke_outline"/> <!-- focused -->
     <item android:color="@color/buttonStroke_outline"/> <!-- default -->
 </selector>

--- a/res/color/btn_text_states_stop_btn_outline.xml
+++ b/res/color/btn_text_states_stop_btn_outline.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"  android:color="@color/buttonDisabledStroke_outline"/> <!-- disabled -->
     <item android:state_pressed="true"   android:color="@color/buttonStopSelectedStroke_outline"/> <!-- pressed -->
+    <item android:state_selected="true"  android:color="@color/buttonStopSelectedStroke_outline"/> <!-- pressed -->
     <item android:state_focused="true"   android:color="@color/buttonStopSelectedStroke_outline"/> <!-- focused -->
     <item android:color="@color/buttonStopStroke_outline"/> <!-- default -->
 </selector>

--- a/res/color/fn_btn_text_states_outline.xml
+++ b/res/color/fn_btn_text_states_outline.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false"  android:color="@color/buttonFnDisabledStroke_outline"/> <!-- disabled -->
     <item android:state_pressed="true"   android:color="@color/buttonFnSelectedStroke_outline"/> <!-- pressed -->
+    <item android:state_selected="true"  android:color="@color/buttonFnSelectedStroke_outline"/> <!-- pressed -->
     <item android:state_focused="true"   android:color="@color/buttonFnSelectedStroke_outline"/> <!-- focused -->
     <item android:color="@color/buttonStroke_outline"/> <!-- default -->
 </selector>

--- a/res/drawable/fn_button_states_round_outline.xml
+++ b/res/drawable/fn_button_states_round_outline.xml
@@ -12,7 +12,7 @@
     <item android:state_pressed="true" android:state_enabled="true">
         <shape android:shape="rectangle"  >
             <corners android:radius="5dip" />
-            <stroke android:width="2dip" android:color="@color/buttonFnSelectedStroke_outline" />
+            <stroke android:width="3dip" android:color="@color/buttonFnSelectedStroke_outline" />
             <solid android:color="@color/buttonFnSelectedFill_outline"/>
         </shape>
     </item>
@@ -20,7 +20,7 @@
     <item >
         <shape android:shape="rectangle"  >
             <corners android:radius="5dip" />
-            <stroke android:width="2dip" android:color="@color/buttonFnStroke_outline" />
+            <stroke android:width="1dip" android:color="@color/buttonFnStroke_outline" />
             <solid android:color="@color/buttonFnFill_outline" />
         </shape>
     </item>

--- a/res/drawable/sticky_button_states.xml
+++ b/res/drawable/sticky_button_states.xml
@@ -11,5 +11,9 @@
       android:state_enabled="true"
       android:drawable="@drawable/btn_pressed" />
    <item
+       android:state_selected="true"
+       android:state_enabled="true"
+       android:drawable="@drawable/btn_pressed" />
+   <item
       android:drawable="@drawable/btn_not_pressed" />
 </selector>

--- a/res/drawable/sticky_button_states_round.xml
+++ b/res/drawable/sticky_button_states_round.xml
@@ -12,7 +12,15 @@
     <item android:state_pressed="true" android:state_enabled="true">
         <shape android:shape="rectangle"  >
             <corners android:radius="5dip" />
-            <stroke android:width="1dip" android:color="@color/buttonSelectedStroke_black" />
+            <stroke android:width="3dip" android:color="@color/buttonSelectedStroke_black" />
+            <solid android:color="@color/buttonSelectedFill_black"/>
+        </shape>
+    </item>
+
+    <item android:state_selected="true" android:state_enabled="true">
+        <shape android:shape="rectangle"  >
+            <corners android:radius="3dip" />
+            <stroke android:width="4dip" android:color="@color/buttonSelectedStroke_black" />
             <solid android:color="@color/buttonSelectedFill_black"/>
         </shape>
     </item>

--- a/res/drawable/sticky_button_states_round_outline.xml
+++ b/res/drawable/sticky_button_states_round_outline.xml
@@ -12,7 +12,15 @@
     <item android:state_pressed="true" android:state_enabled="true">
         <shape android:shape="rectangle"  >
             <corners android:radius="5dip" />
-            <stroke android:width="2dip" android:color="@color/buttonSelectedStroke_outline" />
+            <stroke android:width="3dip" android:color="@color/buttonSelectedStroke_outline" />
+            <solid android:color="@color/buttonSelectedFill_outline"/>
+        </shape>
+    </item>
+
+    <item android:state_selected="true" android:state_enabled="true">
+        <shape android:shape="rectangle"  >
+            <corners android:radius="5dip" />
+            <stroke android:width="3dip" android:color="@color/buttonSelectedStroke_outline" />
             <solid android:color="@color/buttonSelectedFill_outline"/>
         </shape>
     </item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -501,23 +501,4 @@
         <item>High Contrast Outline Theme</item>
     </string-array>
 
-    <string-array name="prefDirectionButtonsOptions">
-        <item>Forward</item>
-        <item>East</item>
-        <item>West</item>
-        <item>North</item>
-        <item>South</item>
-        <item>Up</item>
-        <item>Down</item>
-    </string-array>
-    <string-array name="prefDirectionButtonsEntries">
-        <item>Forward / Reverse</item>
-        <item>East \u00B7F\u00B7 / West \u00B7R\u00B7</item>
-        <item>West \u00B7F\u00B7 / East \u00B7R\u00B7</item>
-        <item>North \u00B7F\u00B7 / South \u00B7R\u00B7</item>
-        <item>South \u00B7F\u00B7 / North \u00B7R\u00B7</item>
-        <item>Up \u00B7F\u00B7 / Down \u00B7R\u00B7</item>
-        <item>Down \u00B7F\u00B7 / Up \u00B7R\u00B7</item>
-    </string-array>
-
 </resources>

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -44,6 +44,7 @@
     <bool name="prefGamePadMultipleDevicesDefaultValue">true</bool>
 
     <bool name="prefSwapForwardReverseButtonsDefaultValue">false</bool>
+    <bool name="prefSwapForwardReverseButtonsLongPressDefaultValue">false</bool>
 
     <bool name="prefImportExportLocoListDefaultValue">true</bool>
     <bool name="prefAutoImportExportDefaultValue">false</bool>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -354,8 +354,19 @@
     <string name="prefHostImportExportSummary">\'Import\' or \'Export\' your preferences for a specific host to the \'engine_driver/\' folder. The host must be in your recent connection list.\nWill occur IMMEDIATELY on selecting the option.\n(Only available when not currently connected.)</string>
     <string name="prefHostImportExportDefaultValue">None</string>
 
-    <string name="prefSwapForwardReverseButtonsTitle">Swap Forward and Reverse</string>
-    <string name="prefSwapForwardReverseButtonsSummary">Swap the Forward and Reverse Buttons. REQUIRES a restart of Engine Driver, or it will behave unpredictably.</string>
+    <string name="prefSwapForwardReverseButtonsTitle">Swap Direction Buttons</string>
+    <string name="prefSwapForwardReverseButtonsSummary">Permanently swap the two Direction Buttons for all throttles.</string>
+
+    <string name="prefSwapForwardReverseButtonsLongPressTitle">Long press Swap Direction Buttons</string>
+    <string name="prefSwapForwardReverseButtonsLongPressSummary">Temporarily swap the two Direction Buttons with a long press of any of Direction Button.</string>
+
+    <string name="prefLeftDirectionButtonsTitle">Left Direction Button label</string>
+    <string name="prefLeftDirectionButtonsSummary">Labels for all LEFT direction buttons. Enter \'Foward\' or blank for normal behaviour.\nNote: If the \'Swap\' option above is selected, this is the for the Right Button. </string>
+    <string name="prefLeftDirectionButtonsDefaultValue">Forward</string>
+
+    <string name="prefRightDirectionButtonsTitle">Right Direction Button label</string>
+    <string name="prefRightDirectionButtonsSummary">Labels for all RIGHT direction buttons. Enter \'Reverse\' or blank for normal behaviour.\nNote: If the \'Swap\' option above is selected, this is the for the Left Button.</string>
+    <string name="prefRightDirectionButtonsDefaultValue">Reverse</string>
 
     <string name="prefThemeTitle">Theme/Style</string>
     <string name="prefThemeSummary">App theme. REQUIRES restart of Engine Driver. \nRequires Android Honeycomb or later.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="prefThrottleStatusTitle">Throttle Page Status Row Preferences</string>
     <string name="prefSliderTitle">Slider and Direction Button Preferences</string>
     <string name="prefSliderSummary">Options for Speed Slider, Speed Buttons and Direction Buttons</string>
-    <string name="prefIncreaseSliderHeightTitle">Increase Slider Height?</string>
+    <string name="prefIncreaseSliderHeightTitle">Increase Slider/Speed Height?</string>
     <string name="prefIncreaseSliderHeightSummary">Use a taller slider, or speed buttons, for throttles.</string>
     <string name="prefHideSliderTitle">Hide Speed Slider?</string>
     <string name="prefHideSliderSummary">Do not show speed slider, use speed buttons instead.</string>
@@ -361,11 +361,11 @@
     <string name="prefSwapForwardReverseButtonsLongPressSummary">Temporarily swap the two Direction Buttons with a long press of any of Direction Button.</string>
 
     <string name="prefLeftDirectionButtonsTitle">Left Direction Button label</string>
-    <string name="prefLeftDirectionButtonsSummary">Labels for all LEFT direction buttons. Enter \'Foward\' or blank for normal behaviour.\nNote: If the \'Swap\' option above is selected, this is the for the Right Button. </string>
+    <string name="prefLeftDirectionButtonsSummary">Labels for all LEFT direction buttons. Enter \'Foward\' or blank for normal behaviour.</string>
     <string name="prefLeftDirectionButtonsDefaultValue">Forward</string>
 
     <string name="prefRightDirectionButtonsTitle">Right Direction Button label</string>
-    <string name="prefRightDirectionButtonsSummary">Labels for all RIGHT direction buttons. Enter \'Reverse\' or blank for normal behaviour.\nNote: If the \'Swap\' option above is selected, this is the for the Left Button.</string>
+    <string name="prefRightDirectionButtonsSummary">Labels for all RIGHT direction buttons. Enter \'Reverse\' or blank for normal behaviour.</string>
     <string name="prefRightDirectionButtonsDefaultValue">Reverse</string>
 
     <string name="prefThemeTitle">Theme/Style</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -86,19 +86,36 @@
                 android:summary="@string/prefHideSliderSummary"
                 android:title="@string/prefHideSliderTitle" >
             </CheckBoxPreference>
+
             <CheckBoxPreference
                 android:defaultValue="@bool/prefSwapForwardReverseButtonsDefaultValue"
                 android:key="prefSwapForwardReverseButtons"
                 android:summary="@string/prefSwapForwardReverseButtonsSummary"
                 android:title="@string/prefSwapForwardReverseButtonsTitle" >
             </CheckBoxPreference>
-            <ListPreference
-                android:defaultValue="@string/prefDirectionButtonsDefaultValue"
-                android:entries="@array/prefDirectionButtonsEntries"
-                android:entryValues="@array/prefDirectionButtonsOptions"
-                android:key="prefDirectionButtons"
-                android:summary="@string/prefDirectionButtonsSummary"
-                android:title="@string/prefDirectionButtonsTitle" />
+
+            <CheckBoxPreference
+                android:defaultValue="@bool/prefSwapForwardReverseButtonsLongPressDefaultValue"
+                android:key="prefSwapForwardReverseButtonsLongPress"
+                android:summary="@string/prefSwapForwardReverseButtonsLongPressSummary"
+                android:title="@string/prefSwapForwardReverseButtonsLongPressTitle" >
+            </CheckBoxPreference>
+
+            <EditTextPreference
+                android:defaultValue="@string/prefLeftDirectionButtonsDefaultValue"
+                android:dialogTitle="@string/prefLeftDirectionButtonsTitle"
+                android:key="prefLeftDirectionButtons"
+                android:maxLength="7"
+                android:summary="@string/prefLeftDirectionButtonsSummary"
+                android:title="@string/prefLeftDirectionButtonsTitle" />
+            <EditTextPreference
+                android:defaultValue="@string/prefRightDirectionButtonsDefaultValue"
+                android:dialogTitle="@string/prefRightDirectionButtonsTitle"
+                android:key="prefRightDirectionButtons"
+                android:maxLength="7"
+                android:summary="@string/prefRightDirectionButtonsSummary"
+                android:title="@string/prefRightDirectionButtonsTitle" />
+
 
         </PreferenceScreen>
 

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -644,14 +644,19 @@ public class connection_activity extends Activity {
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
         if (prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_AND_DISCONNECT)) {
-            String exportedPreferencesFileName = mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
+            if (mainapp.connectedHostName != null) {
+                String exportedPreferencesFileName = mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
 
-            if (!exportedPreferencesFileName.equals(".ed")) {
-                File path = Environment.getExternalStorageDirectory();
-                File engine_driver_dir = new File(path, "engine_driver");
-                engine_driver_dir.mkdir();            // create directory if it doesn't exist
+                if (!exportedPreferencesFileName.equals(".ed")) {
+                    File path = Environment.getExternalStorageDirectory();
+                    File engine_driver_dir = new File(path, "engine_driver");
+                    engine_driver_dir.mkdir();            // create directory if it doesn't exist
 
-                res = importExportPreferences.saveSharedPreferencesToFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);;
+                    res = importExportPreferences.saveSharedPreferencesToFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);
+                    ;
+                }
+            } else {
+                Toast.makeText(getApplicationContext(), "Unable to save host specific preferences. Can't get host name.", Toast.LENGTH_LONG).show();
             }
         } else { // preference is NOT to save the preferences for the host
             res = true;
@@ -665,12 +670,16 @@ public class connection_activity extends Activity {
        SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
        String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue)).trim();
 
-       String exportedPreferencesFileName = mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
-
        if ((prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_AND_DISCONNECT))
-       || (prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_ONLY))) {  // automatically load the host specific preferences, if the preference is set
-           res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);
-       } else {// preference is NOT to load the preferences for the host
+               || (prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_ONLY))) {  // automatically load the host specific preferences, if the preference is set
+           if (mainapp.connectedHostName != null) {
+               String exportedPreferencesFileName = mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
+               res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);
+               res = true;
+           } else {
+               Toast.makeText(getApplicationContext(), "Unable to load host specific preferences. Can't get host name.", Toast.LENGTH_LONG).show();
+           }
+       } else { // preference is NOT to load the preferences for the host
            res = true;
        }
        return res;

--- a/src/jmri/enginedriver/function_button.java
+++ b/src/jmri/enginedriver/function_button.java
@@ -19,9 +19,9 @@ package jmri.enginedriver;
 
 interface function_button {
     //Constant values for the function buttons (excluding direction buttons):
-    int FORWARD = 990;
+    //int FORWARD = 990;
     int STOP = 991;
-    int REVERSE = 992;
+    //int REVERSE = 992;
     int SELECT_LOCO = 993;
     int SPEED_LABEL = 994;
     int SPEED_INC = 995;

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -326,8 +326,11 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     private boolean prefSwapForwardReverseButtonsLongPress = false;
     private boolean currentSwapForwardReverseButtons = false;
 
-    private String prefLeftDirectionButtons = "Forward";
-    private String prefRightDirectionButtons = "Reverse";
+    private static String DIRECTION_BUTTON_LEFT_TEXT = "Forward";
+    private static String DIRECTION_BUTTON_RIGHT_TEXT = "Reverse";
+
+    private String prefLeftDirectionButtons = DIRECTION_BUTTON_LEFT_TEXT;
+    private String prefRightDirectionButtons = DIRECTION_BUTTON_RIGHT_TEXT;
 
     //Throttle Array
     private final char[] allThrottleLetters = {'T', 'S', 'G'};
@@ -544,6 +547,9 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         @Override
         public void handleMessage(Message msg) {
             String response_str = msg.obj.toString();
+
+            Log.d("Engine_Driver", "throttle handleMessage " + response_str );
+
             switch (msg.what) {
                 case message_type.RESPONSE: { // handle messages from WiThrottle server
                     if (response_str.length() < 2)
@@ -886,7 +892,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     private boolean directionButtonsAreCurrentlyReversed() {
         boolean isOk = false;
         if ( ((!prefSwapForwardReverseButtons) && (currentSwapForwardReverseButtons))
-                || (((!prefSwapForwardReverseButtons) && (currentSwapForwardReverseButtons))) ) {
+                || (((prefSwapForwardReverseButtons) && (!currentSwapForwardReverseButtons))) ) {
             isOk= true;
         }
         return isOk;
@@ -901,18 +907,18 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     }
 
     private void setDirectionButtonLabels() {
-        String FullLeftText = "Forward";
-        String FullRightText = "Reverse";
-        String dirLeftText = "Forward";
-        String dirRightText = "Reverse";
+        String FullLeftText = DIRECTION_BUTTON_LEFT_TEXT;
+        String FullRightText = DIRECTION_BUTTON_RIGHT_TEXT;
+        String dirLeftText = DIRECTION_BUTTON_LEFT_TEXT;
+        String dirRightText = DIRECTION_BUTTON_RIGHT_TEXT;
         String dirLeftExtraText = " \u00B7F\u00B7";
         String dirRightExtraText = " \u00B7R\u00B7";
 
-        if ( ((prefLeftDirectionButtons.equals("Forward")) && (prefRightDirectionButtons.equals("Reverse")))
+        if ( ((prefLeftDirectionButtons.equals(DIRECTION_BUTTON_LEFT_TEXT)) && (prefRightDirectionButtons.equals(DIRECTION_BUTTON_RIGHT_TEXT)))
                 || ((prefLeftDirectionButtons.equals("")) && (prefRightDirectionButtons.equals(""))) ){
             if(directionButtonsAreCurrentlyReversed()) {
-                FullLeftText = "Reverse";
-                FullRightText = "Forward";
+                FullLeftText = DIRECTION_BUTTON_RIGHT_TEXT;
+                FullRightText = DIRECTION_BUTTON_LEFT_TEXT;
             }
         } else {
             dirLeftText = prefLeftDirectionButtons;
@@ -1268,115 +1274,49 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
 
     // indicate direction using the button pressed state
     void showDirectionIndication(char whichThrottle, int direction) {
-        Button bFwd;
-        Button bRev;
-        if (!prefSwapForwardReverseButtons) {
-            if (whichThrottle == 'T') {
-                bFwd = bFwdT;
-                bRev = bRevT;
-            } else if (whichThrottle == 'G') {
-                bFwd = bFwdG;
-                bRev = bRevG;
-            } else {
+        Button bFwd = bFwdT;
+        Button bRev = bRevT;
+        switch (whichThrottle) {
+            case 'S':
                 bFwd = bFwdS;
                 bRev = bRevS;
-            }
-        } else {
-            if (whichThrottle == 'T') {
-                bRev = bFwdT;
-                bFwd = bRevT;
-            } else if (whichThrottle == 'G') {
-                bRev = bFwdG;
-                bFwd = bRevG;
-            } else {
-                bRev = bFwdS;
-                bFwd = bRevS;
-            }
+                break;
+            case 'G':
+                bFwd = bFwdG;
+                bRev = bRevG;
         }
+
         boolean setLeftDirectionButtonEnabled = true;
         if (direction == 0) {  //0=reverse 1=forward
             if (!directionButtonsAreCurrentlyReversed())
                 setLeftDirectionButtonEnabled = false;
             else
                 setLeftDirectionButtonEnabled = true;
-        } else
-        if (!directionButtonsAreCurrentlyReversed())
-            setLeftDirectionButtonEnabled = true;
-        else
-            setLeftDirectionButtonEnabled = false;
+        } else {
+            if (!directionButtonsAreCurrentlyReversed())
+                setLeftDirectionButtonEnabled = true;
+            else
+                setLeftDirectionButtonEnabled = false;
+        }
 
         if (!setLeftDirectionButtonEnabled) {
-            bFwd.setPressed(false);
-            bRev.setPressed(true);
+            bFwd.setSelected(false);
+            bRev.setSelected(true);
             bFwd.setTypeface(null, Typeface.NORMAL);
-            bRev.setTypeface(null, Typeface.ITALIC);
+            bRev.setTypeface(null, Typeface.ITALIC + Typeface.BOLD);
         } else {
-            bFwd.setPressed(true);
-            bRev.setPressed(false);
-            bFwd.setTypeface(null, Typeface.ITALIC);
+            bFwd.setSelected(true);
+            bRev.setSelected(false);
+            bFwd.setTypeface(null, Typeface.ITALIC + Typeface.BOLD);
             bRev.setTypeface(null, Typeface.NORMAL);
         }
 
-//        bFwd.invalidate(); //button wasn't changing at times
-//        bRev.invalidate();
+        //bFwd.invalidate(); //button wasn't changing at times
+        //bRev.invalidate();
     }
 
     // indicate requested direction using the button typeface
     void showDirectionRequest(char whichThrottle, int direction) {
-/**  this appears to do alow the same as the function above, which this calls anyway
-        Button bFwd;
-        Button bRev;
-        if (!directionButtonsAreCurrentlyReversed()) {
-            if (whichThrottle == 'T') {
-                bFwd = bFwdT;
-                bRev = bRevT;
-                dirT = direction;
-            } else if (whichThrottle == 'G') {
-                bFwd = bFwdG;
-                bRev = bRevG;
-                dirG = direction;
-            } else {
-                bFwd = bFwdS;
-                bRev = bRevS;
-                dirS = direction;
-            }
-        } else {
-            if (whichThrottle == 'T') {
-                bRev = bFwdT;
-                bFwd = bRevT;
-                dirT = direction;
-            } else if (whichThrottle == 'G') {
-                bRev = bFwdG;
-                bFwd = bRevG;
-                dirG = direction;
-            } else {
-                bRev = bFwdS;
-                bFwd = bRevS;
-                dirS = direction;
-            }
-
-        }
-        boolean setLeftDirectionButtonEnabled = true;
-        if (direction == 0) {  //0=reverse 1=forward
-            if (!directionButtonsAreCurrentlyReversed())
-                setLeftDirectionButtonEnabled = false;
-            else
-                setLeftDirectionButtonEnabled = true;
-        } else
-        if (!directionButtonsAreCurrentlyReversed())
-            setLeftDirectionButtonEnabled = true;
-        else
-            setLeftDirectionButtonEnabled = false;
-
-        if (!setLeftDirectionButtonEnabled) {
-            bFwd.setTypeface(null, Typeface.NORMAL);
-            bRev.setTypeface(null, Typeface.ITALIC);
-
-        } else {
-            bFwd.setTypeface(null, Typeface.ITALIC);
-            bRev.setTypeface(null, Typeface.NORMAL);
-        }
-**/
         /*
          * this code gathers direction feedback for the direction indication
          * 
@@ -1428,7 +1368,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
         if (pressed) {
             bStop.setPressed(true);
-            bStop.setTypeface(null, Typeface.ITALIC);
+            bStop.setTypeface(null, Typeface.ITALIC + Typeface.BOLD);
         } else {
             bStop.setPressed(false);
             bStop.setTypeface(null, Typeface.NORMAL);
@@ -1652,7 +1592,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
         if (b != null && fs != null) {
             if (fs[function]) {
-                b.setTypeface(null, Typeface.ITALIC);
+                b.setTypeface(null, Typeface.ITALIC + Typeface.BOLD);
                 b.setPressed(true);
             } else {
                 b.setTypeface(null, Typeface.NORMAL);
@@ -1677,7 +1617,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
         if (b != null) {
             if (reqState != 0) {
-                b.setTypeface(null, Typeface.ITALIC);
+                b.setTypeface(null, Typeface.ITALIC + Typeface.BOLD);
             } else {
                 b.setTypeface(null, Typeface.NORMAL);
             }
@@ -2798,6 +2738,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
 
         @Override
         public boolean onLongClick(View v) {
+            doButtonPress();  //in case the the direction button long clicked is not the current direction change the direction first
+
             if (prefSwapForwardReverseButtonsLongPress) {
                 v.playSoundEffect(SoundEffectConstants.CLICK);
                 if (currentSwapForwardReverseButtons) {

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -902,8 +902,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         prefSwapForwardReverseButtons = prefs.getBoolean("prefSwapForwardReverseButtons", getResources().getBoolean(R.bool.prefSwapForwardReverseButtonsDefaultValue));
         prefSwapForwardReverseButtonsLongPress = prefs.getBoolean("prefSwapForwardReverseButtonsLongPress", getResources().getBoolean(R.bool.prefSwapForwardReverseButtonsLongPressDefaultValue));
 
-        prefLeftDirectionButtons = prefs.getString("prefLeftDirectionButtons", getApplicationContext().getResources().getString(R.string.prefLeftDirectionButtonsDefaultValue));
-        prefRightDirectionButtons = prefs.getString("prefRightDirectionButtons", getApplicationContext().getResources().getString(R.string.prefRightDirectionButtonsDefaultValue));
+        prefLeftDirectionButtons = prefs.getString("prefLeftDirectionButtons", getApplicationContext().getResources().getString(R.string.prefLeftDirectionButtonsDefaultValue)).trim();
+        prefRightDirectionButtons = prefs.getString("prefRightDirectionButtons", getApplicationContext().getResources().getString(R.string.prefRightDirectionButtonsDefaultValue)).trim();
     }
 
     private void setDirectionButtonLabels() {


### PR DESCRIPTION
CHANGE - long press on either direction button now swaps direction but not the direction.
CHANGE - user editable text for the direction keys
BUG - Button Press Style still not correct

I can't figure this out.  The styling appears to be correct when I debug it, but not when I run it normally.

 When I watch it in the debugger...
 On a direction button press the showDirectionRequest() function is called directly which changes the button style (pressed + italic).
 Then the Throttle receives two messages. The first message is the reverse to the direction of whatever you touched (Forward if you clicked Reverse, and vice versa).
 The second message is the same as whatever you touched.  So it sets the button to pressed, then not presssed, then pressed.

 If it is done slowly in the debugger it seems to be ok, but not if you let it run normally.  The italisising seems to work in most but not all cases.

 I don't understand where the extra (wrong) message comes from.