### PR TITLE
Change Stop button long-press behaviour to act on timeout

### DIFF
--- a/assets/about_page.html
+++ b/assets/about_page.html
@@ -23,6 +23,7 @@
     <li>Prevent crashes reported to Play Store</li>
     <li>highlight loco number when the select button is disabled</li>
     <li>German translation by Daniel Sieber</li>
+    <li>ESU MC2 Stop button now registers long-press via a timer rather than on release</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -3,6 +3,7 @@
  * monochrome icon for the notification bar
  * handle MRC sending multiple VN messages
  * prevent crashes reported to Play Store
+ * ESU MC2 Stop button long-press behaviour modified to act on timeout rather than release
 **Version 2.19
  * New flashlight button option for devices with on-board camera flash. Needs Camera permission for this.
  * optional 'simple' throttle screen allowing up to six throttles with vertical speed sliders but no function buttons

--- a/src/jmri/enginedriver/throttle.java
+++ b/src/jmri/enginedriver/throttle.java
@@ -34,6 +34,7 @@ import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.os.Handler;
 import android.os.Message;
 import android.os.SystemClock;
@@ -2697,6 +2698,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         private long timePressed;
         private boolean wasLongPress = false;
         private int delay;
+        private CountDownTimer buttonTimer;
 
         @Override
         public void onStopButtonDown() {
@@ -2721,17 +2723,39 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             // Read current stop button delay pref value
             delay = preferences.getIntPrefValue(prefs,"prefEsuMc2StopButtonDelay",
                     getApplicationContext().getResources().getString(R.string.prefEsuMc2StopButtonDelayDefaultValue));
+            buttonTimer = new CountDownTimer(delay, delay) {
+                @Override
+                public void onTick(long l) {
+                    // do nothing...
+                }
+
+                @Override
+                public void onFinish() {
+                    doStopButtonUp(true);
+                }
+            };
+            buttonTimer.start();
         }
 
         @Override
         public void onStopButtonUp() {
+            buttonTimer.cancel();
+            doStopButtonUp(false);
+        }
+
+        private void doStopButtonUp(boolean fromTimer) {
+            buttonTimer.cancel();
             if (!getConsist(whichVolume).isActive()) {
                 Log.d("Engine_Driver", "ESU_MCII: Stop button up for inactive throttle " + whichVolume);
                 return;
             }
-            Log.d("Engine_Driver", "ESU_MCII: Stop button up for throttle " + whichVolume);
+            if (fromTimer) {
+                Log.d("Engine_Driver", "ESU_MCII: Stop button timer finished for throttle " + whichVolume);
+            } else {
+                Log.d("Engine_Driver", "ESU_MCII: Stop button up for throttle " + whichVolume);
+            }
             if (isEsuMc2Stopped) {
-                if (System.currentTimeMillis() - timePressed > delay) {
+                if (fromTimer || System.currentTimeMillis() - timePressed > delay) {
                     // It's a long initial press so record this
                     wasLongPress = true;
                     Log.d("Engine_Driver", "ESU_MCII: Stop button press was long - long flash Red LED");


### PR DESCRIPTION
This modifies the behaviour of the ESU MCII on-device Stop button to react to a long-press via a timeout as opposed to release.

This means that we no longer wait for the release of the button to check if the configured threshold to stop all throttles has passed, rather act even while the button is still held down.

Short presses (i.e. button release prior to threshold) are still honoured and react accordingly.

Verified using ESU MCII with demo server.