### PR TITLE
FIX  - accelerometer in the device to install from the Play Store 

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,7 +23,7 @@
         tools:ignore="OldTargetApi" >
     </uses-sdk>
     <uses-permission android:name="android.permission.READ_LOGS" />
-    <uses-feature android:name="android.hardware.sensor.accelerometer" />
+    <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="false" />
     <application
         android:name="jmri.enginedriver.threaded_application"
         android:allowBackup="true"

--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -10,6 +10,7 @@
 <p>Engine Driver version 2.19 includes:<br/>
 <ul>
     <li>option to change languages from the preferences screen</li>
+    <li>no longer requires an accelerometer in the device to install from the Play Store (reported bug)</li>
 </ul>
 </p>
 <br/><em><a

--- a/bin/AndroidManifest.xml
+++ b/bin/AndroidManifest.xml
@@ -22,7 +22,7 @@
         tools:ignore="OldTargetApi" >
     </uses-sdk>
     <uses-permission android:name="android.permission.READ_LOGS" />
-    <uses-feature android:name="android.hardware.sensor.accelerometer" />
+    <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="false" />
     <application
         android:name="jmri.enginedriver.threaded_application"
         android:allowBackup="true"


### PR DESCRIPTION
no longer requires an accelerometer in the device to install from the Play Store (reported bug)