### PR TITLE
ESU MCII - don't update speed when screen locked

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -16,6 +16,7 @@
     <li>import includes throttle name if on the same device that exported them</li>
     <li>multiple options for shaking the phone to perform an action</li>
     <li>separate preferences for Volume key and Gamepad speed increments</li>
+    <li>fix issue with ESU Mobile Control II knob position updating speed even when screen locked</li>
 </ul>
 </p>
 <br/><em><a

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -2,10 +2,11 @@
  * prevent some crashes reported to Google Play
  * option to hide the demo server
  * option for the volume keys to follow the last touched throttle
- * Fix issue with ESU Mobile Control II knob position not updating on EStop
+ * fix issue with ESU Mobile Control II knob position not updating on EStop
  * Import includes throttle name if on the same device that exported them
  * multiple options for shaking the phone to perform an action
  * separate preferences for Volume key and Gamepad speed increments
+ * fix issue with ESU Mobile Control II knob position updating speed even when screen locked
 **Version 2.17
  * Add support for ESU Mobile Control II throttle
  * Add toast messages when ESU Mobile Control II in stop mode


### PR DESCRIPTION
fixes JMRI/EngineDriver#185

This ensures that an ESU MCII respects a locked screen and does not update speed if knob inadvertently moved whilst locked.

This also blocks device button pushes when screen locked, aside from any assigned to STOP functions.

As this stands, the on-device STOP button remains active whilst screen is locked.