### PR TITLE
Catch exception when running on hardware with flash-less camera

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/util/Flashlight.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/Flashlight.java
@@ -181,6 +181,9 @@ public abstract class Flashlight {
                 Log.e("Engine_Driver", "Error switching on flashlight: " + ex.getMessage());
                 Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOnFailed), Toast.LENGTH_LONG).show();
                 return false;
+            } catch (IllegalArgumentException ex) {
+                Log.e("Engine_Driver", "Problem switching on flashlight:" + ex.getMessage());
+                return false;
             }
         }
 
@@ -192,6 +195,8 @@ public abstract class Flashlight {
             } catch (CameraAccessException ex) {
                 Log.e("Engine_Driver", "Error switching off flashlight: " + ex.getMessage());
                 Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOffFailed), Toast.LENGTH_LONG).show();
+            } catch (IllegalArgumentException ex) {
+                Log.e("Engine_Driver", "Problem switching off flashlight:" + ex.getMessage());
             }
         }
     }


### PR DESCRIPTION
This caters for running on hardware that has a camera, but no flash unit.

Until a cleaner way is found of identifying this situation, simply catches the exception otherwise thrown.