### PR TITLE
UPDATE - Gamepad Test page

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -121,7 +121,6 @@
         <activity
             android:name=".gamepad_test"
             android:alwaysRetainTaskState="true"
-            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustNothing"
             android:label="@string/app_name_gamepad_test" >
         </activity>

--- a/bin/AndroidManifest.xml
+++ b/bin/AndroidManifest.xml
@@ -119,7 +119,6 @@
         <activity
             android:name=".gamepad_test"
             android:alwaysRetainTaskState="true"
-            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustNothing"
             android:label="@string/app_name_gamepad_test" >
         </activity>

--- a/res/layout/gamepad_test.xml
+++ b/res/layout/gamepad_test.xml
@@ -3,271 +3,338 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/throttle_screen_wrapper"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_height="match_parent"
     android:keepScreenOn="true"
-    android:orientation="vertical" >
-        <LinearLayout
-            android:id="@+id/gamepad_test_screen"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/gamepad_test_screen"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:visibility="visible">
+
+        <RelativeLayout
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <LinearLayout
-                android:id="@+id/gamepad_test"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <RelativeLayout
-                    android:id="@+id/gamepad_test_mode_label_group"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_margin="5dp">
-
-                    <TextView
-                        android:id="@+id/gamepad_test_mode_label"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gamepadTestModeLabel"
-                        android:textSize="12sp" />
-
-                    <Spinner
-                        android:id="@+id/gamepad_test_mode"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/gamepad_test_mode_label"
-                        />
-                </RelativeLayout>
-
-                <TableLayout
-                    android:id="@+id/gamepad_dpad"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="5dp"
-                    android:paddingLeft="6dp"
-                    android:paddingRight="6dp">
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_dpad_up"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelDpadUp"
-                            android:textSize="14sp" />
-                    </TableRow>
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_dpad_left"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelDpadLeft"
-                            android:textSize="14sp" />
-
-                        <Button
-                            android:id="@+id/gamepad_test_dpad_right"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelDpadRight"
-                            android:textSize="14sp" />
-                    </TableRow>
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_dpad_down"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelDpadDown"
-                            android:textSize="14sp" />
-                    </TableRow>
-
-                </TableLayout>
-
-                <TableLayout
-                    android:id="@+id/gamepad_buttons"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_margin="5dp"
-                    android:paddingLeft="6dp"
-                    android:paddingRight="6dp">
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_a"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonA"
-                            android:textSize="14sp" />
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_b"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonB"
-                            android:textSize="14sp" />
-                    </TableRow>
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_x"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonX"
-                            android:textSize="14sp" />
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_y"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonY"
-                            android:textSize="14sp" />
-                    </TableRow>
-
-                </TableLayout>
-
-                <RelativeLayout
-                    android:id="@+id/gamepad_test_optional_group"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_margin="5dp">
-
-                    <TextView
-                        android:id="@+id/gamepad_test_optional_label"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gamepadTestOptionalLabel"
-                        android:textSize="12sp" />
-                </RelativeLayout>
-
-                <TableLayout
-                    android:id="@+id/gamepad_buttons_extra"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_margin="5dp"
-                    android:paddingLeft="6dp"
-                    android:paddingRight="6dp">
-
-                    <TableRow android:gravity="center_horizontal">
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_start"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonStart"
-                            android:textSize="14sp" />
-
-                        <Button
-                            android:id="@+id/gamepad_test_button_enter"
-                            style="?attr/ed_normal_button_style"
-                            android:layout_width="100dip"
-                            android:layout_height="30dip"
-                            android:text="@string/gamepadTestButtonLabelButtonEnter"
-                            android:textSize="14sp" />
-                    </TableRow>
-                </TableLayout>
-
-                <RelativeLayout
-                    android:id="@+id/gamepad_test_keycode_label_group"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_margin="5dp">
-
-                    <TextView
-                        android:id="@+id/gamepad_test_keycode_label"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gamepadTestKeycodeLabel"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/gamepad_test_keycode"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/gamepad_test_keycode_label"
-                        android:text=""
-                        android:textSize="15sp" />
-                </RelativeLayout>
-
-                <RelativeLayout
-                    android:id="@+id/gamepad_test_keyfunction_label_group"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_margin="5dp">
-
-                    <TextView
-                        android:id="@+id/gamepad_test_keyfunction_label"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gamepadTestFunctionLabel"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/gamepad_test_keyfunction"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/gamepad_test_keyfunction_label"
-                        android:text=""
-                        android:textSize="15sp" />
-                </RelativeLayout>
-
-                <RelativeLayout
-                    android:id="@+id/gamepad_test_complete_group"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_margin="5dp">
-
-                    <TextView
-                        android:id="@+id/gamepad_test_complete_label"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/gamepadTestCompleteLabel"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/gamepad_test_complete"
-                        style="@style/floating_text_style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/gamepad_test_complete_label"
-                        android:text=""
-                        android:textSize="15sp" />
-                </RelativeLayout>
-
-                <LinearLayout
-                    android:id="@+id/separator"
-                    android:layout_width="fill_parent"
-                    android:layout_height="2dp"
-                    android:background="#888888"
-                    android:orientation="vertical" />
-            </LinearLayout>
+            android:layout_height="0dp"
+            android:layout_margin="5dp"
+            android:layout_weight=".9">
 
             <TextView
-                android:id="@+id/gamepad_test_help"
+                android:id="@+id/gamepad_test_mode_label"
                 style="@style/floating_text_style"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_margin="5dp"
-                android:text="@string/gamepadTestHelp"
-                android:textSize="15sp" />
+                android:text="@string/gamepadTestModeLabel"
+                android:textSize="11sp" />
+
+            <Spinner
+                android:id="@+id/gamepad_test_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_toEndOf="@+id/gamepad_test_mode_label"
+                android:layout_toRightOf="@+id/gamepad_test_mode_label" />
+        </RelativeLayout>
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_weight="8.2"
+            android:orientation="vertical">
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:id="@+id/gamepad_test"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TableLayout
+                            android:id="@+id/gamepad_dpad"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="3dp"
+                            android:paddingLeft="6dp"
+                            android:paddingRight="6dp">
+
+                            <TableRow android:gravity="center_horizontal">
+
+                                <LinearLayout
+                                    android:id="@+id/gamepad_dpad_left_cell"
+                                    android:layout_width="fill_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical">
+
+                                    <Button
+                                        android:id="@+id/gamepad_test_dpad_left"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_height="25dip"
+                                        android:text="@string/gamepadTestButtonLabelDpadLeft"
+                                        android:textSize="12sp" />
+                                </LinearLayout>
+
+                                <LinearLayout
+                                    android:id="@+id/gamepad_dpad_center_cell"
+                                    android:layout_width="fill_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:orientation="vertical"
+                                    android:weightSum="2">
+
+                                    <Button
+                                        android:id="@+id/gamepad_test_dpad_up"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_height="25dip"
+                                        android:layout_weight="1"
+                                        android:text="@string/gamepadTestButtonLabelDpadUp"
+                                        android:textSize="12sp" />
+
+                                    <Button
+                                        android:id="@+id/gamepad_test_dpad_down"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_height="25dip"
+                                        android:layout_weight="1"
+                                        android:text="@string/gamepadTestButtonLabelDpadDown"
+                                        android:textSize="12sp" />
+                                </LinearLayout>
+
+                                <LinearLayout
+                                    android:id="@+id/gamepad_dpad_right_cell"
+                                    android:layout_width="fill_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical">
+
+                                    <Button
+                                        android:id="@+id/gamepad_test_dpad_right"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_height="25dip"
+                                        android:text="@string/gamepadTestButtonLabelDpadRight"
+                                        android:textSize="12sp" />
+                                </LinearLayout>
+
+                            </TableRow>
+
+                        </TableLayout>
+
+                        <TableLayout
+                            android:id="@+id/gamepad_buttons"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_margin="3dp"
+                            android:paddingLeft="6dp"
+                            android:paddingRight="6dp">
+
+                            <TableRow android:gravity="center_horizontal">
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_a"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonA"
+                                    android:textSize="12sp" />
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_b"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonB"
+                                    android:textSize="12sp" />
+                            </TableRow>
+
+                            <TableRow android:gravity="center_horizontal">
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_x"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonX"
+                                    android:textSize="12sp" />
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_y"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonY"
+                                    android:textSize="12sp" />
+                            </TableRow>
+
+                        </TableLayout>
+
+                        <RelativeLayout
+                            android:id="@+id/gamepad_test_optional_group"
+                            android:layout_width="fill_parent"
+                            android:layout_height="fill_parent"
+                            android:layout_margin="3dp">
+
+                            <TextView
+                                android:id="@+id/gamepad_test_optional_label"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/gamepadTestOptionalLabel"
+                                android:textSize="12sp" />
+                        </RelativeLayout>
+
+                        <TableLayout
+                            android:id="@+id/gamepad_buttons_extra"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_margin="3dp"
+                            android:paddingLeft="6dp"
+                            android:paddingRight="6dp">
+
+                            <TableRow android:gravity="center_horizontal">
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_start"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonStart"
+                                    android:textSize="12sp" />
+
+                                <Button
+                                    android:id="@+id/gamepad_test_button_enter"
+                                    style="?attr/ed_normal_button_style"
+                                    android:layout_width="100dip"
+                                    android:layout_height="25dip"
+                                    android:text="@string/gamepadTestButtonLabelButtonEnter"
+                                    android:textSize="12sp" />
+                            </TableRow>
+                        </TableLayout>
+
+                        <LinearLayout
+                            android:id="@+id/gamepad_test_keys"
+                            android:layout_width="fill_parent"
+                            android:layout_height="25dip"
+                            android:orientation="horizontal">
+
+                            <TextView
+                                android:id="@+id/gamepad_test_keycode_label"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1.5"
+                                android:text="@string/gamepadTestKeycodeLabel"
+                                android:textSize="12sp" />
+
+                            <TextView
+                                android:id="@+id/gamepad_test_keycode"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_toRightOf="@id/gamepad_test_keycode_label"
+                                android:layout_weight="3.5"
+                                android:text=""
+                                android:textSize="12sp" />
+
+                            <TextView
+                                android:id="@+id/gamepad_test_keyfunction_label"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1.5"
+                                android:text="@string/gamepadTestFunctionLabel"
+                                android:textSize="12sp" />
+
+                            <TextView
+                                android:id="@+id/gamepad_test_keyfunction"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_toRightOf="@id/gamepad_test_keyfunction_label"
+                                android:layout_weight="3.5"
+                                android:text=""
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
+                        <RelativeLayout
+                            android:id="@+id/gamepad_test_complete_group"
+                            android:layout_width="fill_parent"
+                            android:layout_height="fill_parent"
+                            android:layout_margin="3dp">
+
+                            <TextView
+                                android:id="@+id/gamepad_test_complete_label"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/gamepadTestCompleteLabel"
+                                android:textSize="12sp" />
+
+                            <TextView
+                                android:id="@+id/gamepad_test_complete"
+                                style="@style/floating_text_style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_toRightOf="@id/gamepad_test_complete_label"
+                                android:text=""
+                                android:textSize="15sp" />
+                        </RelativeLayout>
+
+                        <LinearLayout
+                            android:id="@+id/separator"
+                            android:layout_width="fill_parent"
+                            android:layout_height="2dp"
+                            android:background="#888888"
+                            android:orientation="vertical" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/gamepad_test_help"
+                        style="@style/floating_text_style"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="3dp"
+                        android:text="@string/gamepadTestHelp"
+                        android:textSize="15sp" />
+
+                </LinearLayout>
+
+            </ScrollView>
 
         </LinearLayout>
+
+        <TableLayout
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_margin="3dp"
+            android:layout_weight=".9"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp">
+
+            <TableRow android:gravity="center_horizontal">
+
+                <Button
+                    android:id="@+id/gamepad_test_button_cancel"
+                    style="?attr/ed_normal_button_style"
+                    android:text="@string/gamepadTestCancel" />
+
+                <Button
+                    android:id="@+id/gamepad_test_button_skip"
+                    style="?attr/ed_normal_button_style"
+                    android:text="@string/gamepadTestSkip" />
+            </TableRow>
+
+        </TableLayout>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -456,12 +456,17 @@
     <string name="gamepadTestModeLabel">Type:\s</string>
     <string name="gamepadTestKeycodeLabel">key_code:\s</string>
     <string name="gamepadTestFunctionLabel">function:\s</string>
-    <string name="gamepadTestCompleteLabel">test status: </string>
-    <string name="gamepadTestHelp">To confirm: Press all Dpad buttons AND all four main buttons.\nIf you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\nPressing \'Back\' will exit the test but the Gamepad will not work.</string>
+    <string name="gamepadTestCompleteLabel">test status:\s</string>
+    <string name="gamepadTestHelp">You MUST press all Dpad AND four main buttons.\nIf you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\n\'Back\' or \'Cancel\' will exit the test but the Gamepad will not work.\n\'Skip\' will force the test to pass, even if the gamepad does not work correctly.</string>
+    <string name="gamepadTestHelpNonForced">If you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\nYou may be required to re-test the gamepad from the throttle screen.</string>
     <string name="gamepadTestIncomplete">"Test Incomplete"</string>
     <string name="gamepadTestComplete">"Test Complete"</string>
     <string name="gamepadTestCompleteToast">"Gamepad test completed successfully"</string>
     <string name="gamepadTestInvalidKeycode">"Invalid Keycode for this mode"</string>
+
+    <string name="gamepadTestCancel">"Cancel"</string>
+    <string name="gamepadTestCancelNonForced">"Close"</string>
+    <string name="gamepadTestSkip">"Skip"</string>
     <!--    Gamepad test page -->
 
 </resources>

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -241,10 +241,12 @@ public class gamepad_test extends Activity implements OnGestureListener {
         if (testComplete) {
 
             tvGamepadComplete.setText(R.string.gamepadTestComplete);
-            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.gamepadTestCompleteToast), Toast.LENGTH_SHORT).show();
-            if (result!=RESULT_OK) {
-                result = RESULT_OK;
-                end_this_activity();
+            if (!whichGamepadNo.equals(" ")) {
+                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.gamepadTestCompleteToast), Toast.LENGTH_SHORT).show();
+                if (result != RESULT_OK) {
+                    result = RESULT_OK;
+                    end_this_activity(true);
+                }
             }
         }
 		return testComplete;
@@ -478,6 +480,18 @@ public class gamepad_test extends Activity implements OnGestureListener {
         }
     }
 
+    private class cancel_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            end_this_activity(false);
+        }
+    }
+
+    private class skip_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            end_this_activity(true);
+        }
+    }
+
     /**
      * Called when the activity is first created.
      */
@@ -495,8 +509,9 @@ public class gamepad_test extends Activity implements OnGestureListener {
         Bundle extras = getIntent().getExtras();
         if (extras != null) {
             whichGamepadNo = extras.getString("whichGamepadNo");
-            mainapp.applyTheme(this);
         }
+
+        mainapp.applyTheme(this);
 
         setContentView(R.layout.gamepad_test);
         //put pointer to this activity's handler in main app's shared variable
@@ -559,6 +574,22 @@ public class gamepad_test extends Activity implements OnGestureListener {
         mode_spinner.setOnItemSelectedListener(new spinner_listener());
 
         setGamepadKeys();
+
+        //Set the button
+        Button cancelButton = (Button) findViewById(R.id.gamepad_test_button_cancel);
+        gamepad_test.cancel_button_listener cancel_click_listener = new gamepad_test.cancel_button_listener();
+        cancelButton.setOnClickListener(cancel_click_listener);
+
+        Button skipButton = (Button) findViewById(R.id.gamepad_test_button_skip);
+        if (whichGamepadNo.equals(" ")) {
+            skipButton.setVisibility(View.GONE);
+            cancelButton.setText(R.string.gamepadTestCancelNonForced);
+            TextView tvHelpText = (TextView) findViewById(R.id.gamepad_test_help);
+            tvHelpText.setText(R.string.gamepadTestHelpNonForced);
+        } else {
+            gamepad_test.skip_button_listener skip_click_listener = new gamepad_test.skip_button_listener();
+            skipButton.setOnClickListener(skip_click_listener);
+        }
     }
 
     @Override
@@ -593,9 +624,13 @@ public class gamepad_test extends Activity implements OnGestureListener {
     }
 
     // end current activity
-    void end_this_activity() {
+    void end_this_activity(boolean passedTest) {
         Intent resultIntent = new Intent();
-        resultIntent.putExtra("whichGamepadNo", whichGamepadNo+"1");  //pass whichGamepadNo as an extra - plus "1" for pass
+        if (passedTest) {
+            resultIntent.putExtra("whichGamepadNo", whichGamepadNo + "1");  //pass whichGamepadNo as an extra - plus "1" for pass
+        } else {
+            resultIntent.putExtra("whichGamepadNo", whichGamepadNo+"2");  //pass whichGamepadNo as an extra - plus "2" for fail
+        }
         setResult(result, resultIntent);
         this.finish();
         connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4263,7 +4263,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             mainapp.setWebMenuOption(TMenu);
             mainapp.setRoutesMenuOption(TMenu);
             mainapp.setTurnoutsMenuOption(TMenu);
-            //mainapp.setGamepadTestMenuOption(TMenu);
+            mainapp.setGamepadTestMenuOption(TMenu);
         }
         vThrotScrWrap.invalidate();
         // Log.d("Engine_Driver","ending set_labels");
@@ -4476,14 +4476,14 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 startActivityForResult(consistLightsEdit3, ACTIVITY_CONSIST_LIGHTS);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
-                /*
+
             case R.id.gamepad_test_mnu:
                 in = new Intent().setClass(this, gamepad_test.class);
                 navigatingAway = true;
                 startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
-                */
+
         }
         return super.onOptionsItemSelected(item);
     }


### PR DESCRIPTION
FIX - Gamepad Test page should now work on early version of Android
UPDATE - rearranged the Gamepad Test page so that it is shorter, and the centre section scrolls
UPDATE - Added skip and cancel buttons to the Gamepad Test page
UPDATE - re-added the the Gamepad Test menu option.  Can be invoked from the Throttle page at any time. This does not close automatically when complete. skip option revoved. Different help text. Cancel becomes close.