### PR TITLE
FIX - Failed resolution of: Lorg/apache/http/impl/client/DefaultHttpC…

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:theme="@style/app_splash"
         android:usesCleartextTraffic="true"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <activity
             android:name=".intro_activity"
             android:label="@string/app_name_intro"


### PR DESCRIPTION
…lient;

     Caused by: java.lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/impl/client/DefaultHttpClient;
        at jmri.enginedriver.ImageDownloader.downloadBitmap(ImageDownloader.java:166)
        at jmri.enginedriver.ImageDownloader$BitmapDownloaderTask.doInBackground(ImageDownloader.java:250)
        at jmri.enginedriver.ImageDownloader$BitmapDownloaderTask.doInBackground(ImageDownloader.java:236)