### PR TITLE
 avoid NPEs, update to -test7

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jmri.enginedriver"
     android:versionCode="42"
-    android:versionName="2.17-test6" android:installLocation="auto">
+    android:versionName="2.17-test7" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -461,13 +461,15 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
             prefs.edit().putString("prefGamePadType", gamePadModesArray[whichGamePadModeIndex]).commit();  //reset the preference
 
-        if (oldWhichGamePadModeIndex != whichGamePadModeIndex) {
-            setGamepadKeys();
-            oldWhichGamePadModeIndex = whichGamePadModeIndex;
-        }
+            if (oldWhichGamePadModeIndex != whichGamePadModeIndex) {
+                setGamepadKeys();
+                oldWhichGamePadModeIndex = whichGamePadModeIndex;
+            }
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
+            if ((imm != null) && (view != null)) {
+                imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
+            }
         }
 
         @Override
@@ -584,7 +586,7 @@ public class gamepad_test extends Activity implements OnGestureListener {
      */
     @Override
     public void onDestroy() {
-        Log.d("Engine_Driver", "ConsistLightsEdit.onDestroy()");
+        Log.d("Engine_Driver", "gamepad_test.onDestroy()");
 
         //mainapp.consist_lights_edit_msg_handler = null;
         super.onDestroy();

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -2345,10 +2345,13 @@ public class threaded_application extends Application {
     }
 
     public void displayEStop(Menu menu) {
+        MenuItem mi = menu.findItem(R.id.EmerStop);
+        if (mi == null) return;
+
         if (prefs.getBoolean("show_emergency_stop_menu_preference", false)) {
-            menu.findItem(R.id.EmerStop).setVisible(true);
+            mi.setVisible(true);
         } else {
-            menu.findItem(R.id.EmerStop).setVisible(false);
+            mi.setVisible(false);
         }
 
     }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4526,12 +4526,14 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             }
             case ACTIVITY_GAMEPAD_TEST: {
                 //if (resultCode == gamepad_test.RESULT_OK) {
+                if (data != null) {
                     String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
                     if (whichGamepadNo != null) {
-                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0,1));
-                        int result = Integer.valueOf(whichGamepadNo.substring(1,2));
+                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0, 1));
+                        int result = Integer.valueOf(whichGamepadNo.substring(1, 2));
                         gamePadDeviceIdsTested[gamepadNo] = result;
                     }
+                }
                 //}
                 break;
             }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4526,16 +4526,16 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             }
             case ACTIVITY_GAMEPAD_TEST: {
                 //if (resultCode == gamepad_test.RESULT_OK) {
-                    if (data != null) {
-                        String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
-                        if (whichGamepadNo != null) {
-                            int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0, 1));
-                            int result = Integer.valueOf(whichGamepadNo.substring(1, 2));
-                            gamePadDeviceIdsTested[gamepadNo] = result;
-                        }
-                    } else {
-                        Log.e("Engine_Driver", "OnActivityResult(ACTIVITY_GAMEPAD_TEST) called with null data!");
+                if (data != null) {
+                    String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
+                    if (whichGamepadNo != null) {
+                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0, 1));
+                        int result = Integer.valueOf(whichGamepadNo.substring(1, 2));
+                        gamePadDeviceIdsTested[gamepadNo] = result;
                     }
+                } else {
+                    Log.e("Engine_Driver", "OnActivityResult(ACTIVITY_GAMEPAD_TEST) called with null data!");
+                }
                 //}
                 break;
             }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4526,14 +4526,16 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             }
             case ACTIVITY_GAMEPAD_TEST: {
                 //if (resultCode == gamepad_test.RESULT_OK) {
-                if (data != null) {
-                    String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
-                    if (whichGamepadNo != null) {
-                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0,1));
-                        int result = Integer.valueOf(whichGamepadNo.substring(1,2));
-                        gamePadDeviceIdsTested[gamepadNo] = result;
+                    if (data != null) {
+                        String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
+                        if (whichGamepadNo != null) {
+                            int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0, 1));
+                            int result = Integer.valueOf(whichGamepadNo.substring(1, 2));
+                            gamePadDeviceIdsTested[gamepadNo] = result;
+                        }
+                    } else {
+                        Log.e("Engine_Driver", "OnActivityResult(ACTIVITY_GAMEPAD_TEST) called with null data!");
                     }
-                }
                 //}
                 break;
             }

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4529,8 +4529,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 if (data != null) {
                     String whichGamepadNo = data.getExtras().getString("whichGamepadNo");
                     if (whichGamepadNo != null) {
-                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0, 1));
-                        int result = Integer.valueOf(whichGamepadNo.substring(1, 2));
+                        int gamepadNo = Integer.valueOf(whichGamepadNo.substring(0,1));
+                        int result = Integer.valueOf(whichGamepadNo.substring(1,2));
                         gamePadDeviceIdsTested[gamepadNo] = result;
                     }
                 }


### PR DESCRIPTION
@flash62au the change in throttle.java prevents a crash on my 4.4.4 device, where data is null. This results in the test results not being recorded, and therefore testing keeps repeating, until I turn off "Enforce Gamepad Testing". I could not determine WHY data was null, data is not null when called for the ACTIVITY_SELECT_LOCO just above it.
Any idea what I'm missing regarding this?