### PR TITLE
FIX - Crash when holding Gamepad button on Exit

### DIFF
--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -151,11 +151,11 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         prefThrottleScreenTypeOriginal = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         showHideThrottleTypePreferences();
-/*        if (mainapp.connectedHostName.equals("")) { // option is only available when there is no curent connection
+        if (mainapp.connectedHostName.equals("")) { // option is only available when there is no curent connection
             enableDisablePreference("prefThrottleScreenType", true);
         } else {
             enableDisablePreference("prefThrottleScreenType", false);
-        } */
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/src/jmri/enginedriver/preferences.java
+++ b/src/jmri/enginedriver/preferences.java
@@ -151,11 +151,11 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         prefThrottleScreenTypeOriginal = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         showHideThrottleTypePreferences();
-        if (mainapp.connectedHostName.equals("")) { // option is only available when there is no curent connection
+/*        if (mainapp.connectedHostName.equals("")) { // option is only available when there is no curent connection
             enableDisablePreference("prefThrottleScreenType", true);
         } else {
             enableDisablePreference("prefThrottleScreenType", false);
-        }
+        } */
     }
 
     @SuppressWarnings("deprecation")

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -124,6 +124,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     protected threaded_application mainapp; // hold pointer to mainapp
     protected SharedPreferences prefs;
 
+    protected boolean appIsFinishing = false;
+
     protected static final int MAX_SCREEN_THROTTLES = 3;
     // activity codes
     public static final int ACTIVITY_PREFS = 0;
@@ -2558,10 +2560,13 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     }
 
     void GamepadFeedbackSound(boolean invalidAction) {
+        if (appIsFinishing) { return;}
+
         if (invalidAction)
             tg.startTone(ToneGenerator.TONE_PROP_NACK);
         else
             tg.startTone(ToneGenerator.TONE_PROP_BEEP);
+
     }
 
     void GamepadFeedbackSoundStop() {
@@ -2585,6 +2590,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
 
         @Override
         public void run() {
+            if (appIsFinishing) { return;}
+
             if (mGamepadAutoIncrement) {
                 GamepadIncrementSpeed(whichThrottle);
                 gamepadRepeatUpdateHandler.postDelayed(new GamepadRptUpdater(whichThrottle), REP_DELAY);
@@ -3401,6 +3408,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
 
         if (mainapp.isForcingFinish()) { // expedite
+            appIsFinishing = true;
             return;
         }
 
@@ -3819,6 +3827,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         super.onResume();
         mainapp.removeNotification();
         if (mainapp.isForcingFinish()) { // expedite
+            appIsFinishing = true;
             this.finish();
             overridePendingTransition(0, 0);
             return;
@@ -4484,6 +4493,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         }
 
         webView.stopLoading();
+        appIsFinishing = true;
         this.finish(); // end this activity
         overridePendingTransition(0, 0);
     }


### PR DESCRIPTION
Solves one crash when you hold a gamepad button down at the same time you press the back button and exit the app.