### PR TITLE
option for ESU Mobile Control II to disable direction change

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -23,6 +23,7 @@
     <li>new 'Dark' Theme added</li>
     <li>option to reset the Function Label defaults</li>
     <li>option to reduce the number of displayed Default Function Buttons</li>
+    <li>option for ESU Mobile Control II to disable direction change at zero end-stop position</li>
 </ul>
 </p>
 <br/><em><a

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -13,6 +13,7 @@
  * New Dark theme option
  * option to reset the Function Label defaults
  * option to reduce the number of displayed default Function Labels
+ * option for ESU Mobile Control II to disable direction change at zero end-stop position
 **Version 2.17
  * Add support for ESU Mobile Control II throttle
  * Add toast messages when ESU Mobile Control II in stop mode

--- a/res/values-en-rAU/strings.xml
+++ b/res/values-en-rAU/strings.xml
@@ -14,6 +14,9 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 <resources>
+    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
+
     <string name="app_name_turnouts">Points - Engine Driver</string>
 
     <string name="turnouts">Points</string>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -15,6 +15,7 @@
 -->
 <resources>
     <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
 
     <string name="app_name_turnouts">Points - Engine Driver</string>
 

--- a/res/values-en-rNZ/strings.xml
+++ b/res/values-en-rNZ/strings.xml
@@ -15,6 +15,7 @@
 -->
 <resources>
     <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
 
     <string name="app_name_turnouts">Points - Engine Driver</string>
 

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -60,4 +60,5 @@
     <bool name="prefTtsGamepadTestDefaultValue">true</bool>
     <bool name="prefTtsGamepadTestCompleteDefaultValue">true</bool>
 
+    <bool name="prefEsuMc2EndStopDirectionChangeDefaultValue">true</bool>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -250,6 +250,8 @@
     <string name="prefEsuMc2ZeroTrimTitle">Control Knob Zero Trim</string>
     <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to counter-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
     <string name="prefEsuMc2ZeroTrimDefaultValue">10</string>
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Direction Change at end-stop</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at counter-clockwise end-stop position.</string>
     <!-- ESU MCII preferences -->
 
     <!-- ESU MCII Messages -->

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -615,6 +615,11 @@
                     android:inputType="number"
                     android:digits="0123456789"
                     android:numeric="integer" />
+                <CheckBoxPreference
+                    android:key="prefEsuMc2EndStopDirectionChange"
+                    android:title="@string/prefEsuMc2EndStopDirectionChangeTitle"
+                    android:summary="@string/prefEsuMc2EndStopDirectionChangeSummary"
+                    android:defaultValue="@bool/prefEsuMc2EndStopDirectionChangeDefaultValue" />
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -453,6 +453,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     private Handler esuButtonRepeatUpdateHandler = new Handler();
     private boolean esuButtonAutoIncrement = false;
     private boolean esuButtonAutoDecrement = false;
+    private boolean prefEsuMc2EndStopDirectionChange = true;
 
     // Create default ESU MCII ThrottleScale for each throttle
     private ThrottleScale esuThrottleScaleT = new ThrottleScale(10, 127);
@@ -1180,6 +1181,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         prefTtsThrottleResponse = prefs.getString("prefTtsThrottleResponse", getResources().getString(R.string.prefTtsThrottleResponseDefaultValue));
         prefTtsGamepadTest = prefs.getBoolean("prefTtsGamepadTest", getResources().getBoolean(R.bool.prefTtsGamepadTestDefaultValue));
         prefTtsGamepadTestComplete = prefs.getBoolean("prefTtsGamepadTestComplete", getResources().getBoolean(R.bool.prefTtsGamepadTestCompleteDefaultValue));
+
+        prefEsuMc2EndStopDirectionChange = prefs.getBoolean("prefEsuMc2EndStopDirectionChange", getResources().getBoolean(R.bool.prefEsuMc2EndStopDirectionChangeDefaultValue));
     }
 
     private void getDirectionButtonPrefs() {
@@ -2943,9 +2946,14 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         public void onButtonDown() {
             Log.d("Engine_Driver", "ESU_MCII: Knob button down for throttle " + whichVolume);
             if (!isScreenLocked) {
-                Log.d("Engine_Driver", "ESU_MCII: Attempting to switch direction");
-                changeDirectionIfAllowed(whichVolume, (getDirection(whichVolume) == 1 ? 0 : 1));
-                speedUpdateAndNotify(whichVolume, 0, false);
+                if (prefEsuMc2EndStopDirectionChange) {
+                    Log.d("Engine_Driver", "ESU_MCII: Attempting to switch direction");
+                    changeDirectionIfAllowed(whichVolume, (getDirection(whichVolume) == 1 ? 0 : 1));
+                    speedUpdateAndNotify(whichVolume, 0, false);
+                } else {
+                    Log.d("Engine_Driver", "ESU_MCII: Direction change option disabled - do nothing");
+                    speedUpdateAndNotify(whichVolume, 0, false);
+                }
             } else {
                 Log.d("Engine_Driver", "ESU_MCII: Screen locked - do nothing");
             }


### PR DESCRIPTION
This adds a new option for the ESU Mobile Control II to disable direction change at zero end-stop position.

Requested by Pete Mulvany