### PR TITLE
CHANGE - Import includes Throttle name

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -13,6 +13,7 @@
     <li>option to hide the demo server</li>
     <li>option for the volume keys to follow the last touched throttle</li>
     <li>Fix issue with ESU Mobile Control II knob position not updating on EStop</li>
+    <li>Import includes throttle name if on the same device that exported them</li>
 </ul>
 </p>
 <br/><em><a

--- a/src/jmri/enginedriver/ImportExportPreferences.java
+++ b/src/jmri/enginedriver/ImportExportPreferences.java
@@ -23,6 +23,7 @@ package jmri.enginedriver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Environment;
+import android.provider.Settings;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -107,7 +108,7 @@ public class ImportExportPreferences {
     }
 
     @SuppressWarnings({ "unchecked" })
-    public boolean loadSharedPreferencesFromFile(Context context, SharedPreferences sharedPreferences, String exportedPreferencesFileName) {
+    public boolean loadSharedPreferencesFromFile(Context context, SharedPreferences sharedPreferences, String exportedPreferencesFileName, String deviceId) {
         currentlyImporting = true;
         boolean res = false;
         boolean srcExists = false;
@@ -150,8 +151,12 @@ public class ImportExportPreferences {
                     res = true;
 
                     res = true;
-                    // restore the remembered throttle name to avoid a duplicate throttle name
-                    sharedPreferences.edit().putString("throttle_name_preference", currentThrottleNameValue).commit();
+
+                    // restore the remembered throttle name to avoid a duplicate throttle name if this is a differnt to device to where it was originally saved
+                    String restoredDeviceId = sharedPreferences.getString("prefAndroidId", "").trim();
+                    if ((!restoredDeviceId.equals(deviceId)) || (restoredDeviceId.equals(""))) {
+                        sharedPreferences.edit().putString("throttle_name_preference", currentThrottleNameValue).commit();
+                    }
                     sharedPreferences.edit().putString("prefImportExport", "None").commit();  //reset the preference
                     sharedPreferences.edit().putString("prefHostImportExport", "None").commit();  //reset the preference
                     sharedPreferences.edit().putString("prefAutoImportExport", prefAutoImportExport).commit();  //reset the preference

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -78,6 +78,8 @@ public class connection_activity extends Activity {
     private int connected_port;
     private boolean navigatingAway = false;        // flag for onPause: set to true when another activity is selected, false if going into background
 
+    private String deviceId = "";
+
     private static final String demo_host = "jmri.mstevetodd.com";
     private static final String demo_port = "44444";
 
@@ -679,11 +681,14 @@ public class connection_activity extends Activity {
        SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
        String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue)).trim();
 
+       deviceId = Settings.System.getString(getContentResolver(), Settings.System.ANDROID_ID);
+       sharedPreferences.edit().putString("prefAndroidId", deviceId).commit();
+
        if ((prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_AND_DISCONNECT))
                || (prefAutoImportExport.equals(AUTO_IMPORT_EXPORT_OPTION_CONNECT_ONLY))) {  // automatically load the host specific preferences, if the preference is set
            if (mainapp.connectedHostName != null) {
                String exportedPreferencesFileName = mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
-               res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);
+               res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName, deviceId);
                res = true;
            } else {
                Toast.makeText(getApplicationContext(), "Unable to load host specific preferences. Can't get host name.", Toast.LENGTH_LONG).show();

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -57,6 +57,8 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
     private Menu PRMenu;
     private int result;                     // set to RESULT_FIRST_USER when something is edited
 
+    private String deviceId = "";
+
     private boolean currentlyImporting = false;
     private String exportedPreferencesFileName =  "exported_preferences.ed";
     private boolean overwiteFile = false;
@@ -133,6 +135,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
             getPreferenceScreen().findPreference("prefSelectedLocoIndicator").setSelectable(false);
             getPreferenceScreen().findPreference("prefSelectedLocoIndicator").setEnabled(false);
         }
+
+        deviceId = Settings.System.getString(getContentResolver(), Settings.System.ANDROID_ID);
+        sharedPreferences.edit().putString("prefAndroidId", deviceId).commit();
     }
 
     @SuppressWarnings("deprecation")
@@ -276,7 +281,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                     if (currentValue.equals("Export")) {
                         saveSharedPreferencesToFile(sharedPreferences,exportedPreferencesFileName);
                     } else if (currentValue.equals("Import")) {
-                        loadSharedPreferencesFromFile(sharedPreferences,exportedPreferencesFileName);
+                        loadSharedPreferencesFromFile(sharedPreferences,exportedPreferencesFileName, deviceId);
                     } else if (currentValue.equals("Reset")) {
                         resetPreferences(sharedPreferences);
                     }
@@ -291,7 +296,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                         if (action.equals(EXPORT_PREFIX)) {
                             saveSharedPreferencesToFile(sharedPreferences,exportedPreferencesFileName);
                         } else if (action.equals(IMPORT_PREFIX)) {
-                            loadSharedPreferencesFromFile(sharedPreferences, exportedPreferencesFileName);
+                            loadSharedPreferencesFromFile(sharedPreferences, exportedPreferencesFileName, deviceId);
                         }
                     }
                 }
@@ -324,8 +329,8 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
     }
 
     @SuppressWarnings({ "unchecked" })
-    private boolean loadSharedPreferencesFromFile(SharedPreferences sharedPreferences, String exportedPreferencesFileName) {
-        boolean res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName);
+    private boolean loadSharedPreferencesFromFile(SharedPreferences sharedPreferences, String exportedPreferencesFileName, String deviceId) {
+        boolean res = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName, deviceId);
 
         if (!res) {
             Toast.makeText(getApplicationContext(), "Import from 'engine_driver/" + exportedPreferencesFileName + "' failed! You may not have saved the preferences for this host yet.", Toast.LENGTH_LONG).show();


### PR DESCRIPTION
If the preferences are being imported into the same device that exported them, the throttle name is also imported.  This includes the automatic host based imports.