### PR TITLE
avoid concurrentmodification

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/Consist.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/Consist.java
@@ -17,10 +17,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -63,14 +62,14 @@ import java.util.Set;
 
     }
 
-    private LinkedHashMap<String, ConLoco> con;            //locos assigned to this consist (i.e. this throttle)
+    private Map<String, ConLoco> con;                   //locos assigned to this consist (i.e. this throttle)
     private String leadAddr;                            //address of lead loco
     //TODO: eliminate stored leadAddr and create on the fly?
     private String trailAddr;                            //address of trail loco
 
 
     public Consist() {
-        con = new LinkedHashMap<>();
+        con = Collections.synchronizedMap(new LinkedHashMap<String, ConLoco>());
         leadAddr = "";
         trailAddr = "";
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -19,6 +19,7 @@ package jmri.enginedriver;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -47,8 +48,6 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-
-import android.content.Context;
 
 import jmri.enginedriver.Consist.ConLoco;
 
@@ -84,7 +83,7 @@ public class ConsistEdit extends Activity implements OnGestureListener {
         //clear and rebuild
         consistObjList.clear();
         int pos = 0;
-        Collection<ConLoco> cgl = consist.getLocos(); //copy to prevent concurrentmodification
+        Collection<ConLoco> cgl = consist.getLocos(); //copy from synchronized map to avoid holding it while iterating
         for (ConLoco l : cgl) {
             if (l.isConfirmed()) {
                 consistObjList.add(l);

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
@@ -19,6 +19,7 @@ package jmri.enginedriver;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -47,15 +48,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
-import android.content.Context;
-
-import jmri.enginedriver.Consist;
 import jmri.enginedriver.Consist.ConLoco;
-import jmri.enginedriver.R;
-import jmri.enginedriver.connection_activity;
-import jmri.enginedriver.message_type;
-import jmri.enginedriver.reconnect_status;
-import jmri.enginedriver.threaded_application;
 
 public class ConsistLightsEdit extends Activity implements OnGestureListener {
     public static final int LIGHT_OFF = 0;
@@ -85,7 +78,7 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
         //clear and rebuild
         consistObjList.clear();
         int pos = 0;
-        Collection<ConLoco> cgl = consist.getLocos(); //copy to prevent concurrentmodification
+        Collection<ConLoco> cgl = consist.getLocos(); //copy from synchronized map to avoid holding it while iterating
         for (ConLoco l : cgl) {
             if (l.isConfirmed()) {
                 consistObjList.add(l);

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -143,7 +143,7 @@ public class select_loco extends Activity {
 
             //put roster entries into screen list
             if (mainapp.roster_entries != null) {
-                ArrayList<String> rns = new ArrayList<>(mainapp.roster_entries.keySet());  //copy to prevent concurrentmodification
+                ArrayList<String> rns = new ArrayList<>(mainapp.roster_entries.keySet());  //copy from synchronized map to avoid holding it while iterating
                 for (String rostername : rns) {
                     if ((prefRosterFilter.length() == 0) || (rostername.toUpperCase().contains(prefRosterFilter.toUpperCase()))) {
                         // put key and values into temp hashmap
@@ -173,7 +173,7 @@ public class select_loco extends Activity {
 
             //add consist entries to screen list
             if (mainapp.consist_entries != null) {
-                ArrayList<String> ces = new ArrayList<>(mainapp.consist_entries.keySet());  //copy to prevent concurrentmodificationexception
+                ArrayList<String> ces = new ArrayList<>(mainapp.consist_entries.keySet());  //copy from synchronized map to avoid holding it while iterating
                 for (String consist_addr : ces) {
                     // put key and values into temp hashmap
                     HashMap<String, String> hm = new HashMap<>();

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -81,11 +81,12 @@ import java.net.UnknownHostException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 
 import javax.jmdns.JmDNS;
@@ -129,8 +130,8 @@ public class threaded_application extends Application {
     String[] rt_user_names;
     String[] rt_states;
     HashMap<String, String> rt_state_names; //if not set, routes are not allowed
-    LinkedHashMap<String, String> roster_entries;  //roster sent by WiThrottle
-    LinkedHashMap<String, String> consist_entries;
+    Map<String, String> roster_entries;  //roster sent by WiThrottle
+    Map<String, String> consist_entries;
     private static DownloadRosterTask dlRosterTask = null;
     private static DownloadMetaTask dlMetadataTask = null;
     HashMap<String, RosterEntry> roster;  //roster entries retrieved from /roster/?format=xml (null if not retrieved)
@@ -1044,7 +1045,8 @@ public class threaded_application extends Application {
         //  RL2]\[NS2591}|{2591}|{L]\[NS4805}|{4805}|{L
         private void process_roster_list(String response_str) {
             //clear the global variable
-            roster_entries = new LinkedHashMap<>();
+              roster_entries = Collections.synchronizedMap(new LinkedHashMap<String,String>());
+              //todo   RDB why don't we just clear the existing map with roster_entries.clear() instead of disposing and creating a new instance?
 
             String[] ta = splitByString(response_str, "]\\[");  //initial separation
             //initialize app arrays (skipping first)
@@ -2120,9 +2122,9 @@ public class threaded_application extends Application {
             function_states[i] = new boolean[32];        // also allocated in onCreate() ???
         }
 
-        consist_entries = new LinkedHashMap<>();
+        consist_entries = Collections.synchronizedMap(new LinkedHashMap<String,String>());
         roster = null;
-        roster_entries = new LinkedHashMap<>();
+        roster_entries = Collections.synchronizedMap(new LinkedHashMap<String,String>());
         metadata = null;
         doFinish = false;
         turnouts_list_position = 0;


### PR DESCRIPTION
Change roster_entries, consist_entries and ConLoco.con from
LinkedHashMap to Collections.synchronizedMap(LinkedHashMap) to avoid
concurrency issues when copying the maps for reading.  Note that if this
works it would then be good to test whether we can eliminate the copying
and just do the reading on the original instances of the maps.