### PR TITLE
Fix active throttle tracking on non-user generated events

### DIFF
--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -3195,6 +3195,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 if (IS_ESU_MCII) {
                     setEsuThrottleKnobPosition(whichThrottle, speed);
                 }
+
+                setActiveThrottle(whichThrottle); // set the throttle the volume keys control depending on the preference
             } else {
                 if (limitedJump) {
                     if (speed >= jumpSpeed) {   // stop when we reach the target
@@ -3209,8 +3211,6 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 applySpeedRelatedOptions(whichThrottle);
             }
             lastSpeed = speed;
-
-            setActiveThrottle(whichThrottle); // set the throttle the volume keys control depending on the preference
         }
 
         @Override


### PR DESCRIPTION
After change brought in by #172 certain scenarios cause tracked throttle to be changed without user interaction.

Example is, after an Estop, the last throttle is selected even if that was not the one being controlled.

This fixes that behaviour whilst still allowing user-generated tracking to switch control.

Tested on ESU MC2