### PR TITLE
Fix issue with MC2 knob position not updating on EStop

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -12,6 +12,7 @@
     <li>prevent some crashes reported to Google Play</li>
     <li>option to hide the example server</li>
     <li>option for the volume keys to foloow the last touched throttle</li>
+    <li>Fix issue with ESU Mobile Control II knob position not updating on EStop</li>
 </ul>
 </p>
 <br/><em><a

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,5 +1,6 @@
 **Version 2.18
  * prevent some crashes reported to Google Play
+ * Fix issue with ESU Mobile Control II knob position not updating on EStop
 **Version 2.17
  * Add support for ESU Mobile Control II throttle
  * Add toast messages when ESU Mobile Control II in stop mode

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -4469,6 +4469,10 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 mainapp.sendEStopMsg();
                 speedUpdate(0);  // update all three throttles
                 applySpeedRelatedOptions();  // update all three throttles
+                if (IS_ESU_MCII) {
+                    Log.d("Engine_Driver", "ESU_MCII: Move knob request for EStop");
+                    setEsuThrottleKnobPosition(whichVolume, 0);
+                }
 
                 break;
             case R.id.power_layout_button:


### PR DESCRIPTION
Noticed that, on Estop, the knob wasn't reflecting the zero state.

This fixes that.