### PR TITLE
FIX - only set function button state if the message relates to lead loco

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
@@ -58,6 +58,7 @@ public class Loco {
         this.confirmed = false;
         this.rosterName = null;
         this.isFromRoster = false;
+        this.functionLabels = null;
     }
 
     public Loco(Loco l) {
@@ -66,6 +67,7 @@ public class Loco {
         this.rosterName = l.rosterName;
         this.confirmed = l.confirmed;
         this.isFromRoster = l.isFromRoster;
+        this.functionLabels = l.functionLabels;
     }
 
     public boolean isConfirmed() {
@@ -135,7 +137,7 @@ public class Loco {
 
     public void setFunctionLabelDefaults(threaded_application mainapp, Integer whichThrottle) {
         if (mainapp.function_labels != null) {
-            functionLabels = new LinkedHashMap<>(mainapp.function_labels[whichThrottle]);
+            functionLabels = new LinkedHashMap<>(mainapp.function_labels_default);
         }
     }
 /**
@@ -151,9 +153,9 @@ public class Loco {
 **/
      public Integer getFunctionNumberFromLabel(String lab) {
         Integer functionNumber = -1;
-         if (!lab.equals("")) {
-             for (int i = 0; i < functionLabels.size(); i++) {
-                 if (functionLabels != null) {
+        if (!lab.equals("")) {
+             if (functionLabels != null) {
+                 for (int i = 0; i < functionLabels.size(); i++) {
                      if (functionLabels.get(i) != null) {
                          if (functionLabels.get(i).equals(lab)) {
                              functionNumber = i;
@@ -188,8 +190,8 @@ public class Loco {
             || ( ( Rule.equals(CONSIST_FUNCTION_ACTION_TRAIL))
                     && (isTrail) ) ) {
                     // cycle through this locos function labels to find the partly matching string
-                for (int i = 0; i < functionLabels.size(); i++) {
-                    if (functionLabels != null) {
+                if (functionLabels != null) {
+                    for (int i = 0; i < functionLabels.size(); i++) {
                         if (functionLabels.get(i) != null) {
                             if (functionLabels.get(i).toLowerCase().contains(prefConsistFollowStrings.get(matchingRule).toLowerCase())) {
                                 functionList.add(i);

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -737,7 +737,13 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                                     } else if (com3 == 'F') {
                                         try {
                                             int function = Integer.valueOf(ls[1].substring(2));
-                                            set_function_state(whichThrottle, function);
+
+                                            String loco = ls[0].substring(3);
+                                            Consist con = mainapp.consists[whichThrottle];
+                                            if ( (prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_ORIGINAL))
+                                                    || (loco.equals(con.getLeadAddr())) ) { //if using the 'complex' follow function rules, only send it to the lead loco
+                                                set_function_state(whichThrottle, function);
+                                            }
                                         } catch (Exception ignored) {
                                         }
                                     } else if (com3 == 's') {

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -3277,7 +3277,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
 
 
         private void getFunctionNumber(Consist con) {
-            if (functionNumber==-1) { // find the function number for this if we don't aready have it
+            if (functionNumber==-1) { // find the function number for this if we don't already have it
                 for (Consist.ConLoco l : con.getLocos()) {
                     if (l.getAddress().equals(con.getLeadAddr())) {
                         functionNumber=l.getFunctionNumberFromLabel(lab);

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -769,7 +769,7 @@
         <item>Do Nothing</item>
         <item>Lead Loco - Same Function number</item>
         <item>Lead+Trail Locos - Same Function number</item>
-        <item>AAll Locos - Same Function number</item>
+        <item>All Locos - Same Function number</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
resolves a problem where a function button is pressed on a loco that is also part of a consist elsewhere, or where a function button is also matched, using the new rules, on a different function number on a loco in the same consist.