### PR TITLE
FIX/UPDATE - gamepad test page

### DIFF
--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -258,8 +258,35 @@ public class gamepad_test extends Activity implements OnGestureListener {
             }
         }
 		return testComplete;
-}
+    }
+
+    private void setButtonOff(Button btn) {
+        btn.setClickable(false);
+        btn.setSelected(false);
+        btn.setTypeface(null, Typeface.NORMAL);
+    }
+
+    private void setAllButtonsOff(){
+        setButtonOff(bDpadUp);
+        setButtonOff(bDpadDown);
+        setButtonOff(bDpadLeft);
+        setButtonOff(bDpadRight);
+        setButtonOff(bButtonX);
+        setButtonOff(bButtonY);
+        setButtonOff(bButtonA);
+        setButtonOff(bButtonB);
+        setButtonOff(bButtonStart);
+        setButtonOff(bButtonEnter);
+
+    }
+
+
     private void setButtonOn(Button btn, String fn, String keyCodeString) {
+
+        if (whichGamepadNo.equals(" ")) {
+            setAllButtonsOff();
+        }
+
         btn.setClickable(true);
         btn.setSelected(true);
         btn.setTypeface(null, Typeface.ITALIC);
@@ -622,7 +649,7 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
         Button skipButton = (Button) findViewById(R.id.gamepad_test_button_skip);
         if (whichGamepadNo.equals(" ")) {
-            cancelButton.setVisibility(View.GONE);
+            resetButton.setVisibility(View.GONE);
             skipButton.setVisibility(View.GONE);
             cancelButton.setText(R.string.gamepadTestCancelNonForced);
             TextView tvHelpText = (TextView) findViewById(R.id.gamepad_test_help);


### PR DESCRIPTION
FIX - 'close' button on the preference version of the test page was being hidden (instead of the 'reset' button)
UPDATE - on the preference version of the test page, only the last button pressed is highlighted.