### PR TITLE
FIX - crash when swtiching throttle types on old versions of Android

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -238,7 +238,7 @@
     <string name="prefNumOfThrottlesDefault">Due</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipo di schermo dell\'acceleratore</string>
-    <string name="prefThrottleScreenTypeSummary">Quale tipo di schermo del throttle usare.  \nATTENZIONE! Engine Driver si riavvierà immediatamente.</string>
+    <string name="prefThrottleScreenTypeSummary">Quale tipo di schermo del throttle usare.  \nATTENZIONE! Engine Driver si riavvierà immediatamente.\n(Disponibile solo quando non attualmente connesso.)</string>
 
     <string name="prefMaximumThrottleTitle">Percentuale massima di controllo</string>
 

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -238,7 +238,7 @@
     <string name="prefNumOfThrottlesDefault">Dois</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipo de tela do acelerador</string>
-    <string name="prefThrottleScreenTypeSummary">Que tipo de tela de acelerador usar. \ nATENÇÃO! Engine Driver irá reiniciar imediatamente.</string>
+    <string name="prefThrottleScreenTypeSummary">Que tipo de tela de acelerador usar. \ nATENÇÃO! Engine Driver irá reiniciar imediatamente.\n(Somente disponível quando não atualmente conectado.)</string>
 
     <string name="prefMaximumThrottleTitle">Porcentagem máxima Controle</string>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -274,7 +274,7 @@
     <string name="prefNumOfThrottlesDefault">Two</string>
 
     <string name="prefThrottleScreenTypeTitle">Throttle Screen Type</string>
-    <string name="prefThrottleScreenTypeSummary">Which type of throttle screen to use.\nWARNING! Engine Driver will restart immediately!</string>
+    <string name="prefThrottleScreenTypeSummary">Which type of throttle screen to use.\nWARNING! Engine Driver will restart immediately!\n(Only available when not currently connected.)</string>
     <string name="prefThrottleScreenTypeDefault">Default</string>
 
     <string name="prefMaximumThrottleTitle">Maximum Throttle Percentage</string>

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -136,7 +136,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
         sharedPreferences.edit().putBoolean("prefGamepadTestNow", false).commit();  //reset the preference
 
         if (mainapp.androidVersion < mainapp.minActivatedButtonsVersion) {
-            enableDisablePreference("prefSelectedLocoIndicator",false);
+            enableDisablePreference("prefSelectedLocoIndicator", false);
         }
 
         deviceId = Settings.System.getString(getContentResolver(), Settings.System.ANDROID_ID);
@@ -144,13 +144,18 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         String currentValue = sharedPreferences.getString("prefTtsWhen", "");
         if (currentValue.equals("None")) {
-            enableDisablePreference("prefTtsThrottleResponse",false);
+            enableDisablePreference("prefTtsThrottleResponse", false);
             enableDisablePreference("prefTtsGamepadTest", false);
-            enableDisablePreference("prefTtsGamepadTestComplete",false);
+            enableDisablePreference("prefTtsGamepadTestComplete", false);
         }
 
         prefThrottleScreenTypeOriginal = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         showHideThrottleTypePreferences();
+        if (mainapp.connectedHostName.equals("")) { // option is only available when there is no curent connection
+            enableDisablePreference("prefThrottleScreenType", true);
+        } else {
+            enableDisablePreference("prefThrottleScreenType", false);
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -355,6 +360,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         Intent intent = getBaseContext().getPackageManager().getLaunchIntentForPackage(getBaseContext().getPackageName());
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
         Runtime.getRuntime().exit(0); // really force the kill


### PR DESCRIPTION
I can't resolve the timing problem of the create and destroy on preference change, so I have restricted when the Throttle Screen Type can be selected to just the Connection Screen.