### PR TITLE
CHANGES - TTS and Gamepad Testing

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -17,6 +17,8 @@
     <li>multiple options for shaking the phone to perform an action</li>
     <li>separate preferences for Volume key and Gamepad speed increments</li>
     <li>fix issue with ESU Mobile Control II knob position updating speed even when screen locked</li>
+    <li>option to speak some gamepad related events </li>
+    <li>option to skip the gamepad test with just one 'decrease speed' button press</li>
 </ul>
 </p>
 <br/><em><a

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -46,6 +46,7 @@
     <bool name="prefSwapForwardReverseButtonsDefaultValue">false</bool>
     <bool name="prefSwapForwardReverseButtonsLongPressDefaultValue">false</bool>
     <bool name="prefGamepadTestEnforceTestingDefaultValue">true</bool>
+    <bool name="prefGamepadTestEnforceTestingSimpleDefaultValue">false</bool>
     <bool name="prefGamepadSwapForwardReverseWithScreenButtonsDefaultValue">true</bool>
     <bool name="prefImportExportLocoListDefaultValue">true</bool>
     <bool name="prefAutoImportExportDefaultValue">false</bool>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -411,6 +411,9 @@
     <string name="prefGamepadTestEnforceTestingTitle">Enforce Gamepad Testing</string>
     <string name="prefGamepadTestEnforceTestingSummary">Test each gamepad every time they are connected.</string>
 
+    <string name="prefGamepadTestEnforceTestingSimpleTitle">Use Simple Test</string>
+    <string name="prefGamepadTestEnforceTestingSimpleSummary">Only test that you can reduce speed.</string>
+
     <string name="prefLeftDirectionButtonsTitle">Left Direction Button label</string>
     <string name="prefLeftDirectionButtonsSummary">Labels for all LEFT direction buttons. Enter \'Forward\' or blank for normal behaviour.</string>
     <string name="prefLeftDirectionButtonsDefaultValue">Forward</string>
@@ -495,7 +498,7 @@
     <string name="gamepadTestKeycodeLabel">Key code:\s\s</string>
     <string name="gamepadTestFunctionLabel">Function:\s\s</string>
     <string name="gamepadTestCompleteLabel">Test status:\s\s</string>
-    <string name="gamepadTestHelp">Scroll down to see the full instructions…\n\nPress ALL Dpad AND four primary buttons or the gamepad WILL NOT WORK.\n\nIf you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your gamepad) or try a different gamepad Type (above).\n\n\'BACK\' or \'CANCEL\' will exit the test but the gamepad WILL NOT WORK.\n\'SKIP\', or pressing the \'Decrease Speed\' gamepad button three times, will force the test to pass, even if the gamepad does not work properly.\n\'RESET\' will make ED think no gamepads have been used yet.\n\nUse the \'Gamepad Test n\' menu options to get back to this page.</string>
+    <string name="gamepadTestHelp">Scroll down to see the full instructions…\n\nPress ALL Dpad AND four primary buttons or the gamepad WILL NOT WORK.\n\nIf you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your gamepad) or try a different gamepad Type (above).\n\n\'BACK\' or \'CANCEL\' will exit the test but the gamepad WILL NOT WORK.\n\'SKIP\', or pressing the \'Decrease Speed\' gamepad button three times, will force the test to pass, even if the gamepad does not work properly.\n\'RESET\' will make ED think no gamepads have been used yet.\nIf \'simple\' test is selected, a single \'Decrease Speed\' button press will skip the test.\n\nUse the \'Gamepad Test n\' menu options to get back to this page.</string>
     <string name="gamepadTestHelpNonForced">If you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\nYou may be required to re-test the gamepad when you first use it from the throttle screen.</string>
     <string name="gamepadTestIncomplete">"Test Incomplete"</string>
     <string name="gamepadTestComplete">"Test Complete"</string>
@@ -579,29 +582,30 @@
     <string name="prefTtsWhenSummary">When to speak key events and actions using Text to Speech (TTS).</string>
     <string name="prefTtsWhenDefaultValue">None</string>
 
-    <string name="prefTtsThrottleTitle">On Throttle Change</string>
+    <string name="prefTtsThrottleTitle">On Gamepad Throttle change</string>
     <string name="prefTtsThrottleSummary">When you select a different throttle.</string>
 
-    <string name="prefTtsThrottleSpeedTitle">On Throttle Change + speed</string>
+    <string name="prefTtsThrottleSpeedTitle">On Gamepad Throttle change + speed</string>
     <string name="prefTtsThrottleSpeedSummary">When you select a different throttle, also speak speed. Overrides throttle alone option. </string>
 
-    <string name="prefTtsThrottleLocoSpeedTitle">On Throttle Change + loco</string>
+    <string name="prefTtsThrottleLocoSpeedTitle">On Gamepad Throttle Change + loco</string>
     <string name="prefTtsThrottleLocoSpeedSummary">When you select a different throttle, also speak loco numbers. Overrides throttle alone option. </string>
 
-    <string name="prefTtsGamepadTestTitle">On Gamepad test</string>
+    <string name="prefTtsGamepadTestTitle">On Gamepad Test</string>
     <string name="prefTtsGamepadTestSummary">When the gamepad test page is launched. </string>
 
-    <string name="prefTtsGamepadTestCompleteTitle">On Gamepad test complete</string>
+    <string name="prefTtsGamepadTestCompleteTitle">On Gamepad Test complete</string>
     <string name="prefTtsGamepadTestCompleteSummary">When the gamepad test page is finished. </string>
 
     <string name="TtsVolumeThrottle">Throttle</string>
     <string name="TtsGamepadThrottle">Throttle</string>
     <string name="TtsLoco">Loco</string>
     <string name="TtsSpeed">Speed</string>
-    <string name="TtsGamepadTest">Gamepad Test</string>
-    <string name="TtsGamepadTestComplete">Test Complete</string>
-    <string name="TtsGamepadTestSkipped">Test Skipped</string>
-    <string name="TtsGamepadTestReset">Gamepad Reset</string>
+    <string name="TtsGamepadTest">Gamepad test</string>
+    <string name="TtsGamepadTestComplete">Test complete</string>
+    <string name="TtsGamepadTestSkipped">Test skipped</string>
+    <string name="TtsGamepadTestFail">Test cancelled</string>
+    <string name="TtsGamepadTestReset">Gamepad reset</string>
 <!--
     <string name="TTS_Screen_Dimmed">Dimmed, swipe up to restore</string>
     <string name="TTS_Screen_Locked">Locked, swipe up to restore</string>
@@ -616,7 +620,7 @@
     <string name="TTS_Dir_Change_While_Moving_Disabled">Direction not changed</string>
     <string name="TTS_Function">Function </string>
 -->
-    <string name="toastTtsFailed">Sorry! Text To Speech failed...</string>
+    <string name="toastTtsFailed">Sorry! Text to speech failed...</string>
 
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -222,56 +222,6 @@
 
         </PreferenceScreen>
 
-        <PreferenceScreen
-            android:key="prefTts"
-            android:title="@string/prefTtsTitle"
-            android:summary="@string/prefTtsSummary"
-            android:persistent="false">
-            <ListPreference
-                android:defaultValue="@string/prefTtsWhenDefaultValue"
-                android:entries="@array/prefTtsWhenEntries"
-                android:entryValues="@array/prefTtsWhenOptions"
-                android:key="prefTtsWhen"
-                android:summary="@string/prefTtsWhenSummary"
-                android:title="@string/prefTtsWhenTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefTtsThrottleDefaultValue"
-                android:key="prefTtsThrottle"
-                android:summary="@string/prefTtsThrottleSummary"
-                android:title="@string/prefTtsThrottleTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefTtsThrottleSpeedDefaultValue"
-                android:key="prefTtsThrottleSpeed"
-                android:summary="@string/prefTtsThrottleSpeedSummary"
-                android:title="@string/prefTtsThrottleSpeedTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefTtsThrottleLocoSpeedDefaultValue"
-                android:key="prefTtsThrottleLocoSpeed"
-                android:summary="@string/prefTtsThrottleLocoSpeedSummary"
-                android:title="@string/prefTtsThrottleLocoSpeedTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefTtsGamepadTestDefaultValue"
-                android:key="prefTtsGamepadTest"
-                android:summary="@string/prefTtsGamepadTestSummary"
-                android:title="@string/prefTtsGamepadTestTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefTtsGamepadTestCompleteDefaultValue"
-                android:key="prefTtsGamepadTestComplete"
-                android:summary="@string/prefTtsGamepadTestCompleteSummary"
-                android:title="@string/prefTtsGamepadTestCompleteTitle" />
-
-        </PreferenceScreen>
-
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -317,7 +267,61 @@
                 android:summary="@string/prefVolumeKeysFollowLastTouchedThrottleSummary"
                 android:title="@string/prefVolumeKeysFollowLastTouchedThrottleTitle" >
             </CheckBoxPreference>
+        </PreferenceScreen>
 
+        <PreferenceScreen
+            android:key="prefTts"
+            android:title="@string/prefTtsTitle"
+            android:summary="@string/prefTtsSummary"
+            android:persistent="false">
+
+            <ListPreference
+                android:defaultValue="@string/prefTtsWhenDefaultValue"
+                android:entries="@array/prefTtsWhenEntries"
+                android:entryValues="@array/prefTtsWhenOptions"
+                android:key="prefTtsWhen"
+                android:summary="@string/prefTtsWhenSummary"
+                android:title="@string/prefTtsWhenTitle" />
+
+            <CheckBoxPreference
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:defaultValue="@bool/prefTtsThrottleDefaultValue"
+                android:key="prefTtsThrottle"
+                android:summary="@string/prefTtsThrottleSummary"
+                android:title="@string/prefTtsThrottleTitle" />
+
+            <CheckBoxPreference
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:defaultValue="@bool/prefTtsThrottleSpeedDefaultValue"
+                android:key="prefTtsThrottleSpeed"
+                android:summary="@string/prefTtsThrottleSpeedSummary"
+                android:title="@string/prefTtsThrottleSpeedTitle" />
+
+            <CheckBoxPreference
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:defaultValue="@bool/prefTtsThrottleLocoSpeedDefaultValue"
+                android:key="prefTtsThrottleLocoSpeed"
+                android:summary="@string/prefTtsThrottleLocoSpeedSummary"
+                android:title="@string/prefTtsThrottleLocoSpeedTitle" />
+
+            <CheckBoxPreference
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:defaultValue="@bool/prefTtsGamepadTestDefaultValue"
+                android:key="prefTtsGamepadTest"
+                android:summary="@string/prefTtsGamepadTestSummary"
+                android:title="@string/prefTtsGamepadTestTitle" />
+
+            <CheckBoxPreference
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:defaultValue="@bool/prefTtsGamepadTestCompleteDefaultValue"
+                android:key="prefTtsGamepadTestComplete"
+                android:summary="@string/prefTtsGamepadTestCompleteSummary"
+                android:title="@string/prefTtsGamepadTestCompleteTitle" />
         </PreferenceScreen>
 
         <PreferenceScreen
@@ -325,6 +329,7 @@
             android:title="@string/prefGamePadTitle"
             android:summary="@string/prefGamePadSummary"
             android:persistent="false">
+
             <ListPreference
                 android:defaultValue="@string/prefGamePadTypeDefaultValue"
                 android:entries="@array/prefGamePadTypeEntries"
@@ -332,6 +337,7 @@
                 android:key="prefGamePadType"
                 android:summary="@string/prefGamePadTypeSummary"
                 android:title="@string/prefGamePadTypeTitle" />
+
             <CheckBoxPreference
                 android:defaultValue="@bool/prefGamepadTestNowDefaultValue"
                 android:key="prefGamepadTestNow"
@@ -455,6 +461,12 @@
                 android:key="prefGamepadTestEnforceTesting"
                 android:summary="@string/prefGamepadTestEnforceTestingSummary"
                 android:title="@string/prefGamepadTestEnforceTestingTitle" >
+            </CheckBoxPreference>
+            <CheckBoxPreference
+                android:defaultValue="@bool/prefGamepadTestEnforceTestingSimpleDefaultValue"
+                android:key="prefGamepadTestEnforceTestingSimple"
+                android:summary="@string/prefGamepadTestEnforceTestingSimpleSummary"
+                android:title="@string/prefGamepadTestEnforceTestingSimpleTitle" >
             </CheckBoxPreference>
         </PreferenceScreen>
 

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -93,6 +93,8 @@ public class gamepad_test extends Activity implements OnGestureListener {
     String[] gamePadModesArray;
     String[] gamePadModeEntriesArray;
 
+    private boolean prefGamepadTestEnforceTestingSimple = true;
+
     private boolean[] gamepadButtonsChecked = {false,false,false,false,false,false,false,false,false,false};
 
     // Gamepad Button preferences
@@ -125,6 +127,7 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
     private static String GAMEPAD_TEST_PASS = "1";
     private static String GAMEPAD_TEST_FAIL = "2";
+    private static String GAMEPAD_TEST_SKIPPED = "3";
     private static String GAMEPAD_TEST_RESET = "9";
 
     private int decreaseButtonCount = 0;
@@ -294,11 +297,11 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
         tvGamepadKeyCode.setText(String.valueOf(keyCodeString));
         tvGamepadKeyFunction.setText(fn);
-        if (fn.equals("Decrease Speed")) {
+        if (fn.equals("Decrease Speed")) { // button is set to decrease speed
             decreaseButtonCount++;
-            if (decreaseButtonCount>=3) {
+            if ((decreaseButtonCount>=3) || (prefGamepadTestEnforceTestingSimple)) {
                 result = RESULT_OK;
-                end_this_activity(GAMEPAD_TEST_PASS);
+                end_this_activity(GAMEPAD_TEST_SKIPPED);
             }
         } else {
             decreaseButtonCount = 0;
@@ -408,24 +411,28 @@ public class gamepad_test extends Activity implements OnGestureListener {
                 if (yAxis == -1) { // DPAD Up Button
                     setButtonOn(bDpadUp, prefGamePadButtons[5],"DPad Up");
                     setAllKeyCodes( this.getResources().getString(R.string.gamepadTestKeyCodesUpCode), action);
+                    GamepadFeedbackSound(false);
                     isTestComplete(5);
                     return (true); // stop processing this key
 
                 } else if (yAxis == 1) { // DPAD Down Button
                     setButtonOn(bDpadDown, prefGamePadButtons[7],"DPad Down");
                     setAllKeyCodes( this.getResources().getString(R.string.gamepadTestKeyCodesDownCode), action);
+                    GamepadFeedbackSound(false);
                     isTestComplete(7);
                     return (true); // stop processing this key
 
                 } else if (xAxis == -1) { // DPAD Left Button
                     setButtonOn(bDpadLeft, prefGamePadButtons[8],"DPad Left");
                     setAllKeyCodes( this.getResources().getString(R.string.gamepadTestKeyCodesLeftCode), action);
+                    GamepadFeedbackSound(false);
                     isTestComplete(8);
                     return (true); // stop processing this key
 
                 } else if (xAxis == 1) { // DPAD Right Button
                     setButtonOn(bDpadRight, prefGamePadButtons[6],"DPad Right");
                     setAllKeyCodes( this.getResources().getString(R.string.gamepadTestKeyCodesRightCode), action);
+                    GamepadFeedbackSound(false);
                     isTestComplete(6);
                     return (true); // stop processing this key
                 }
@@ -461,57 +468,69 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
                 if (action == ACTION_UP) {
                     GamepadFeedbackSoundStop();
-                }
+                } else {
+                    if (keyCode == gamePadKeys[2]) { // DPAD Up Button
+                        setButtonOn(bDpadUp, prefGamePadButtons[5], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(5);
+                        return (true); // stop processing this key
 
-                if (keyCode == gamePadKeys[2]) { // DPAD Up Button
-                    setButtonOn(bDpadUp, prefGamePadButtons[5], String.valueOf(keyCode));
-                    isTestComplete(5);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
+                        setButtonOn(bDpadDown, prefGamePadButtons[7], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(7);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys[3]) { // DPAD Down Button
-                    setButtonOn(bDpadDown, prefGamePadButtons[7], String.valueOf(keyCode));
-                    isTestComplete(7);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
+                        setButtonOn(bDpadLeft, prefGamePadButtons[8], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(8);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys[4]) { // DPAD Left Button
-                    setButtonOn(bDpadLeft, prefGamePadButtons[8], String.valueOf(keyCode));
-                    isTestComplete(8);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
+                        setButtonOn(bDpadRight, prefGamePadButtons[6], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(6);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys[5]) { // DPAD Right Button
-                    setButtonOn(bDpadRight, prefGamePadButtons[6], String.valueOf(keyCode));
-                    isTestComplete(6);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[7]) { // ios button
+                        setButtonOn(bButtonX, prefGamePadButtons[1], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(1);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys[7]) { // ios button
-                    setButtonOn(bButtonX, prefGamePadButtons[1], String.valueOf(keyCode));
-                    isTestComplete(1);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys_Up[8]) { // X button
+                        setButtonOn(bButtonY, prefGamePadButtons[3], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(3);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys_Up[8]) { // X button
-                    setButtonOn(bButtonY, prefGamePadButtons[3], String.valueOf(keyCode));
-                    isTestComplete(3);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
+                        setButtonOn(bButtonA, prefGamePadButtons[2], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(2);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys_Up[9]) { // Triangle button
-                    setButtonOn(bButtonA, prefGamePadButtons[2], String.valueOf(keyCode));
-                    isTestComplete(2);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys_Up[10]) { // @ button
+                        setButtonOn(bButtonB, prefGamePadButtons[4], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(4);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys_Up[10]) { // @ button
-                    setButtonOn(bButtonB, prefGamePadButtons[4], String.valueOf(keyCode));
-                    isTestComplete(4);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[6]) { // start button
+                        setButtonOn(bButtonStart, prefGamePadButtons[0], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(0);
+                        return (true); // stop processing this key
 
-                } else if (keyCode == gamePadKeys[6]) { // start button
-                    setButtonOn(bButtonStart, prefGamePadButtons[0], String.valueOf(keyCode));
-                    isTestComplete(0);
-                    return (true); // stop processing this key
+                    } else if (keyCode == gamePadKeys[1]) { // Return button
+                        setButtonOn(bButtonEnter, prefGamePadButtons[9], String.valueOf(keyCode));
+                        GamepadFeedbackSound(false);
+                        isTestComplete(9);
+                        return (true); // stop processing this key
+                    }
 
-                } else if (keyCode == gamePadKeys[1]) { // Return button
-                    setButtonOn(bButtonEnter, prefGamePadButtons[9], String.valueOf(keyCode));
-                    isTestComplete(9);
-                    return (true); // stop processing this key
+                    GamepadFeedbackSound(true);
                 }
                 return (true); // ignore any other keycodes
             }
@@ -560,7 +579,7 @@ public class gamepad_test extends Activity implements OnGestureListener {
     }
     private class skip_button_listener implements View.OnClickListener {
         public void onClick(View v) {
-            end_this_activity(GAMEPAD_TEST_PASS);
+            end_this_activity(GAMEPAD_TEST_SKIPPED);
         }
     }
 
@@ -591,6 +610,8 @@ public class gamepad_test extends Activity implements OnGestureListener {
 
         mainapp = (threaded_application) this.getApplication();
         prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
+
+        prefGamepadTestEnforceTestingSimple = prefs.getBoolean("prefGamepadTestEnforceTestingSimple", getResources().getBoolean(R.bool.prefGamepadTestEnforceTestingSimpleDefaultValue));
 
         // tone generator for feedback sounds
         tg = new ToneGenerator(AudioManager.STREAM_NOTIFICATION,
@@ -697,6 +718,10 @@ public class gamepad_test extends Activity implements OnGestureListener {
     @Override
     public void onDestroy() {
         Log.d("Engine_Driver", "gamepad_test.onDestroy()");
+
+        if (tg != null) {
+            tg.release();
+        }
 
         //mainapp.consist_lights_edit_msg_handler = null;
         super.onDestroy();


### PR DESCRIPTION
NEW - new preference to skip gamepad test with just one 'decrease speed'
CHANGE - Remove TTS message when you change the Volume controlled Throttle
CHANGE - more tones played in the gamepad test screen
CHANGE - different TTS messages for different results from the gamepad test page