### PR TITLE
NEW - Gamepad testing screen added

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -118,5 +118,12 @@
             android:launchMode="singleTask" 
             android:label="LogViewerActivity" >
         </activity>
+        <activity
+            android:name=".gamepad_test"
+            android:alwaysRetainTaskState="true"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing"
+            android:label="@string/app_name_gamepad_test" >
+        </activity>
     </application>
 </manifest>

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -15,7 +15,9 @@
     <li>Improved the rounding error on scale speed calculations (The throttle will zero more reliably)</li>
     <li>Optional alternate labels for the throttle direction buttons</li>
     <li>Optional long press on the direction buttons to swap them</li>
-    <li>prevent some crashes reported to Play Store</li>
+    <li>Prevent some crashes reported to Play Store</li>
+    <li>Enable screen dimming option on older version of Android.  Dimming level minimum of 1.</li>
+    <li>Rudimentary gamepad testing screen added</li>
 </ul>
 </p>
 <br/><em><a

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -18,6 +18,7 @@
     <li>Prevent some crashes reported to Play Store</li>
     <li>Enable screen dimming option on older version of Android.  Dimming level minimum of 1.</li>
     <li>Rudimentary gamepad testing screen added</li>
+    <li>Option to hide BOTH the Speed Slider and the Speed Buttons</li>
 </ul>
 </p>
 <br/><em><a

--- a/bin/AndroidManifest.xml
+++ b/bin/AndroidManifest.xml
@@ -116,5 +116,12 @@
             android:launchMode="singleTask" 
             android:label="LogViewerActivity" >
         </activity>
+        <activity
+            android:name=".gamepad_test"
+            android:alwaysRetainTaskState="true"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing"
+            android:label="@string/app_name_gamepad_test" >
+        </activity>
     </application>
 </manifest>

--- a/res/layout/gamepad_test.xml
+++ b/res/layout/gamepad_test.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/throttle_screen_wrapper"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:keepScreenOn="true"
+    android:orientation="vertical" >
+        <LinearLayout
+            android:id="@+id/gamepad_test_screen"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/gamepad_test"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:orientation="vertical">
+
+                <RelativeLayout
+                    android:id="@+id/gamepad_test_mode_label_group"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent">
+                    <TextView
+                        android:id="@+id/gamepad_test_mode_label"
+                        style="@style/floating_text_style"
+                        android:textSize="12sp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Gamepad type: " />
+
+                    <TextView
+                        android:id="@+id/gamepad_test_mode"
+                        style="@style/floating_text_style"
+                        android:layout_toRightOf="@id/gamepad_test_mode_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="gamepad type goes here"
+                        android:textSize="15sp" />
+                </RelativeLayout>
+
+                <TableLayout
+                    android:id="@+id/gamepad_dpad"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:paddingLeft="6dp"
+                    android:paddingRight="6dp">
+
+                    <TableRow  android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_dpad_up"
+                            style="?attr/ed_normal_button_style"
+                            android:text="Up" />
+                    </TableRow>
+
+                    <TableRow android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_dpad_left"
+                            style="?attr/ed_normal_button_style"
+                            android:text="Left" />
+
+                        <Button
+                            android:id="@+id/gamepad_test_dpad_right"
+                            style="?attr/ed_normal_button_style"
+                            android:text="Right" />
+                    </TableRow>
+
+                    <TableRow android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_dpad_down"
+                            style="?attr/ed_normal_button_style"
+                            android:text="Down" />
+                    </TableRow>
+
+                </TableLayout>
+
+                <TableLayout
+                    android:id="@+id/gamepad_buttons"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_margin="10dp"
+                    android:paddingLeft="6dp"
+                    android:paddingRight="6dp">
+
+                    <TableRow android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_x"
+                            style="?attr/ed_normal_button_style"
+                            android:text="X" />
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_y"
+                            style="?attr/ed_normal_button_style"
+                            android:text="Y" />
+                    </TableRow>
+
+                    <TableRow android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_a"
+                            style="?attr/ed_normal_button_style"
+                            android:text="A" />
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_b"
+                            style="?attr/ed_normal_button_style"
+                            android:text="B" />
+                    </TableRow>
+                </TableLayout>
+
+                <RelativeLayout
+                    android:id="@+id/gamepad_test_keycode_label_group"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:layout_margin="5dp">
+
+                    <TextView
+                        android:id="@+id/gamepad_test_keycode_label"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="key_code: "
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/gamepad_test_keycode"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toRightOf="@id/gamepad_test_keycode_label"
+                        android:text="keycode goes here"
+                        android:textSize="15sp" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/gamepad_test_keyfunction_label_group"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:layout_margin="5dp">
+
+                    <TextView
+                        android:id="@+id/gamepad_test_keyfunction_label"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="function: "
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/gamepad_test_keyfunction"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toRightOf="@id/gamepad_test_keyfunction_label"
+                        android:text="function goes here"
+                        android:textSize="15sp" />
+                </RelativeLayout>
+
+                <LinearLayout
+                    android:id="@+id/separator"
+                    android:layout_width="fill_parent"
+                    android:layout_height="2dp"
+                    android:background="#888888"
+                    android:orientation="vertical" />
+            </LinearLayout>
+            <TextView
+                android:id="@+id/gamepad_test_help"
+                style="@style/floating_text_style"
+                android:textSize="15sp"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/gamepad_test_help" />
+
+        </LinearLayout>
+</LinearLayout>

--- a/res/layout/gamepad_test.xml
+++ b/res/layout/gamepad_test.xml
@@ -16,27 +16,28 @@
                 android:id="@+id/gamepad_test"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="10dp"
                 android:orientation="vertical">
 
                 <RelativeLayout
                     android:id="@+id/gamepad_test_mode_label_group"
                     android:layout_width="fill_parent"
-                    android:layout_height="fill_parent">
+                    android:layout_height="fill_parent"
+                    android:layout_margin="5dp">
+
                     <TextView
                         android:id="@+id/gamepad_test_mode_label"
                         style="@style/floating_text_style"
-                        android:textSize="12sp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Gamepad type: " />
+                        android:text="@string/gamepadTestModeLabel"
+                        android:textSize="12sp" />
 
                     <TextView
                         android:id="@+id/gamepad_test_mode"
                         style="@style/floating_text_style"
-                        android:layout_toRightOf="@id/gamepad_test_mode_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_toRightOf="@id/gamepad_test_mode_label"
                         android:text="gamepad type goes here"
                         android:textSize="15sp" />
                 </RelativeLayout>
@@ -45,16 +46,18 @@
                     android:id="@+id/gamepad_dpad"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
+                    android:layout_margin="5dp"
                     android:paddingLeft="6dp"
                     android:paddingRight="6dp">
 
-                    <TableRow  android:gravity="center_horizontal">
+                    <TableRow android:gravity="center_horizontal">
 
                         <Button
                             android:id="@+id/gamepad_test_dpad_up"
                             style="?attr/ed_normal_button_style"
-                            android:text="Up" />
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelDpadUp"
+                            android:textSize="14sp" />
                     </TableRow>
 
                     <TableRow android:gravity="center_horizontal">
@@ -62,12 +65,16 @@
                         <Button
                             android:id="@+id/gamepad_test_dpad_left"
                             style="?attr/ed_normal_button_style"
-                            android:text="Left" />
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelDpadLeft"
+                            android:textSize="14sp" />
 
                         <Button
                             android:id="@+id/gamepad_test_dpad_right"
                             style="?attr/ed_normal_button_style"
-                            android:text="Right" />
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelDpadRight"
+                            android:textSize="14sp" />
                     </TableRow>
 
                     <TableRow android:gravity="center_horizontal">
@@ -75,7 +82,9 @@
                         <Button
                             android:id="@+id/gamepad_test_dpad_down"
                             style="?attr/ed_normal_button_style"
-                            android:text="Down" />
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelDpadDown"
+                            android:textSize="14sp" />
                     </TableRow>
 
                 </TableLayout>
@@ -85,7 +94,7 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:layout_margin="10dp"
+                    android:layout_margin="5dp"
                     android:paddingLeft="6dp"
                     android:paddingRight="6dp">
 
@@ -94,12 +103,18 @@
                         <Button
                             android:id="@+id/gamepad_test_button_x"
                             style="?attr/ed_normal_button_style"
-                            android:text="X" />
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonX"
+                            android:textSize="14sp" />
 
                         <Button
                             android:id="@+id/gamepad_test_button_y"
                             style="?attr/ed_normal_button_style"
-                            android:text="Y" />
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonY"
+                            android:textSize="14sp" />
                     </TableRow>
 
                     <TableRow android:gravity="center_horizontal">
@@ -107,12 +122,62 @@
                         <Button
                             android:id="@+id/gamepad_test_button_a"
                             style="?attr/ed_normal_button_style"
-                            android:text="A" />
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonA"
+                            android:textSize="14sp" />
 
                         <Button
                             android:id="@+id/gamepad_test_button_b"
                             style="?attr/ed_normal_button_style"
-                            android:text="B" />
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonB"
+                            android:textSize="14sp" />
+                    </TableRow>
+                </TableLayout>
+
+                <RelativeLayout
+                    android:id="@+id/gamepad_test_optional_group"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:layout_margin="5dp">
+
+                    <TextView
+                        android:id="@+id/gamepad_test_optional_label"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/gamepadTestOptionalLabel"
+                        android:textSize="12sp" />
+                </RelativeLayout>
+
+                <TableLayout
+                    android:id="@+id/gamepad_buttons_extra"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_margin="5dp"
+                    android:paddingLeft="6dp"
+                    android:paddingRight="6dp">
+
+                    <TableRow android:gravity="center_horizontal">
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_start"
+                            style="?attr/ed_normal_button_style"
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonStart"
+                            android:textSize="14sp" />
+
+                        <Button
+                            android:id="@+id/gamepad_test_button_enter"
+                            style="?attr/ed_normal_button_style"
+                            android:layout_width="100dip"
+                            android:layout_height="30dip"
+                            android:text="@string/gamepadTestButtonLabelButtonEnter"
+                            android:textSize="14sp" />
                     </TableRow>
                 </TableLayout>
 
@@ -127,7 +192,7 @@
                         style="@style/floating_text_style"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="key_code: "
+                        android:text="@string/gamepadTestKeycodeLabel"
                         android:textSize="12sp" />
 
                     <TextView
@@ -151,7 +216,7 @@
                         style="@style/floating_text_style"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="function: "
+                        android:text="@string/gamepadTestFunctionLabel"
                         android:textSize="12sp" />
 
                     <TextView
@@ -164,6 +229,30 @@
                         android:textSize="15sp" />
                 </RelativeLayout>
 
+                <RelativeLayout
+                    android:id="@+id/gamepad_test_complete_group"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent"
+                    android:layout_margin="5dp">
+
+                    <TextView
+                        android:id="@+id/gamepad_test_complete_label"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="complete?: "
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/gamepad_test_complete"
+                        style="@style/floating_text_style"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toRightOf="@id/gamepad_test_complete_label"
+                        android:text="test complete or incomplete goes here"
+                        android:textSize="15sp" />
+                </RelativeLayout>
+
                 <LinearLayout
                     android:id="@+id/separator"
                     android:layout_width="fill_parent"
@@ -171,13 +260,15 @@
                     android:background="#888888"
                     android:orientation="vertical" />
             </LinearLayout>
+
             <TextView
                 android:id="@+id/gamepad_test_help"
                 style="@style/floating_text_style"
-                android:textSize="15sp"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/gamepad_test_help" />
+                android:layout_margin="5dp"
+                android:text="@string/gamepad_test_help"
+                android:textSize="15sp" />
 
         </LinearLayout>
 </LinearLayout>

--- a/res/menu/gamepad_test.xml
+++ b/res/menu/gamepad_test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@+id/gamepad_test_mnu" android:title="@string/gamepad_test"></item>
+</menu>

--- a/res/menu/throttle_menu.xml
+++ b/res/menu/throttle_menu.xml
@@ -32,5 +32,5 @@
     <item android:id="@+id/EditLightsConsistT_menu" android:title="Edit Consist Lights Throttle 1" android:visible="false"></item>
     <item android:id="@+id/EditLightsConsistS_menu" android:title="Edit Consist Lights Throttle 2" android:visible="false"></item>
     <item android:id="@+id/EditLightsConsistG_menu" android:title="Edit Consist Lights Throttle 3" android:visible="false"></item>
-    <item android:id="@+id/gamepad_test_mnu" android:title="@string/gamepad_test"></item>
+    <item android:id="@+id/gamepad_test_mnu" android:title="@string/gamepad_test" android:visible="false"></item>
 </menu>

--- a/res/menu/throttle_menu.xml
+++ b/res/menu/throttle_menu.xml
@@ -32,4 +32,5 @@
     <item android:id="@+id/EditLightsConsistT_menu" android:title="Edit Consist Lights Throttle 1" android:visible="false"></item>
     <item android:id="@+id/EditLightsConsistS_menu" android:title="Edit Consist Lights Throttle 2" android:visible="false"></item>
     <item android:id="@+id/EditLightsConsistG_menu" android:title="Edit Consist Lights Throttle 3" android:visible="false"></item>
+    <item android:id="@+id/gamepad_test_mnu" android:title="@string/gamepad_test"></item>
 </menu>

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -30,6 +30,7 @@
     <bool name="prefConnectToFirstServer">false</bool>
     <bool name="prefDisplaySpeedArrows">false</bool>
     <bool name="prefHideSliderDefaultValue">false</bool>
+    <bool name="prefHideSliderAndSpeedButtonsDefaultValue">false</bool>
     <bool name="prefSwipeThroughTurnoutsDefaultValue">true</bool>
     <bool name="prefSwipeThroughRoutesDefaultValue">true</bool>
     <bool name="prefDirChangeWhileMovingDefaultValue">true</bool>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="prefIncreaseSliderHeightSummary">Use a taller slider, or speed buttons, for throttles.</string>
     <string name="prefHideSliderTitle">Hide Speed Slider?</string>
     <string name="prefHideSliderSummary">Do not show speed slider, use speed buttons instead.</string>
+    <string name="prefHideSliderAndSpeedButtonsTitle">Hide Slider AND Speed Buttons?</string>
+    <string name="prefHideSliderAndSpeedButtonsSummary">Do not show either speed slider or speed buttons.\nNote: Overrides the \'Hide Slider\', \'Slider Height\' and \'Display Speed buttons\' options.</string>
     <string name="prefDirChangeWhileMovingTitle">Direction change while moving?</string>
     <string name="prefDirChangeWhileMovingSummary">Allow direction change when moving.</string>
     <string name="prefStopOnDirectionChangeTitle">Stop on direction change?</string>
@@ -419,4 +421,19 @@
     <string name="functionButton30DefultValue">30</string>
     <string name="functionButton31DefultValue">31</string>
 
+    <string name="gamepadTestButtonLabelDpadUp">Up</string>
+    <string name="gamepadTestButtonLabelDpadDown">Down</string>
+    <string name="gamepadTestButtonLabelDpadLeft">Left</string>
+    <string name="gamepadTestButtonLabelDpadRight">Right</string>
+    <string name="gamepadTestButtonLabelButtonX">C | X [iOS]</string>
+    <string name="gamepadTestButtonLabelButtonY">D | Y [Triangle]</string>
+    <string name="gamepadTestButtonLabelButtonA">A [Cross]</string>
+    <string name="gamepadTestButtonLabelButtonB">B [@]</string>
+    <string name="gamepadTestButtonLabelButtonStart">Start | Enter</string>
+    <string name="gamepadTestButtonLabelButtonEnter">Select | Enter</string>
+
+    <string name="gamepadTestOptionalLabel">Optional (may not be on the device)</string>
+    <string name="gamepadTestModeLabel">Gamepad mode/type: </string>
+    <string name="gamepadTestKeycodeLabel">key_code: </string>
+    <string name="gamepadTestFunctionLabel">function: </string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="app_name_select_loco">Engine Driver - Select Loco</string>
     <string name="app_name_ConsistEdit">Engine Driver - Consist Edit</string>
     <string name="app_name_ConsistLightsEdit">Engine Driver - Consist Lights</string>
+    <string name="app_name_gamepad_test">Gamepad Test - Engine Driver</string>
+    <string name="gamepad_test">Gamepad Test</string>
     <string name="notification_title">Engine Driver is running</string>
     <string name="notification_text">Tap to reopen Engine Driver</string>
     <string name="host_ip">Host Name or Address</string>
@@ -176,6 +178,11 @@
     <string name="prefGamePadButtonDownDefaultValue">Decrease Speed</string>
     <string name="prefGamePadButtonLeftDefaultValue">Forward</string>
     <!--    Gamepad button preferences   -->
+
+    <!--    Gamepad test page -->
+    <string name="gamepad_test_help">Move the DPad in all four directions and press the four main buttons to confirm.  Press Back Arrow when done.</string>
+    <!--    Gamepad test page -->
+
 
     <!-- ESU MCII preferences -->
     <string name="prefEsuMc2ThrottleNameDefaultValue">ESU MobileControl II</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -86,6 +86,12 @@
                 android:summary="@string/prefHideSliderSummary"
                 android:title="@string/prefHideSliderTitle" >
             </CheckBoxPreference>
+            <CheckBoxPreference
+                android:defaultValue="@bool/prefHideSliderAndSpeedButtonsDefaultValue"
+                android:key="prefHideSliderAndSpeedButtons"
+                android:summary="@string/prefHideSliderAndSpeedButtonsSummary"
+                android:title="@string/prefHideSliderAndSpeedButtonsTitle" >
+            </CheckBoxPreference>
 
             <CheckBoxPreference
                 android:defaultValue="@bool/prefSwapForwardReverseButtonsDefaultValue"

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -1,0 +1,503 @@
+/*Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package jmri.enginedriver;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.media.AudioManager;
+import android.media.ToneGenerator;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+import android.view.GestureDetector;
+import android.view.GestureDetector.OnGestureListener;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnTouchListener;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.SimpleAdapter;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import eu.esu.mobilecontrol2.sdk.MobileControl2;
+import jmri.enginedriver.Consist.ConLoco;
+
+import static android.view.InputDevice.getDevice;
+import static android.view.KeyEvent.ACTION_DOWN;
+import static android.view.KeyEvent.ACTION_UP;
+import static android.view.KeyEvent.KEYCODE_A;
+import static android.view.KeyEvent.KEYCODE_D;
+import static android.view.KeyEvent.KEYCODE_F;
+import static android.view.KeyEvent.KEYCODE_N;
+import static android.view.KeyEvent.KEYCODE_R;
+import static android.view.KeyEvent.KEYCODE_T;
+import static android.view.KeyEvent.KEYCODE_V;
+import static android.view.KeyEvent.KEYCODE_W;
+import static android.view.KeyEvent.KEYCODE_X;
+
+public class gamepad_test extends Activity implements OnGestureListener {
+
+    private threaded_application mainapp;  // hold pointer to mainapp
+    private Menu CLEMenu;
+
+    private GestureDetector myGesture;
+
+    private SharedPreferences prefs;
+
+    private String whichGamePadMode = "None";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_ALL_STOP = "All Stop";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_STOP = "Stop";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_NEXT_THROTTLE = "Next Throttle";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_FORWARD = "Forward";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_REVERSE = "Reverse";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_FORWARD_REVERSE_TOGGLE = "Forward/Reverse Toggle";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_INCREASE_SPEED = "Increase Speed";
+    private static String PREF_GAMEPAD_BUTTON_OPTION_DECREASE_SPEED = "Decrease Speed";
+
+    // Gamepad Button preferences
+    private String[] prefGamePadButtons = {"Next Throttle","Stop", "Function 00/Light", "Function 01/Bell", "Function 02/Horn",
+            "Increase Speed", "Reverse", "Decrease Speed", "Forward", "All Stop"};
+
+    //                              none     NextThr  Speed+    Speed-      Fwd         Rev       All Stop    F2         F1          F0        Stop
+    private int[] gamePadKeys =     {0,        0,   KEYCODE_W, KEYCODE_X,   KEYCODE_A, KEYCODE_D, KEYCODE_V, KEYCODE_T, KEYCODE_N, KEYCODE_R, KEYCODE_F};
+    private int[] gamePadKeys_Up =  {0,        0,   KEYCODE_W,  KEYCODE_X, KEYCODE_A, KEYCODE_D, KEYCODE_V, KEYCODE_T, KEYCODE_N, KEYCODE_R, KEYCODE_F};
+
+    private ToneGenerator tg;
+
+    private Button bDpadUp; // buttons
+    private Button bDpadDown;
+    private Button bDpadLeft;
+    private Button bDpadRight;
+    private Button bButtonX;
+    private Button bButtonY;
+    private Button bButtonA;
+    private Button bButtonB;
+    private TextView tvGamepadMode;
+    private TextView tvGamepadKeyCode;
+    private TextView tvGamepadKeyFunction;
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        return myGesture.onTouchEvent(event);
+    }
+
+    void GamepadFeedbackSound(boolean invalidAction) {
+        if (invalidAction)
+            tg.startTone(ToneGenerator.TONE_PROP_NACK);
+        else
+            tg.startTone(ToneGenerator.TONE_PROP_BEEP);
+    }
+
+    void GamepadFeedbackSoundStop() {
+        tg.stopTone();
+    }
+
+
+    // setup the appropriate keycodes for the type of gamepad that has been selected in the preferences
+    private void setGamepadKeys() {
+        whichGamePadMode = prefs.getString("prefGamePadType", getApplicationContext().getResources().getString(R.string.prefGamePadTypeDefaultValue));
+
+        // Gamepad button Preferences
+        prefGamePadButtons[0] = prefs.getString("prefGamePadButtonStart", getApplicationContext().getResources().getString(R.string.prefGamePadButtonStartDefaultValue));
+        prefGamePadButtons[9] = prefs.getString("prefGamePadButtonReturn", getApplicationContext().getResources().getString(R.string.prefGamePadButtonReturnDefaultValue));
+        prefGamePadButtons[1] = prefs.getString("prefGamePadButton1", getApplicationContext().getResources().getString(R.string.prefGamePadButton1DefaultValue));
+        prefGamePadButtons[2] = prefs.getString("prefGamePadButton2", getApplicationContext().getResources().getString(R.string.prefGamePadButton2DefaultValue));
+        prefGamePadButtons[3] = prefs.getString("prefGamePadButton3", getApplicationContext().getResources().getString(R.string.prefGamePadButton3DefaultValue));
+        prefGamePadButtons[4] = prefs.getString("prefGamePadButton4", getApplicationContext().getResources().getString(R.string.prefGamePadButton4DefaultValue));
+        // Gamepad DPAD Preferences
+        prefGamePadButtons[5] = prefs.getString("prefGamePadButtonUp", getApplicationContext().getResources().getString(R.string.prefGamePadButtonUpDefaultValue));
+        prefGamePadButtons[6] = prefs.getString("prefGamePadButtonRight", getApplicationContext().getResources().getString(R.string.prefGamePadButtonRightDefaultValue));
+        prefGamePadButtons[7] = prefs.getString("prefGamePadButtonDown", getApplicationContext().getResources().getString(R.string.prefGamePadButtonDownDefaultValue));
+        prefGamePadButtons[8] = prefs.getString("prefGamePadButtonLeft", getApplicationContext().getResources().getString(R.string.prefGamePadButtonLeftDefaultValue));
+
+        if (!whichGamePadMode.equals("None")) {
+            // make sure the Softkeyboard is hidden
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM,
+                    WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
+        }
+
+        int[] bGamePadKeys;
+        int[] bGamePadKeysUp;
+
+        switch (whichGamePadMode) {
+            case "iCade+DPAD":
+            case "iCade+DPAD-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadiCadePlusDpad);
+                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadiCadePlusDpad_UpCodes);
+                break;
+            case "MTK":
+            case "MTK-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadMTK);
+                bGamePadKeysUp = bGamePadKeys;
+                break;
+            case "Game":
+            case "Game-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadGame);
+                bGamePadKeysUp = bGamePadKeys;
+                break;
+/*
+            case "VRBoxA":
+            case "VRBoxA-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxA);
+                bGamePadKeysUp = bGamePadKeys;
+                break;
+            case "VRBoxC":
+            case "VRBoxC-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC);
+                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC_UpCodes);
+                break;
+            case "VRBoxiC":
+            case "VRBoxiC-rotate":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC);
+                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC_UpCodes);
+                break;
+*/
+            case "MagicseeR1B":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadMagicseeR1B);
+                bGamePadKeysUp = bGamePadKeys;
+                break;
+            default: // "iCade" or iCade-rotate
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadiCade);
+                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadiCade_UpCodes);
+                break;
+        }
+        // now grab the keycodes and put them into the arrays that will actually be used.
+        for (int i = 0; i<=10; i++ ) {
+            gamePadKeys[i] = bGamePadKeys[i];
+            gamePadKeys_Up[i] = bGamePadKeysUp[i];
+        }
+
+        // if the preference name has "-rotate" at the end of it swap the dpad buttons around
+        if (whichGamePadMode.contains("-rotate")) {
+            gamePadKeys[2] = bGamePadKeys[4];
+            gamePadKeys[3] = bGamePadKeys[5];
+            gamePadKeys[4] = bGamePadKeys[3];
+            gamePadKeys[5] = bGamePadKeys[2];
+
+            gamePadKeys_Up[2] = bGamePadKeysUp[4];
+            gamePadKeys_Up[3] = bGamePadKeysUp[5];
+            gamePadKeys_Up[4] = bGamePadKeysUp[3];
+            gamePadKeys_Up[5] = bGamePadKeysUp[2];
+        }
+    }
+
+    private void setButtonOn(Button btn, String fn, int keyCode) {
+        btn.setClickable(true);
+        btn.setSelected(true);
+
+        tvGamepadKeyCode.setText(String.valueOf(keyCode));
+        tvGamepadKeyFunction.setText(fn);
+
+    }
+
+    // listener for the joystick events
+    @Override
+    public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
+        //Log.d("Engine_Driver", "dgme " + event.getAction());
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB_MR1) {
+            if (!whichGamePadMode.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
+                int action;
+
+                float xAxis = 0;
+                xAxis = event.getAxisValue(MotionEvent.AXIS_X);
+                float yAxis = event.getAxisValue(MotionEvent.AXIS_Y);
+
+                if ((xAxis!=0) || (yAxis!=0)) {
+                    action = ACTION_DOWN;
+                } else {
+                    action = ACTION_UP;
+                }
+
+                if (action == ACTION_UP) {
+                    GamepadFeedbackSoundStop();
+                }
+
+                if (yAxis == -1) { // DPAD Up Button
+                    setButtonOn(bDpadUp, prefGamePadButtons[5],0);
+                    return (true); // stop processing this key
+
+                } else if (yAxis == 1) { // DPAD Down Button
+                    setButtonOn(bDpadDown, prefGamePadButtons[7],0);
+                    return (true); // stop processing this key
+
+                } else if (xAxis == -1) { // DPAD Left Button
+                    setButtonOn(bDpadLeft, prefGamePadButtons[8],0);
+                    return (true); // stop processing this key
+
+                } else if (xAxis == 1) { // DPAD Right Button
+                    setButtonOn(bDpadRight, prefGamePadButtons[6],0);
+                    return (true); // stop processing this key
+                }
+            }
+        }
+        return super.dispatchGenericMotionEvent(event);
+    }
+
+    // listener for physical keyboard events
+    // used to support the gamepad only   DPAD and key events
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+
+        boolean isExternal = false;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+            InputDevice idev = getDevice(event.getDeviceId());
+            if( idev.toString().contains("Location: external")) isExternal = true;
+        }
+
+        if (isExternal) { // if has come from the phone itself, don't try to process it here
+            if (!whichGamePadMode.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
+
+                int action = event.getAction();
+                int keyCode = event.getKeyCode();
+                int repeatCnt = event.getRepeatCount();
+
+                if (keyCode != 0) {
+                    Log.d("Engine_Driver", "keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
+                }
+
+                if (action == ACTION_UP) {
+                    GamepadFeedbackSoundStop();
+                }
+
+                if (keyCode == gamePadKeys[2]) { // DPAD Up Button
+                    setButtonOn(bDpadUp, prefGamePadButtons[5], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
+                    setButtonOn(bDpadDown, prefGamePadButtons[7], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
+                    setButtonOn(bDpadLeft, prefGamePadButtons[8], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
+                    setButtonOn(bDpadRight, prefGamePadButtons[6], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[7]) { // ios button
+                    setButtonOn(bButtonX, prefGamePadButtons[1], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys_Up[8]) { // X button
+                    setButtonOn(bButtonY, prefGamePadButtons[3], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
+                    setButtonOn(bButtonA, prefGamePadButtons[2], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys_Up[10]) { // @ button
+                    setButtonOn(bButtonB, prefGamePadButtons[4], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[6]) { // start button
+                    //setButtonOn(bButtonB, prefGamePadButtons[0], keyCode);
+                    return (true); // stop processing this key
+
+                } else if (keyCode == gamePadKeys[1]) { // Return button
+                    //setButtonOn(bButtonB, prefGamePadButtons[9], keyCode);
+                    return (true); // stop processing this key
+                }
+            }
+        }
+
+        return super.dispatchKeyEvent(event);
+    }
+
+
+    /**
+     * Called when the activity is first created.
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mainapp = (threaded_application) getApplication();
+        if (mainapp.isForcingFinish()) {     // expedite
+            return;
+        }
+
+        mainapp.applyTheme(this);
+
+        setContentView(R.layout.gamepad_test);
+        //put pointer to this activity's handler in main app's shared variable
+        myGesture = new GestureDetector(this);
+
+        mainapp = (threaded_application) this.getApplication();
+        prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
+
+        // tone generator for feedback sounds
+        tg = new ToneGenerator(AudioManager.STREAM_NOTIFICATION,
+                preferences.getIntPrefValue(prefs,"prefGamePadFeedbackVolume", getApplicationContext().getResources().getString(R.string.prefGamePadFeedbackVolumeDefaultValue)));
+
+        setGamepadKeys();
+
+        // set listener for select loco buttons
+        bDpadUp = (Button) findViewById(R.id.gamepad_test_dpad_up);
+        bDpadUp.setClickable(false);
+
+        bDpadDown = (Button) findViewById(R.id.gamepad_test_dpad_down);
+        bDpadDown.setClickable(false);
+
+        bDpadLeft = (Button) findViewById(R.id.gamepad_test_dpad_left);
+        bDpadLeft.setClickable(false);
+
+        bDpadRight = (Button) findViewById(R.id.gamepad_test_dpad_right);
+        bDpadRight.setClickable(false);
+
+        bButtonX = (Button) findViewById(R.id.gamepad_test_button_x);
+        bButtonX.setClickable(false);
+
+        bButtonY = (Button) findViewById(R.id.gamepad_test_button_y);
+        bButtonY.setClickable(false);
+
+        bButtonA = (Button) findViewById(R.id.gamepad_test_button_a);
+        bButtonA.setClickable(false);
+
+        bButtonB = (Button) findViewById(R.id.gamepad_test_button_b);
+        bButtonB.setClickable(false);
+
+        tvGamepadMode =(TextView) findViewById(R.id.gamepad_test_mode);
+
+        tvGamepadKeyCode =(TextView) findViewById(R.id.gamepad_test_keycode);
+        tvGamepadKeyFunction =(TextView) findViewById(R.id.gamepad_test_keyfunction);
+
+        tvGamepadMode.setText(whichGamePadMode);
+
+//        tvGamepadMode.setText("");
+        tvGamepadKeyCode.setText("");
+        tvGamepadKeyFunction.setText("");
+
+
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mainapp.removeNotification();
+       mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
+        if (CLEMenu != null) {
+            mainapp.displayEStop(CLEMenu);
+        }
+        // suppress popup keyboard until EditText is touched
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (!this.isFinishing()) {       //only invoke setContentIntentNotification when going into background
+            mainapp.addNotification(this.getIntent());
+        }
+    }
+
+    /**
+     * Called when the activity is finished.
+     */
+    @Override
+    public void onDestroy() {
+        Log.d("Engine_Driver", "ConsistLightsEdit.onDestroy()");
+
+        //mainapp.consist_lights_edit_msg_handler = null;
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.gamepad_test, menu);
+        CLEMenu = menu;
+        //mainapp.displayEStop(menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle all of the possible menu actions.
+        switch (item.getItemId()) {
+            case R.id.EmerStop:
+                mainapp.sendEStopMsg();
+                break;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    //Always go to throttle if back button pressed
+    @Override
+    public boolean onKeyDown(int key, KeyEvent event) {
+        if (key == KeyEvent.KEYCODE_BACK) {
+            Intent resultIntent = new Intent();
+//            resultIntent.putExtra("whichThrottle", whichThrottle);  //pass whichThrottle as an extra
+//            setResult(result, resultIntent);
+            this.finish();  //end this activity
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        }
+        return (super.onKeyDown(key, event));
+    }
+
+    @Override
+    public boolean onDown(MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+        return false;
+    }
+
+    @Override
+    public void onLongPress(MotionEvent e) {
+    }
+
+    @Override
+    public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
+        return false;
+    }
+
+    @Override
+    public void onShowPress(MotionEvent e) {
+    }
+
+    @Override
+    public boolean onSingleTapUp(MotionEvent e) {
+        return false;
+    }
+
+    private void disconnect() {
+        this.finish();
+    }
+}

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Typeface;
 import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.os.Bundle;
@@ -77,14 +78,8 @@ public class gamepad_test extends Activity implements OnGestureListener {
     private SharedPreferences prefs;
 
     private String whichGamePadMode = "None";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_ALL_STOP = "All Stop";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_STOP = "Stop";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_NEXT_THROTTLE = "Next Throttle";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_FORWARD = "Forward";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_REVERSE = "Reverse";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_FORWARD_REVERSE_TOGGLE = "Forward/Reverse Toggle";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_INCREASE_SPEED = "Increase Speed";
-    private static String PREF_GAMEPAD_BUTTON_OPTION_DECREASE_SPEED = "Decrease Speed";
+
+    private boolean[] gamepadButtonsChecked = {false,false,false,false,false,false,false,false,false,false};
 
     // Gamepad Button preferences
     private String[] prefGamePadButtons = {"Next Throttle","Stop", "Function 00/Light", "Function 01/Bell", "Function 02/Horn",
@@ -104,9 +99,12 @@ public class gamepad_test extends Activity implements OnGestureListener {
     private Button bButtonY;
     private Button bButtonA;
     private Button bButtonB;
+    private Button bButtonStart;
+    private Button bButtonEnter;
     private TextView tvGamepadMode;
     private TextView tvGamepadKeyCode;
     private TextView tvGamepadKeyFunction;
+    private TextView tvGamepadComplete;
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
@@ -167,23 +165,6 @@ public class gamepad_test extends Activity implements OnGestureListener {
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadGame);
                 bGamePadKeysUp = bGamePadKeys;
                 break;
-/*
-            case "VRBoxA":
-            case "VRBoxA-rotate":
-                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxA);
-                bGamePadKeysUp = bGamePadKeys;
-                break;
-            case "VRBoxC":
-            case "VRBoxC-rotate":
-                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC);
-                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC_UpCodes);
-                break;
-            case "VRBoxiC":
-            case "VRBoxiC-rotate":
-                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC);
-                bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadVRBoxiC_UpCodes);
-                break;
-*/
             case "MagicseeR1B":
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadMagicseeR1B);
                 bGamePadKeysUp = bGamePadKeys;
@@ -213,13 +194,32 @@ public class gamepad_test extends Activity implements OnGestureListener {
         }
     }
 
-    private void setButtonOn(Button btn, String fn, int keyCode) {
+    private boolean isTestComplete(int keyIndex) {
+        gamepadButtonsChecked[keyIndex] = true;
+
+        boolean testComplete = true;
+        for (int i = 1; i<=8; i++ ) {
+            if (!gamepadButtonsChecked[i])
+                testComplete = false;
+        }
+
+        if (testComplete) {
+            tvGamepadComplete.setText("Test Complete");
+        }
+		return testComplete;
+}
+    private void setButtonOn(Button btn, String fn, String keyCodeString) {
         btn.setClickable(true);
         btn.setSelected(true);
+        btn.setTypeface(null, Typeface.ITALIC);
 
-        tvGamepadKeyCode.setText(String.valueOf(keyCode));
+        tvGamepadKeyCode.setText(String.valueOf(keyCodeString));
         tvGamepadKeyFunction.setText(fn);
+    }
 
+    private void invalidKeyCode(int keyCode) {
+        tvGamepadKeyCode.setText(String.valueOf(keyCode));
+        tvGamepadKeyFunction.setText("Invalid Keycode for this mode");
     }
 
     // listener for the joystick events
@@ -245,23 +245,28 @@ public class gamepad_test extends Activity implements OnGestureListener {
                 }
 
                 if (yAxis == -1) { // DPAD Up Button
-                    setButtonOn(bDpadUp, prefGamePadButtons[5],0);
+                    setButtonOn(bDpadUp, prefGamePadButtons[5],"DPad Up");
+                    isTestComplete(5);
                     return (true); // stop processing this key
 
                 } else if (yAxis == 1) { // DPAD Down Button
-                    setButtonOn(bDpadDown, prefGamePadButtons[7],0);
+                    setButtonOn(bDpadDown, prefGamePadButtons[7],"DPad Down");
+                    isTestComplete(7);
                     return (true); // stop processing this key
 
                 } else if (xAxis == -1) { // DPAD Left Button
-                    setButtonOn(bDpadLeft, prefGamePadButtons[8],0);
+                    setButtonOn(bDpadLeft, prefGamePadButtons[8],"DPad Left");
+                    isTestComplete(8);
                     return (true); // stop processing this key
 
                 } else if (xAxis == 1) { // DPAD Right Button
-                    setButtonOn(bDpadRight, prefGamePadButtons[6],0);
+                    setButtonOn(bDpadRight, prefGamePadButtons[6],"DPad Right");
+                    isTestComplete(6);
                     return (true); // stop processing this key
                 }
             }
         }
+
         return super.dispatchGenericMotionEvent(event);
     }
 
@@ -292,43 +297,53 @@ public class gamepad_test extends Activity implements OnGestureListener {
                 }
 
                 if (keyCode == gamePadKeys[2]) { // DPAD Up Button
-                    setButtonOn(bDpadUp, prefGamePadButtons[5], keyCode);
+                    setButtonOn(bDpadUp, prefGamePadButtons[5], String.valueOf(keyCode));
+                    isTestComplete(5);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
-                    setButtonOn(bDpadDown, prefGamePadButtons[7], keyCode);
+                    setButtonOn(bDpadDown, prefGamePadButtons[7], String.valueOf(keyCode));
+                    isTestComplete(7);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
-                    setButtonOn(bDpadLeft, prefGamePadButtons[8], keyCode);
+                    setButtonOn(bDpadLeft, prefGamePadButtons[8], String.valueOf(keyCode));
+                    isTestComplete(8);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
-                    setButtonOn(bDpadRight, prefGamePadButtons[6], keyCode);
+                    setButtonOn(bDpadRight, prefGamePadButtons[6], String.valueOf(keyCode));
+                    isTestComplete(6);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[7]) { // ios button
-                    setButtonOn(bButtonX, prefGamePadButtons[1], keyCode);
+                    setButtonOn(bButtonX, prefGamePadButtons[1], String.valueOf(keyCode));
+                    isTestComplete(1);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys_Up[8]) { // X button
-                    setButtonOn(bButtonY, prefGamePadButtons[3], keyCode);
+                    setButtonOn(bButtonY, prefGamePadButtons[3], String.valueOf(keyCode));
+                    isTestComplete(3);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
-                    setButtonOn(bButtonA, prefGamePadButtons[2], keyCode);
+                    setButtonOn(bButtonA, prefGamePadButtons[2], String.valueOf(keyCode));
+                    isTestComplete(2);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys_Up[10]) { // @ button
-                    setButtonOn(bButtonB, prefGamePadButtons[4], keyCode);
+                    setButtonOn(bButtonB, prefGamePadButtons[4], String.valueOf(keyCode));
+                    isTestComplete(4);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[6]) { // start button
-                    //setButtonOn(bButtonB, prefGamePadButtons[0], keyCode);
+                    setButtonOn(bButtonStart, prefGamePadButtons[0], String.valueOf(keyCode));
+                    isTestComplete(0);
                     return (true); // stop processing this key
 
                 } else if (keyCode == gamePadKeys[1]) { // Return button
-                    //setButtonOn(bButtonB, prefGamePadButtons[9], keyCode);
+                    setButtonOn(bButtonEnter, prefGamePadButtons[9], String.valueOf(keyCode));
+                    isTestComplete(9);
                     return (true); // stop processing this key
                 }
             }
@@ -390,18 +405,24 @@ public class gamepad_test extends Activity implements OnGestureListener {
         bButtonB = (Button) findViewById(R.id.gamepad_test_button_b);
         bButtonB.setClickable(false);
 
+        bButtonStart = (Button) findViewById(R.id.gamepad_test_button_start);
+        bButtonStart.setClickable(false);
+
+        bButtonEnter = (Button) findViewById(R.id.gamepad_test_button_enter);
+        bButtonEnter.setClickable(false);
+
         tvGamepadMode =(TextView) findViewById(R.id.gamepad_test_mode);
 
         tvGamepadKeyCode =(TextView) findViewById(R.id.gamepad_test_keycode);
         tvGamepadKeyFunction =(TextView) findViewById(R.id.gamepad_test_keyfunction);
+        tvGamepadComplete =(TextView) findViewById(R.id.gamepad_test_complete);
 
         tvGamepadMode.setText(whichGamePadMode);
 
 //        tvGamepadMode.setText("");
         tvGamepadKeyCode.setText("");
         tvGamepadKeyFunction.setText("");
-
-
+        tvGamepadComplete.setText("Test Incomplete");
     }
 
     @Override
@@ -460,8 +481,6 @@ public class gamepad_test extends Activity implements OnGestureListener {
     public boolean onKeyDown(int key, KeyEvent event) {
         if (key == KeyEvent.KEYCODE_BACK) {
             Intent resultIntent = new Intent();
-//            resultIntent.putExtra("whichThrottle", whichThrottle);  //pass whichThrottle as an extra
-//            setResult(result, resultIntent);
             this.finish();  //end this activity
             connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             return true;

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -230,7 +230,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                 limitIntPrefValue(sharedPreferences, key, 1, 99, "4");
                 break;
             case "prefScreenBrightnessDim":
-                limitIntPrefValue(sharedPreferences, key, 0, 100, "5");
+                limitIntPrefValue(sharedPreferences, key, 1, 100, "5");
                 break;
             case "WebViewLocation":
                 mainapp.alert_activities(message_type.WEBVIEW_LOC, "");

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -2193,6 +2193,26 @@ public class threaded_application extends Application {
     }
 
     /**
+     * for menu passed in, hide or show the gamepad test menu
+     *
+     * @param menu - menu object that will be adjusted
+     */
+    public void setGamepadTestMenuOption(Menu menu) {
+        String whichGamePadMode = prefs.getString("prefGamePadType", getApplicationContext().getResources().getString(R.string.prefGamePadTypeDefaultValue));
+
+        if (menu != null) {
+            MenuItem item = menu.findItem(R.id.gamepad_test_mnu);
+            if (item != null) {
+                if (!whichGamePadMode .equals("None")) {
+                    item.setVisible(true);
+                } else {
+                    item.setVisible(false);
+                }
+            }
+        }
+    }
+
+    /**
      * for menu passed in, hide or show the routes menu
      *
      * @param menu - menu object that will be adjusted

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -3977,6 +3977,11 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             bRSpdG.setVisibility(View.GONE);
             sliderMargin += 30;  //a little extra margin previously in button
         }
+        if (prefs.getBoolean("prefHideSliderAndSpeedButtons", getResources().getBoolean(R.bool.prefHideSliderAndSpeedButtonsDefaultValue))) {
+            llTSetSpd.setVisibility(View.GONE);
+            llSSetSpd.setVisibility(View.GONE);
+            llGSetSpd.setVisibility(View.GONE);
+        }
 
         sbS.setPadding(sliderMargin, 0, sliderMargin, 0);
         sbG.setPadding(sliderMargin, 0, sliderMargin, 0);
@@ -4086,6 +4091,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             mainapp.setWebMenuOption(TMenu);
             mainapp.setRoutesMenuOption(TMenu);
             mainapp.setTurnoutsMenuOption(TMenu);
+            mainapp.setGamepadTestMenuOption(TMenu);
         }
         vThrotScrWrap.invalidate();
         // Log.d("Engine_Driver","ending set_labels");

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -1799,6 +1799,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
     }
 
+/*
     private boolean isInvalidGamePadKey(int key, int action) {
         boolean isOk = true;
 
@@ -1853,6 +1854,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
         return isOk;
     }
+*/
+
     //
     private int swapToNextAvilableThrottleForGamePad(int fromThrottle, boolean quiet) {
         int whichThrottle = -1;
@@ -4289,6 +4292,12 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 consistLightsEdit3.putExtra("whichThrottle", 'G');
                 navigatingAway = true;
                 startActivityForResult(consistLightsEdit3, ACTIVITY_CONSIST_LIGHTS);
+                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+                break;
+            case R.id.gamepad_test_mnu:
+                in = new Intent().setClass(this, gamepad_test.class);
+                navigatingAway = true;
+                startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
         }


### PR DESCRIPTION
FIX - Swipe up Screen dimming for older Android.  Mimimum level set to 1

Gamepad testing screen is availble from the Throttle Screen menu for now, but will be moved later.