### PR TITLE
FIX - Multiple Gamepads Option

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -169,8 +169,6 @@
     <string name="prefGamePadFeedbackVolumeTitle">Volume del Click % del Pulsante del Gamepad</string>
     <string name="prefGamePadFeedbackVolumeSummary">Impostare volume percentual dei click dei pulsanti del Gamepad.</string>
 
-    <string name="prefGamePadMultipleDevicesTitle">Supporto Multiplo Gamepad</string>
-    <string name="prefGamePadMultipleDevicesSummary">Controllare Controllori separati per ogni Gamepad.\nRichiede Android Jelly Bean o posteriore.</string>
     <string name="prefGamePadSpeedButtonsRepeatTitle">Velocità di ripetizione dei pulsanti velocità.</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">Ritardo fra le ripetizioni del pulsante velocitá del Gamepad. Minore è più veloce.</string>
 

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -168,8 +168,6 @@
     <string name="prefGamePadFeedbackVolumeTitle">Volume do Click % do Botão do Gamepad</string>
     <string name="prefGamePadFeedbackVolumeSummary">Definir a porcentagem de volume dos clicks dos botões do Gamepad.</string>
 
-    <string name="prefGamePadMultipleDevicesTitle">Suporte Gamepads Múltiplos</string>
-    <string name="prefGamePadMultipleDevicesSummary">Controlar Controladores separados para cada Gamepad.\nNecessita de Android Jelly Bean ou sucessivo.</string>
     <string name="prefGamePadSpeedButtonsRepeatTitle">Velocidade  de repetição dos botões de velocidade</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">Atraso entre repetições nos botões de velocidade do Gamepad. Menor é mais rápido.</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -178,8 +178,6 @@
     <string name="prefGamePadFeedbackVolumeTitle">Gamepad Button Click Volume %</string>
     <string name="prefGamePadFeedbackVolumeSummary">Set the volume percent for gamepad button clicks.</string>
     <string name="prefGamePadFeedbackVolumeDefaultValue">100</string>
-    <string name="prefGamePadMultipleDevicesTitle">Support Multiple Gamepads</string>
-    <string name="prefGamePadMultipleDevicesSummary">Control separate throttles with each gamepad. \nRequires Android Jelly Bean or later.</string>
 
     <string name="prefGamePadSpeedButtonsRepeatTitle">Speed button repeat delay</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">How long between repeats on Gamepad speed buttons.  Smaller is faster.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -346,14 +346,6 @@
                 android:numeric="integer"
                 android:summary="@string/prefGamePadFeedbackVolumeSummary"
                 android:title="@string/prefGamePadFeedbackVolumeTitle" />
-            <CheckBoxPreference
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:defaultValue="@bool/prefGamePadMultipleDevicesDefaultValue"
-                android:key="prefGamePadMultipleDevices"
-                android:summary="@string/prefGamePadMultipleDevicesSummary"
-                android:title="@string/prefGamePadMultipleDevicesTitle">
-            </CheckBoxPreference>
             <EditTextPreference
                 android:defaultValue="@string/prefGamePadSpeedButtonsRepeatDefaultValue"
                 android:dialogTitle="@string/prefGamePadSpeedButtonsRepeatTitle"

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -652,29 +652,12 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
         }
         Preference thisPref;
 
-        thisPref = getPreferenceScreen().findPreference("prefGamePadFeedbackVolume");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
+        enableDisablePreference("prefGamePadFeedbackVolume",thisEnabled);
+        enableDisablePreference("prefGamePadSpeedArrowsThrottleRepeatDelay",thisEnabled);
+        enableDisablePreference("prefGamepadSwapForwardReverseWithScreenButtons",thisEnabled);
+        enableDisablePreference("prefGamepadTestEnforceTesting",thisEnabled);
+        enableDisablePreference("prefGamepadTestNow",thisEnabled);
 
-        thisPref = getPreferenceScreen().findPreference("prefGamePadMultipleDevices");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
-
-        thisPref = getPreferenceScreen().findPreference("prefGamePadSpeedArrowsThrottleRepeatDelay");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
-
-        thisPref = getPreferenceScreen().findPreference("prefGamepadSwapForwardReverseWithScreenButtons");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
-
-        thisPref = getPreferenceScreen().findPreference("prefGamepadTestEnforceTesting");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
-
-        thisPref = getPreferenceScreen().findPreference("prefGamepadTestNow");
-        thisPref.setSelectable(thisEnabled);
-        thisPref.setEnabled(thisEnabled);
     }
 
 }


### PR DESCRIPTION
Unticking 'Support Multiple Gamepads' disabled all gamepad support.
The option never had any code behind it so has never worked. As no one has found this before now, I have removed the option entirely.