### PR TITLE
Allow ESU MCII stop button short-press to be disabled

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -24,6 +24,7 @@
     <li>option to reset the Function Label defaults</li>
     <li>option to reduce the number of displayed Default Function Buttons</li>
     <li>option for ESU Mobile Control II to disable direction change at zero end-stop position</li>
+    <li>option for ESU Mobile Control II to disable on-device stop button short-press</li>
 </ul>
 </p>
 <br/><em><a

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -14,6 +14,7 @@
  * option to reset the Function Label defaults
  * option to reduce the number of displayed default Function Labels
  * option for ESU Mobile Control II to disable direction change at zero end-stop position
+ * option for ESU Mobile Control II to disable on-device stop button short-press
 **Version 2.17
  * Add support for ESU Mobile Control II throttle
  * Add toast messages when ESU Mobile Control II in stop mode

--- a/res/values/bool.xml
+++ b/res/values/bool.xml
@@ -61,4 +61,5 @@
     <bool name="prefTtsGamepadTestCompleteDefaultValue">true</bool>
 
     <bool name="prefEsuMc2EndStopDirectionChangeDefaultValue">true</bool>
+    <bool name="prefEsuMc2StopButtonShortPressDefaultValue">true</bool>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -246,6 +246,8 @@
     <string name="prefEsuMc2StopButtonDelayTitle">Stop Button long-press delay</string>
     <string name="prefEsuMc2StopButtonDelaySummary">How long for a \'long-press\' of the Stop button.\nA \'long-press\' stops all active throttles; a \'short-press\' pauses the current throttle.\nSmaller is faster.</string>
     <string name="prefEsuMc2StopButtonDelayDefaultValue">500</string>
+    <string name="prefEsuMc2StopButtonShortPressTitle">Enable Short Press</string>
+    <string name="prefEsuMc2StopButtonShortPressSummary">A \'short-press\' pauses the currently controlled locomotive/consist.\nWill revert to original speed when operations resume.</string>
     <string name="prefEsuMc2ZeroTrimCategoryTitle">Control Knob options</string>
     <string name="prefEsuMc2ZeroTrimTitle">Control Knob Zero Trim</string>
     <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to counter-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -559,6 +559,11 @@
                     android:numeric="integer"
                     android:digits="0123456789"
                     android:inputType="number" />
+                <CheckBoxPreference
+                    android:key="prefEsuMc2StopButtonShortPress"
+                    android:title="@string/prefEsuMc2StopButtonShortPressTitle"
+                    android:summary="@string/prefEsuMc2StopButtonShortPressSummary"
+                    android:defaultValue="@bool/prefEsuMc2StopButtonShortPressDefaultValue" />
             </PreferenceCategory>
             <!-- Button preferences -->
             <PreferenceCategory android:title="@string/prefEsuMc2ButtonsCategoryTitle">

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -454,6 +454,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     private boolean esuButtonAutoIncrement = false;
     private boolean esuButtonAutoDecrement = false;
     private boolean prefEsuMc2EndStopDirectionChange = true;
+    private boolean prefEsuMc2StopButtonShortPress = true;
 
     // Create default ESU MCII ThrottleScale for each throttle
     private ThrottleScale esuThrottleScaleT = new ThrottleScale(10, 127);
@@ -1183,6 +1184,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         prefTtsGamepadTestComplete = prefs.getBoolean("prefTtsGamepadTestComplete", getResources().getBoolean(R.bool.prefTtsGamepadTestCompleteDefaultValue));
 
         prefEsuMc2EndStopDirectionChange = prefs.getBoolean("prefEsuMc2EndStopDirectionChange", getResources().getBoolean(R.bool.prefEsuMc2EndStopDirectionChangeDefaultValue));
+        prefEsuMc2StopButtonShortPress = prefs.getBoolean("prefEsuMc2StopButtonShortPress", getResources().getBoolean(R.bool.prefEsuMc2StopButtonShortPressDefaultValue));
     }
 
     private void getDirectionButtonPrefs() {
@@ -3011,8 +3013,10 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             }
             // Toggle press status
             isEsuMc2Stopped = !isEsuMc2Stopped;
-            set_stop_button(whichVolume, true);
-            speedUpdateAndNotify(whichVolume, 0);
+            if (prefEsuMc2StopButtonShortPress) {
+                set_stop_button(whichVolume, true);
+                speedUpdateAndNotify(whichVolume, 0);
+            }
             esuMc2Led.setState(EsuMc2Led.RED, EsuMc2LedState.ON);
             esuMc2Led.setState(EsuMc2Led.GREEN, EsuMc2LedState.OFF);
             // Read current stop button delay pref value
@@ -3043,17 +3047,27 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                     isEsuMc2AllStopped = true;
                 } else {
                     wasLongPress = false;
-                    Log.d("Engine_Driver", "ESU_MCII: Stop button press was short - short flash Red LED");
-                    esuMc2Led.setState(EsuMc2Led.RED, EsuMc2LedState.QUICK_FLASH);
-                    esuMc2Led.setState(EsuMc2Led.GREEN, EsuMc2LedState.OFF);
-                    setEnabledEsuMc2ThrottleScreenButtons(whichVolume, false);
+                    if (prefEsuMc2StopButtonShortPress) {
+                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short - short flash Red LED");
+                        esuMc2Led.setState(EsuMc2Led.RED, EsuMc2LedState.QUICK_FLASH);
+                        esuMc2Led.setState(EsuMc2Led.GREEN, EsuMc2LedState.OFF);
+                        setEnabledEsuMc2ThrottleScreenButtons(whichVolume, false);
+                    } else {
+                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short but action disabled");
+                        isEsuMc2Stopped = !isEsuMc2Stopped;
+                        esuMc2Led.revertLEDStates();
+                    }
                 }
             } else {
                 if (!wasLongPress) {
-                    Log.d("Engine_Driver", "ESU_MCII: Revert speed value to: " + origSpeed);
-                    set_stop_button(whichVolume, false);
-                    speedUpdateAndNotify(whichVolume, origSpeed);
-                    setEnabledEsuMc2ThrottleScreenButtons(whichVolume, true);
+                    if (prefEsuMc2StopButtonShortPress) {
+                        Log.d("Engine_Driver", "ESU_MCII: Revert speed value to: " + origSpeed);
+                        set_stop_button(whichVolume, false);
+                        speedUpdateAndNotify(whichVolume, origSpeed);
+                        setEnabledEsuMc2ThrottleScreenButtons(whichVolume, true);
+                    } else {
+                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short but revert action disabled");
+                    }
                 } else {
                     Log.d("Engine_Driver", "ESU_MCII: Resume control without speed revert");
                     origSpeed = 0;


### PR DESCRIPTION
This comes from a suggestion by Pete Mulvany to optimise operations where inadvertent short-presses can hamper operations.

The LED on the device will still change to Red when a short-press is detected but, when disabled, no action will be taken upon release.

A long-press (time of which is configurable) will always result in an action stopping all locos currently controlled by the device.