### PR TITLE
NEW - Change language from inside the App

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:description="@string/app_description"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/app_theme" >
+        android:theme="@style/app_splash" >
         <activity
             android:name=".connection_activity"
             android:label="@string/app_name" >

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -7,25 +7,9 @@
 <h1>Engine Driver Throttle for Android</h1>
 <div><img src="file:///android_asset/engine_driver_icon.png" height="144" width="166"
           style="float:left;padding:0 8px 8px 0" alt=""/></div>
-<p>Engine Driver version 2.18 includes:<br/>
+<p>Engine Driver version 2.19 includes:<br/>
 <ul>
-    <li>new 'Dark' Theme added</li>
-    <li>option for the volume keys to follow the last touched throttle</li>
-    <li>option for ESU Mobile Control II to disable direction change at zero end-stop position</li>
-    <li>option for ESU Mobile Control II to disable on-device stop button short-press</li>
-    <li>multiple options for shaking the phone to perform an action</li>
-    <li>Italian and Portuguese translations from Roberto Falorni added</li>
-    <li>option to speak some gamepad related events </li>
-    <li>option to skip the gamepad test with just one 'decrease speed' button press</li>
-    <li>option to reset the Function Label defaults</li>
-    <li>option to reduce the number of displayed Default Function Buttons</li>
-    <li>fix issue with ESU Mobile Control II knob position not updating on EStop</li>
-    <li>fix issue with ESU Mobile Control II knob position updating speed even when screen locked</li>
-    <li>separate preferences for Volume key and Gamepad speed increments</li>
-    <li>import includes throttle name if on the same device that exported them</li>
-    <li>prevent some crashes reported to Google Play</li>
-    <li>option to hide the demo server</li>
-    <li>fixed mis-handling of WiThrottle-created consists</li>
+    <li>option to change languages from the preferences screen</li>
 </ul>
 </p>
 <br/><em><a

--- a/bin/AndroidManifest.xml
+++ b/bin/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:description="@string/app_description"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/app_theme" >
+        android:theme="@style/app_splash" >
         <activity
             android:name=".connection_activity"
             android:label="@string/app_name" >

--- a/res/drawable/app_splash.xml
+++ b/res/drawable/app_splash.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:drawable="@color/transparent" />
+
+</layer-list>

--- a/res/values-it/arrays.xml
+++ b/res/values-it/arrays.xml
@@ -155,7 +155,7 @@
     </string-array>
 
     <string-array name="prefLocaleEntries">  <!-- display version -->
-        <item>Usa le impostazioni globali del telefono</item>
+        <item>Usare le impostazioni globali del telefono</item>
         <item>Inglese (USA) - Impostazione predefinita Engine Driver</item>
         <item>Italiano</item>
         <item>Portoghese</item>

--- a/res/values-it/arrays.xml
+++ b/res/values-it/arrays.xml
@@ -154,4 +154,11 @@
         <item>Controllore + Locomotiva + Velocità</item>
     </string-array>
 
+    <string-array name="prefLocaleEntries">  <!-- display version -->
+        <item>Usa le impostazioni globali del telefono</item>
+        <item>Inglese (USA) - Impostazione predefinita Engine Driver</item>
+        <item>Italiano</item>
+        <item>Portoghese</item>
+    </string-array>
+
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -375,7 +375,7 @@
 
     <string name="prefRightDirectionButtonsTitle">Etichetta Pulsante Direzione Destro</string>
     <string name="prefRightDirectionButtonsSummary">Etichette per tutti i pulsanti direzione DESTRI. Inserire \'Indietro\' o lasciare in bianco per funzionamento normale.</string>
-    <string name="prefRightDirectionButtonsDefaultValue">Invertire</string>
+    <string name="prefRightDirectionButtonsDefaultValue">Indietro</string>
 
     <string name="prefThemeTitle">Tema/Stile</string>
     <string name="prefThemeSummary">Tema App. RICHIEDE riavvio di Engine Driver. \nRichiede Android Honeycomb o successivo.</string>
@@ -396,6 +396,9 @@
 
     <string name="prefAccelerometerShakeThresholdTitle">Livello scuotimento</string>
     <string name="prefAccelerometerShakeThresholdSummary">Livello al quale lo scuotimento sará registrato.(1.5&#8211;3.5) Valori minori risponderanno ad una azione più lieve.\nRichiede il riavvio di Engine Driver per avere effetto.</string>
+
+    <string name="prefLocaleTitle">Posizione</string>
+    <string name="prefLocaleSummary">Lingua da usare. \nAVVERTIMENTO! Engine Driver si riavvierà immediatamente. Le etichette dei pulsanti di direzione verranno ripristinate.</string>
 
     <string name="gamepadTestButtonLabelDpadUp">Su</string>
     <string name="gamepadTestButtonLabelDpadDown">Giu</string>
@@ -444,9 +447,12 @@
     <string name="toastSwipeUpScreenDimmed">Schermo Controllore Scurito - Scorrere per ripristinare</string>
     <string name="toastSwipeUpViewHidden">Vista Web temporaneamente nascosta.  Per nascondere permanentemente, alterare le preferenze.</string>
     <string name="toastThrottleAlertEstop">Avviso: Locomotiva %%1%% é impostata in stato di ESTOP</string>
+
     <string name="toastPreferencesOutsideLimits">Il valore inserito è fuori dai limiti  (%%1%%-%%2%%). Ristabilito %%3%%.</string>
     <string name="toastPreferencesNotNumeric">Il valore inserito non è un numero.(%%1%%-%%2%%). Ristabilito %%3%%.</string>
     <string name="toastPreferencesResetSucceeded">Preferenze resettate a valori default!</string>
+<!--    <string name="toastPreferencesLocaleChange">Engine Driver riavviato con la lingua scelta.</string> -->
+
     <string name="toastTurnoutInvalidNumber">Nomero dello scambio non valido.</string>
     <string name="toastTurnoutCommandTo">Comando inviato allo scambio %%1%%</string>
     <string name="toastTurnoutCommandToClose">Corretto Tracciato</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -148,10 +148,10 @@
     <string name="prefIncreaseSliderHeightTitle">Aumentare altezza acceleratore?</string>
     <string name="prefIncreaseSliderHeightSummary">Usare acceleratore, o Pulsanti Velocitá, più alti per il controllore.</string>
     <string name="prefHideSliderTitle">Nascondere acceleratore?</string>
-    <string name="prefHideSliderSummary">Non mostrare acceleratore., usare pulsanti velocità al suo posto.</string>
-    <string name="prefHideSliderAndSpeedButtonsTitle">Nascondere acceleratore E Pulsanti Velocità? </string>
+    <string name="prefHideSliderSummary">Non mostrare acceleratore, usare pulsanti velocità al suo posto.</string>
+    <string name="prefHideSliderAndSpeedButtonsTitle">Nasc. Accel. E Pulsanti Velocità?</string>
     <string name="prefHideSliderAndSpeedButtonsSummary">Non mostrare nè acceleratore nè Pulsanti di velocità.\nNota: Ignora le ozioni  \'Nascondi Acceleratore\', \'Altezza Acceleratore\' e \'Mostrare Pulsanti velocità\' .</string>
-    <string name="prefDirChangeWhileMovingTitle">Inversione di drezione in movimento?</string>
+    <string name="prefDirChangeWhileMovingTitle">Inversione dir. in movimento?</string>
     <string name="prefDirChangeWhileMovingSummary">Permettere inversione di direzione in movimento.</string>
     <string name="prefStopOnDirectionChangeTitle">Stop per inversione di direzione?</string>
     <string name="prefStopOnDirectionChangeSummary">Ferma il treno all\'inversione di direzione in movimento.</string>
@@ -182,7 +182,7 @@
     <string name="prefGamePadSpeedButtonsRepeatTitle">Velocità di ripetizione dei pulsanti velocità.</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">Ritardo fra le ripetizioni del pulsante velocitá del Gamepad. Minore è più veloce.</string>
 
-    <string name="prefGamePadSpeedButtonsSpeedStepTitle">Incremento pulsante di velcoità</string>
+    <string name="prefGamePadSpeedButtonsSpeedStepTitle">Incremento pulsante di velocità</string>
     <string name="prefGamePadSpeedButtonsSpeedStepSummary">Quanto i pulsanti del Gamepad alterano la velocità.</string>
 
     <string name="prefGamePadButton1Title">Azione del pulsante del Gamepad</string>
@@ -228,7 +228,7 @@
     <string name="toastEsuMc2NoButtonPresses">Pressione pulsanti non permessa: Mobile Control II attualmente in modalitá stop</string>
 
     <string name="prefDefaultFunctionsTitle">Preferenze Funzioni Default</string>
-    <!-- <string name="prefDefaultFunctionsSummary"></string> -->
+    <string name="prefDefaultFunctionsSummary">Quando e come le etichette funzioni di default sono visualizzate.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Usare etichette funzioni default?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Visualizzare le etichette funzione di default al posto delle etichette delle entrate dell\'elenco locomotive.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Diminuire altezza numero Locomotiva?</string>
@@ -304,14 +304,14 @@
     <string name="logViewer">Vedere Relazione</string>
     <string name="clearLocoList">Pulire Lista</string>
     <string name="ClearConnList">Pulire LIsta Recente</string>
-    <string name="prefEmerStopTitle">Mostrate Pulsante Fermata di Emergenza?</string>
+    <string name="prefEmerStopTitle">Mostrate Puls. Fermata Emergenza?</string>
     <string name="prefEmerStopSummary">Mostrate Pulsante Fermata di Emergenza della locomotiva nella barra di azione?</string>
     <string name="EStop">Estop</string>
     <string name="PowerButtonBar">pulsante_energia</string>
-    <string name="prefPowerButtonBarTitle">Mostrare pulsante energia del plastico?</string>
+    <string name="prefPowerButtonBarTitle">Mostrare puls. energia plastico?</string>
     <string name="prefPowerButtonBarSummary">Mostrare pulsante energia negli schermi Controllore, Scambi e Rotte?</string>
     <string name="prefSliderLeftMarginTitle">Margine Controllo di Velocità</string>
-    <string name="prefSliderLeftMarginSummary">Numero di pixels di dislocamento dei bordi delcontrollo di velocità.</string>
+    <string name="prefSliderLeftMarginSummary">Numero di pixels di dislocamento dei bordi del controllo di velocità.</string>
 
     <string name="PrefConnectToFirstServerTitle">Auto-Connessione al primo Server WiThrottle?</string>
     <string name="PrefConnectToFirstServerSummary">Connessione automatica al primo Server WiThrottle trovato?</string>
@@ -361,7 +361,7 @@
     <string name="prefImportExportErrorNotConnected">Host non connesso.</string>
 
     <string name="prefSwapForwardReverseButtonsTitle">Cambia Direzione Pulsanti</string>
-    <string name="prefSwapForwardReverseButtonsSummary">Scambia permanentemente i due Plsanti Direzione per tutti i controllori.</string>
+    <string name="prefSwapForwardReverseButtonsSummary">Scambia permanentemente i due Pulsanti Direzione per tutti i controllori.</string>
     <string name="prefSwapForwardReverseButtonsLongPressTitle">Pressione prolungata provoca scambio Pulsanti Direzione</string>
     <string name="prefSwapForwardReverseButtonsLongPressSummary">Invertire temporaneamente i due Pulsanti Direzione con una pressione prolungata di qualunque Pulsante Direzione.</string>
     <string name="prefGamepadSwapForwardReverseWithScreenButtonsTitle">Scambaire Pulsanti di Direzione con i Pulsanti Schermo</string>
@@ -370,7 +370,7 @@
     <string name="prefGamepadTestEnforceTestingSummary">Testare i gampead ogni volta che sono connessi.</string>
 
     <string name="prefLeftDirectionButtonsTitle">Etichetta Pulsante Direzione Sinistro</string>
-    <string name="prefLeftDirectionButtonsSummary">Etichette per tutti i pulsanti direzione DESTRI. Inserire \'Avanti\' o lasciare in bianco per funzionamento normale.</string>
+    <string name="prefLeftDirectionButtonsSummary">Etichette per tutti i pulsanti direzione SINISTRI. Inserire \'Avanti\' o lasciare in bianco per funzionamento normale.</string>
     <string name="prefLeftDirectionButtonsDefaultValue">Avanti</string>
 
     <string name="prefRightDirectionButtonsTitle">Etichetta Pulsante Direzione Destro</string>
@@ -397,8 +397,8 @@
     <string name="prefAccelerometerShakeThresholdTitle">Livello scuotimento</string>
     <string name="prefAccelerometerShakeThresholdSummary">Livello al quale lo scuotimento sará registrato.(1.5&#8211;3.5) Valori minori risponderanno ad una azione più lieve.\nRichiede il riavvio di Engine Driver per avere effetto.</string>
 
-    <string name="prefLocaleTitle">Posizione</string>
-    <string name="prefLocaleSummary">Lingua da usare. \nAVVERTIMENTO! Engine Driver si riavvierà immediatamente. Le etichette dei pulsanti di direzione verranno ripristinate.</string>
+    <string name="prefLocaleTitle">Localizzazione</string>
+    <string name="prefLocaleSummary">Lingua da usare. \nATTENZIONE! Engine Driver si riavvierà immediatamente. Le etichette dei pulsanti di direzione verranno ripristinate.</string>
 
     <string name="gamepadTestButtonLabelDpadUp">Su</string>
     <string name="gamepadTestButtonLabelDpadDown">Giu</string>

--- a/res/values-pt/arrays.xml
+++ b/res/values-pt/arrays.xml
@@ -153,7 +153,7 @@
     </string-array>
 
     <string-array name="prefLocaleEntries">  <!-- display version -->
-        <item>Use a configuração global do Phoneg</item>
+        <item>Usar a configuração global do telefone</item>
         <item>Inglês (EUA) - padrão do Engine Driver</item>
         <item>Italiano</item>
         <item>Português</item>

--- a/res/values-pt/arrays.xml
+++ b/res/values-pt/arrays.xml
@@ -152,4 +152,11 @@
         <item>Controlador + Locomotiva + Velocidade</item>
     </string-array>
 
+    <string-array name="prefLocaleEntries">  <!-- display version -->
+        <item>Use a configuração global do Phoneg</item>
+        <item>Inglês (EUA) - padrão do Engine Driver</item>
+        <item>Italiano</item>
+        <item>Português</item>
+    </string-array>
+
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -374,7 +374,7 @@
 
     <string name="prefRightDirectionButtonsTitle">Etiqueta Botão Direção Direito</string>
     <string name="prefRightDirectionButtonsSummary">Etiquetas para todos os botões direção DIREITOS. Inserir \'Reverso\' ou deixarem branco para funcionamento normal.</string>
-    <string name="prefRightDirectionButtonsDefaultValue">Inverter</string>
+    <string name="prefRightDirectionButtonsDefaultValue">Reverso</string>
 
     <string name="prefThemeTitle">Tema/Estilo</string>
     <string name="prefThemeSummary">Tema App. NECESSITA reiniciar o Enfine Driver. \nNecessita Android Honeycomb ou sucessivo.</string>
@@ -391,6 +391,9 @@
 
     <string name="prefAccelerometerShakeThresholdTitle">Patamar agitar</string>
     <string name="prefAccelerometerShakeThresholdSummary">Patamar no qual a agitação será registrada. (1.5&#8211;3.5).Valores abaixos responderão a uma ação mais suave.\nNecessita reiniciar Engine Driver para a mudança  ter efeito.</string>
+
+    <string name="prefLocaleTitle">Localização</string>
+    <string name="prefLocaleSummary">Idioma para usar. \nATENÇÃO! Engine Driver irá reiniciar imediatamente. Etiquetas de botão de direção serão redefinidas.</string>
 
     <string name="functionButton00DefultValue">Luz</string>
     <string name="functionButton01DefultValue">Sino</string>
@@ -443,9 +446,12 @@
     <string name="toastSwipeUpScreenDimmed">Tela Controlador Esmaecida - Deslizar para reativar</string>
     <string name="toastSwipeUpViewHidden">Vista Web temporariamente escondida. Para esconder permanentemente alterar as preferências</string>
     <string name="toastThrottleAlertEstop">Alerta: Locomotiva %%1%% está Configurada em estado de ESTOP</string>
+
     <string name="toastPreferencesOutsideLimits">O valor inserido está fora dos limites  (%%1%%-%%2%%). Reiniciado para %%3%%.</string>
     <string name="toastPreferencesNotNumeric">O valor inserido não é um número.(%%1%%-%%2%%). Reiniciado para %%3%%.</string>
     <string name="toastPreferencesResetSucceeded">Preferências Reiniciadas a valores Padrão!</string>
+<!--    <string name="toastPreferencesLocaleChange">Engine Driver reiniciado com o idioma escolhido.</string> -->
+
     <string name="toastTurnoutInvalidNumber">Numero de desvio inválido.</string>
     <string name="toastTurnoutCommandTo">Comando enviado para o desvio %%1%%</string>
     <string name="toastTurnoutCommandToClose">Reto</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -148,9 +148,9 @@
     <string name="prefIncreaseSliderHeightSummary">Usar acelerador, ou botoões de velocidade, mais altos no controlador.</string>
     <string name="prefHideSliderTitle">Esconder acelerador?</string>
     <string name="prefHideSliderSummary">Não mostrar acelerador, usar botões de velocidade.</string>
-    <string name="prefHideSliderAndSpeedButtonsTitle">Esconder acelerador E Botões de velocidade?</string>
+    <string name="prefHideSliderAndSpeedButtonsTitle">Escond. Acel. E Botões de velocidade?</string>
     <string name="prefHideSliderAndSpeedButtonsSummary">Não mostrar nem acelerador nem botões de velocidade.\nNota: Ignora as opções  \'Esconder Acelerador\', \'Altura Acelerador\' e \'Mostrar Botões velocidades\' .</string>
-    <string name="prefDirChangeWhileMovingTitle">Inversão de direção em movimento?</string>
+    <string name="prefDirChangeWhileMovingTitle">Inversão direção em movimento?</string>
     <string name="prefDirChangeWhileMovingSummary">Permitir inversão de direção em movimento.</string>
     <string name="prefStopOnDirectionChangeTitle">Parar ao inverter direção?</string>
     <string name="prefStopOnDirectionChangeSummary">Parar o trem se inverter direção em movimento.</string>
@@ -227,7 +227,7 @@
     <string name="toastEsuMc2NoButtonPresses">Pressão de botões não permitida:Mobile Control II atualmente em modo parada</string>
 
     <string name="prefDefaultFunctionsTitle">Preferências Funções Padrão</string>
-    <!-- <string name="prefDefaultFunctionsSummary"></string> -->
+    <string name="prefDefaultFunctionsSummary">Quando e como as etiquetas das funções padrão são mostradas.</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsTitle">Usar etiquestas funções padrão?</string>
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Visualizar as etiquetas padrão das funções no lugar das etiquetas das entradas da lista de locomotivas.</string>
 
@@ -304,11 +304,11 @@
     <string name="logViewer">Ver Relatório</string>
     <string name="clearLocoList">Limpar Lista</string>
     <string name="ClearConnList">Limpar Lista Recente</string>
-    <string name="prefEmerStopTitle">Mostrar Botão Parada de Emergência?</string>
+    <string name="prefEmerStopTitle">Mostrar Botão Parada Emergência?</string>
     <string name="prefEmerStopSummary">Mostrar Botão Parada de Emergência da locomotiva na barra de ação?</string>
     <string name="EStop">Estop</string>
     <string name="PowerButtonBar">botão_energia</string>
-    <string name="prefPowerButtonBarTitle">Mostrar botão de energia da maquete?</string>
+    <string name="prefPowerButtonBarTitle">Mostrar botão energia maquete?</string>
     <string name="prefPowerButtonBarSummary">Mostrar botão de energia nas telas Controlador, Desvios e Rotas?</string>
     <string name="prefSliderLeftMarginTitle">Margem Controlador de Velocidade</string>
     <string name="prefSliderLeftMarginSummary">Número de pixels de deslocamento das bordas do controlador de velocidade.</string>
@@ -377,7 +377,7 @@
     <string name="prefRightDirectionButtonsDefaultValue">Reverso</string>
 
     <string name="prefThemeTitle">Tema/Estilo</string>
-    <string name="prefThemeSummary">Tema App. NECESSITA reiniciar o Enfine Driver. \nNecessita Android Honeycomb ou sucessivo.</string>
+    <string name="prefThemeSummary">Tema App. NECESSITA reiniciar o Engine Driver. \nNecessita Android Honeycomb ou sucessivo.</string>
 
     <string name="prefHideDemoServerTitle">Esconder Servidor Demo</string>
     <string name="prefHideDemoServerSummary">Esconder o servidor demo \'jmri.mstevetodd.com\' na lista de conexões.</string>
@@ -393,7 +393,7 @@
     <string name="prefAccelerometerShakeThresholdSummary">Patamar no qual a agitação será registrada. (1.5&#8211;3.5).Valores abaixos responderão a uma ação mais suave.\nNecessita reiniciar Engine Driver para a mudança  ter efeito.</string>
 
     <string name="prefLocaleTitle">Localização</string>
-    <string name="prefLocaleSummary">Idioma para usar. \nATENÇÃO! Engine Driver irá reiniciar imediatamente. Etiquetas de botão de direção serão redefinidas.</string>
+    <string name="prefLocaleSummary">Idioma para usar. \nATENÇÃO! Engine Driver irá reiniciar imediatamente. As etiquetas dos botões de direção serão redefinidas.</string>
 
     <string name="functionButton00DefultValue">Luz</string>
     <string name="functionButton01DefultValue">Sino</string>

--- a/res/values-v11/themes.xml
+++ b/res/values-v11/themes.xml
@@ -14,6 +14,11 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 <resources>
+    <style name="app_splash" parent="android:Theme.Translucent">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@drawable/app_splash</item>
+    </style>
+
     <style name="app_theme" parent="@android:style/Theme.Holo">
         <item name="android:windowBackground">@drawable/app_background</item>
         <item name="android:windowTitleStyle">@style/app_title</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -690,4 +690,17 @@
         <item>No</item>
     </string-array>
 
+    <string-array name="prefLocaleEntryValues">
+        <item>Default</item>
+        <item>en_US</item>
+        <item>it</item>
+        <item>pt</item>
+    </string-array>
+    <string-array name="prefLocaleEntries">  <!-- display version -->
+        <item>Use Phone\'s global setting</item>
+        <item>English (US) - Engine Driver\'s default </item>
+        <item>Italian</item>
+        <item>Portuguese</item>
+    </string-array>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -465,6 +465,10 @@
     <string name="prefAccelerometerShakeThresholdSummary">Threshold at which the shake will register. (1.5&#8211;3.5) Lower value will respond to a gentle action.\nRequires restart of engine Driver after changing to take effect.</string>
     <string name="prefAccelerometerShakeThresholdDefaultValue">2.0</string>
 
+    <string name="prefLocaleTitle">Localisation</string>
+    <string name="prefLocaleSummary">Language to use.\nWARNING! Engine Driver will restart immediately. Direction Button labels will be reset.</string>
+    <string name="prefLocaleDefaultValue">Default</string>
+
     <string name="functionButton00DefultValue">Light</string>
     <string name="functionButton01DefultValue">Bell</string>
     <string name="functionButton02DefultValue">Horn</string>
@@ -565,6 +569,7 @@
     <string name="toastPreferencesOutsideLimits">Value entered is outside the limits (%%1%%-%%2%%). Reset to %%3%%.</string>
     <string name="toastPreferencesNotNumeric">Value entered is not numeric (%%1%%-%%2%%). Reset to %%3%%.</string>
     <string name="toastPreferencesResetSucceeded">Preferences Reset to defaults!</string>
+<!--    <string name="toastPreferencesLocaleChange">Engine Driver restarted with chosen Language.</string> -->
 
     <!--    Toast messages for the Turnout Activity -->
     <string name="toastTurnoutInvalidNumber">Invalid turnout number.</string>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -14,9 +14,25 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 <resources>
+    <!-- prior to v11 the splash screen needs to be the same as the normal theme -->
     <style name="app_splash" parent="android:Theme.Translucent">
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@drawable/app_splash</item>
+        <item name="android:windowBackground">@drawable/app_background</item>
+        <item name="android:windowTitleStyle">@style/app_title</item>
+        <item name="android:listViewStyle">@style/EDListView</item>
+        <item name="android:expandableListViewStyle">@style/EDListView</item>
+        <item name="android:listSeparatorTextViewStyle">@style/small_heading_style</item>
+
+        <item name="ed_loco_label_style">@style/loco_label_style</item>
+        <item name="floating_text_style">@style/floating_text_style</item>
+
+        <item name="ed_fn_scrollview_style">@style/fn_scrollview_style</item>
+
+        <item name="ed_large_button_style">@style/large_button_style</item>
+        <item name="ed_normal_button_style">@style/normal_button_style</item>
+        <item name="ed_small_button_style">@style/small_button_style</item>
+        <item name="ed_stop_button_style">@style/stop_button_style</item>
+        <item name="ed_fn_button_style">@style/fn_button_style</item>
+        <item name="ed_list_button_style">@style/list_button_style</item>
     </style>
 
     <style name="app_theme" parent="@android:style/Theme">

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -14,6 +14,11 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 <resources>
+    <style name="app_splash" parent="android:Theme.Translucent">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@drawable/app_splash</item>
+    </style>
+
     <style name="app_theme" parent="@android:style/Theme">
         <item name="android:windowBackground">@drawable/app_background</item>
         <item name="android:windowTitleStyle">@style/app_title</item>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -28,6 +28,14 @@
         android:summary="@string/prefThemeSummary"
         android:title="@string/prefThemeTitle" />
 
+    <ListPreference
+        android:defaultValue="@string/prefLocaleDefaultValue"
+        android:entries="@array/prefLocaleEntries"
+        android:entryValues="@array/prefLocaleEntryValues"
+        android:key="prefLocale"
+        android:summary="@string/prefLocaleSummary"
+        android:title="@string/prefLocaleTitle" />
+
     <PreferenceCategory android:title="@string/prefThrottleStatusTitle" >
         <CheckBoxPreference
             android:defaultValue="@bool/prefShowEmergencyStopButtonDefaultValue"

--- a/src/jmri/enginedriver/ConsistEdit.java
+++ b/src/jmri/enginedriver/ConsistEdit.java
@@ -49,6 +49,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
+import android.content.Context;
+
 import jmri.enginedriver.Consist.ConLoco;
 
 public class ConsistEdit extends Activity implements OnGestureListener {
@@ -174,6 +176,7 @@ public class ConsistEdit extends Activity implements OnGestureListener {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_ConsistEdit)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.consist);
         //put pointer to this activity's handler in main app's shared variable
@@ -366,5 +369,10 @@ public class ConsistEdit extends Activity implements OnGestureListener {
 
     private void disconnect() {
         this.finish();
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 }

--- a/src/jmri/enginedriver/ConsistLightsEdit.java
+++ b/src/jmri/enginedriver/ConsistLightsEdit.java
@@ -48,6 +48,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
+import android.content.Context;
+
 import jmri.enginedriver.Consist;
 import jmri.enginedriver.Consist.ConLoco;
 import jmri.enginedriver.R;
@@ -178,6 +180,7 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_ConsistLightsEdit)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.consist_lights);
         //put pointer to this activity's handler in main app's shared variable
@@ -376,5 +379,10 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
 
     private void disconnect() {
         this.finish();
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 }

--- a/src/jmri/enginedriver/LocaleHelper.java
+++ b/src/jmri/enginedriver/LocaleHelper.java
@@ -1,0 +1,112 @@
+/*
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package jmri.enginedriver;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.preference.PreferenceManager;
+
+import java.util.Locale;
+
+/*
+This class is used to change the application locale.
+It is not designed to allow change on the fly.  The app needs to be re-started.
+
+Modified from code by gunhansancar on 07/10/15.
+*/
+
+// TODO: Fix the Locale change code so that in changes the Country as well as the Language.  For unknown reasons it ignores the Country.
+
+public class LocaleHelper {
+
+    private static final String SELECTED_LANGUAGE = "Locale.Helper.Selected.Language";
+    public static String languageCountry = "";  // will contain the default language at launch
+    private static String prefLocale ="";
+
+    // needs to be called from each activity other than mainapp
+    public static Context onAttach(Context context) {
+        String lang = getLanguagePreference(context);
+        return setLocale(context, lang);
+    }
+
+    // called once from the mainapp activity
+    public static Context onAttach(Context context, String defaultLanguage) {
+        if (languageCountry.equals("")) {
+            languageCountry = defaultLanguage; // set the inital value
+        }
+        String lang = getLanguagePreference(context);
+        return setLocale(context, lang);
+    }
+
+    public static Context setLocale(Context context, String language) {
+
+        if (!language.toUpperCase().equals(languageCountry.toUpperCase())) {   // if it as the same as the language at launch do nothing
+            if (Build.VERSION.SDK_INT >= 17) {
+                return updateResources(context, language);
+            }
+            return updateResourcesLegacy(context, language);
+        } else {
+            return context;
+        }
+    }
+
+    private static String getLanguagePreference(Context context) {
+        SharedPreferences prefs;
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefLocale = prefs.getString("prefLocale", context.getResources().getString(R.string.prefLocaleDefaultValue));
+
+        if (prefLocale.equals("Default")) {
+            prefLocale = languageCountry;
+        }
+        return prefLocale;
+    }
+
+    @TargetApi(17)
+    private static Context updateResources(Context context, String language) {
+
+        Locale locale = new Locale(language);
+        Locale.setDefault(locale);
+
+        Configuration configuration = context.getResources().getConfiguration();
+        configuration.setLocale(locale);
+        configuration.setLayoutDirection(locale);
+
+        return context.createConfigurationContext(configuration);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Context updateResourcesLegacy(Context context, String language) {
+
+        Locale locale = new Locale(language);
+        Locale.setDefault(locale);
+
+        Resources resources = context.getResources();
+
+        Configuration configuration = resources.getConfiguration();
+        configuration.locale = locale;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            configuration.setLayoutDirection(locale);
+        }
+        resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+
+        return context;
+    }
+}

--- a/src/jmri/enginedriver/about_page.java
+++ b/src/jmri/enginedriver/about_page.java
@@ -43,6 +43,7 @@ public class about_page extends Activity {
         mainapp = (threaded_application) this.getApplication();
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_about)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.about_page);
 

--- a/src/jmri/enginedriver/connection_activity.java
+++ b/src/jmri/enginedriver/connection_activity.java
@@ -63,6 +63,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.widget.AdapterView;
 
+import android.content.Context;
+
 public class connection_activity extends Activity {
     private ArrayList<HashMap<String, String>> connections_list;
     private ArrayList<HashMap<String, String>> discovery_list;
@@ -313,6 +315,7 @@ public class connection_activity extends Activity {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_connect)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.connection);
 
@@ -697,4 +700,9 @@ public class connection_activity extends Activity {
        }
        return res;
    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/function_settings.java
+++ b/src/jmri/enginedriver/function_settings.java
@@ -82,6 +82,7 @@ public class function_settings extends Activity {
         //setTitleToIncludeThrotName();
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_functions)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.function_settings);
         orientationChange = false;
@@ -461,4 +462,9 @@ public class function_settings extends Activity {
         }
     }
 
+    // needed in case the langauge was changed from the default
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/gamepad_test.java
+++ b/src/jmri/enginedriver/gamepad_test.java
@@ -803,4 +803,9 @@ public class gamepad_test extends Activity implements OnGestureListener {
     private void disconnect() {
         this.finish();
     }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/power_control.java
+++ b/src/jmri/enginedriver/power_control.java
@@ -19,6 +19,7 @@ package jmri.enginedriver;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
@@ -130,6 +131,7 @@ public class power_control extends Activity {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_power_control)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.power_control);
 
@@ -221,4 +223,9 @@ public class power_control extends Activity {
         this.finish();
     }
 
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -47,6 +47,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import android.content.Context;
+
 import eu.esu.mobilecontrol2.sdk.MobileControl2;
 
 public class preferences extends PreferenceActivity implements OnSharedPreferenceChangeListener {
@@ -93,6 +95,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         mainapp = (threaded_application) getApplication();
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_preferences)); // needed in case the langauge was changed from the default
 
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.preferences);
@@ -325,8 +328,22 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                 limitIntPrefValue(sharedPreferences, key, 0, 29, "29");
                 mainapp.set_default_function_labels(false);
                 break;
-
+            case "prefLocale":
+                sharedPreferences.edit().putString("prefLeftDirectionButtons", "").commit();
+                sharedPreferences.edit().putString("prefRightDirectionButtons", "").commit();
+                forceRestartApp();
+                break;
         }
+    }
+
+    void forceRestartApp() {
+        // Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastPreferencesLocaleChange), Toast.LENGTH_LONG).show(); // app dies before this shows
+
+        Intent intent = getBaseContext().getPackageManager().getLaunchIntentForPackage(getBaseContext().getPackageName());
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(intent);
+        finish();
+        Runtime.getRuntime().exit(0); // really force the kill
     }
 
     void start_gamepad_test_activity() {
@@ -665,4 +682,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
     }
 
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/reconnect_status.java
+++ b/src/jmri/enginedriver/reconnect_status.java
@@ -19,6 +19,7 @@ package jmri.enginedriver;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
@@ -113,6 +114,7 @@ public class reconnect_status extends Activity {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_reconnect_status)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.reconnect_page);
 
@@ -174,4 +176,9 @@ public class reconnect_status extends Activity {
         this.finish();
     }
 
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/routes.java
+++ b/src/jmri/enginedriver/routes.java
@@ -300,6 +300,7 @@ public class routes extends Activity implements OnGestureListener {
 //      setTitleToIncludeThrotName();
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_routes)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.routes);
         //put pointer to this activity's handler in main app's shared variable
@@ -598,4 +599,8 @@ public class routes extends Activity implements OnGestureListener {
         this.finish();
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/select_loco.java
+++ b/src/jmri/enginedriver/select_loco.java
@@ -589,6 +589,7 @@ public class select_loco extends Activity {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_select_loco)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.select_loco);
 
@@ -907,5 +908,10 @@ public class select_loco extends Activity {
 
             return view;
         }
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 }

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -2543,6 +2543,8 @@ public class threaded_application extends Application {
             activity.setTheme(R.style.app_theme_outline);
         } else if (prefTheme.equals("Ultra")) {
             activity.setTheme(R.style.app_theme_ultra);
+        } else {
+            activity.setTheme(R.style.app_theme);
         }
     }
 

--- a/src/jmri/enginedriver/threaded_application.java
+++ b/src/jmri/enginedriver/threaded_application.java
@@ -27,11 +27,13 @@ import android.app.AlertDialog;
 import android.app.Application;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -83,6 +85,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;
@@ -95,6 +98,8 @@ import jmri.enginedriver.Consist.ConLoco;
 import jmri.enginedriver.threaded_application.comm_thread.comm_handler;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterLoader;
+
+import static android.content.pm.PackageManager.GET_META_DATA;
 
 //The application will start up a thread that will handle network communication in order to ensure that the UI is never blocked.
 //This thread will only act upon messages sent to it. The network communication needs to persist across activities, so that is why
@@ -190,6 +195,8 @@ public class threaded_application extends Application {
     public boolean firstCreate = true;
 
     public String connectedHostName = "";
+
+    public String languageCountry = "en";
 
     class comm_thread extends Thread {
         JmDNS jmdns = null;
@@ -2627,6 +2634,16 @@ public class threaded_application extends Application {
             buttonPanelContainer.addView(positiveButton, negativeButtonIndex);
         }
     }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        languageCountry = Locale.getDefault().getLanguage();
+        if (!Locale.getDefault().getCountry().equals("")) {
+            languageCountry = languageCountry + "_" + Locale.getDefault().getCountry();
+        }
+        super.attachBaseContext(LocaleHelper.onAttach(base, languageCountry));
+    }
+
 }
 
 

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -3718,6 +3718,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_throttle)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.throttle);
 
@@ -5387,4 +5388,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         alert.show();
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }

--- a/src/jmri/enginedriver/turnouts.java
+++ b/src/jmri/enginedriver/turnouts.java
@@ -324,6 +324,7 @@ public class turnouts extends Activity implements OnGestureListener {
         }
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_turnouts)); // needed in case the langauge was changed from the default
 
         setContentView(R.layout.turnouts);
 
@@ -650,5 +651,11 @@ public class turnouts extends Activity implements OnGestureListener {
 
     private void disconnect() {
         this.finish();
+    }
+
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 }

--- a/src/jmri/enginedriver/web_activity.java
+++ b/src/jmri/enginedriver/web_activity.java
@@ -139,6 +139,7 @@ public class web_activity extends Activity {
         setContentView(R.layout.web_activity);
 
         mainapp.applyTheme(this);
+        setTitle(getApplicationContext().getResources().getString(R.string.app_name_web)); // needed in case the langauge was changed from the default
 
         webView = (WebView) findViewById(R.id.webview);
         String databasePath = webView.getContext().getDir("databases", Context.MODE_PRIVATE).getPath();
@@ -405,4 +406,8 @@ public class web_activity extends Activity {
         firstUrl = null;
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
 }


### PR DESCRIPTION
NEW - Change language from inside the App

NEW - Load transparent Splash Screen  …
Load a transparent splash screen on start, before loading the chosen theme.
Stops the checkerplate bitmap from momentarily being displayed when you are using any of the non-default themes.