### PR TITLE
Recents - Swipe remove, long press rename, import/export

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/util/SwipeDetector.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/SwipeDetector.java
@@ -1,0 +1,86 @@
+// by OMAK
+// stackoverflow.com/questions/17520750/list-view-item-swipe-left-and-swipe-right
+
+package jmri.enginedriver.util;
+
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+
+public class SwipeDetector implements View.OnTouchListener {
+
+    public static enum Action {
+        LR, // Left to Right
+        RL, // Right to Left
+        TB, // Top to bottom
+        BT, // Bottom to Top
+        None // when no action was detected
+    }
+
+    private static final String logTag = "SwipeDetector";
+    private static final int MIN_DISTANCE = 100;
+    private float downX, downY, upX, upY;
+    private Action mSwipeDetected = Action.None;
+
+    public boolean swipeDetected() {
+        return mSwipeDetected != Action.None;
+    }
+
+    public Action getAction() {
+        return mSwipeDetected;
+    }
+
+    public boolean onTouch(View v, MotionEvent event) {
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN: {
+                downX = event.getX();
+                downY = event.getY();
+                mSwipeDetected = Action.None;
+                return false; // allow other events like Click to be processed
+            }
+            case MotionEvent.ACTION_MOVE: {
+                upX = event.getX();
+                upY = event.getY();
+
+                float deltaX = downX - upX;
+                float deltaY = downY - upY;
+
+                // horizontal swipe detection
+                if (Math.abs(deltaX) > MIN_DISTANCE) {
+                    // left or right
+                    if (deltaX < 0) {
+                        Log.d("Engine_Driver","SwipeDetector: Swipe Left to Right");
+//                        Logger.show(Log.INFO,logTag, "Swipe Left to Right");
+                        mSwipeDetected = Action.LR;
+                        return true;
+                    }
+                    if (deltaX > 0) {
+                        Log.d("Engine_Driver","SwipeDetector: Swipe Right to Left");
+//                        Logger.show(Log.INFO,logTag, "Swipe Right to Left");
+                        mSwipeDetected = Action.RL;
+                        return true;
+                    }
+                } else
+
+                    // vertical swipe detection
+                    if (Math.abs(deltaY) > MIN_DISTANCE) {
+                        // top or down
+                        if (deltaY < 0) {
+                            Log.d("Engine_Driver","SwipeDetector: Swipe Top to Bottom");
+//                            Logger.show(Log.INFO,logTag, "Swipe Top to Bottom");
+                            mSwipeDetected = Action.TB;
+                            return false;
+                        }
+                        if (deltaY > 0) {
+                            Log.d("Engine_Driver","SwipeDetector: Swipe Bottom to Top");
+//                            Logger.show(Log.INFO,logTag, "Swipe Bottom to Top");
+                            mSwipeDetected = Action.BT;
+                            return false;
+                        }
+                    }
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/EngineDriver/src/main/res/layout/edit_recent_name.xml
+++ b/EngineDriver/src/main/res/layout/edit_recent_name.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="10dp"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/editRecentName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text" />
+
+</LinearLayout>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -737,9 +737,18 @@
     <string name="toastSelectLocoConfirmClear">Confirm that you want remove all the Recent Locomotives by pressing the \'Clear List\' button AGAIN.</string>
     <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists by pressing the \'Clear List\' button AGAIN.</string>
     <string name="toastNumThrottles">Chosen Throttle Screen Type does not support that many throttles. Reducing to %1$s.</string>
+    <string name="toastRecentsHelp">Touch to select.\nLong press to rename.\nSwipe Left to Right to remove an entry.</string>
+    <string name="toastRecentConsistsHelp">Touch to select.\nLong press to rename.\nSwipe Left to Right to remove an entry.</string>
+    <string name="toastRosterHelp">Touch to Select.\nLong press for details.</string>
 
     <!--    Toast messages for the Log Viewer Activity -->
     <string name="toastSaveLogFile">Logging Started in file %1$s. Logging will continue until you exit the Engine Driver app.</string>
+
+    <string name="RecentsNameEditTitle">Recent Loco Name</string>
+    <string name="RecentsNameEditText">Enter a name for the Loco</string>
+
+    <string name="RecentConsistsNameEditTitle">Recent Consist Name</string>
+    <string name="RecentConsistsNameEditText">Enter a name for the Consist</string>
 
     <string name="prefTtsTitle">Voice Response Preferences</string>
     <string name="prefTtsSummary">Options to speak key events</string>


### PR DESCRIPTION
For Recent Locos and Recent Consists
- Swipe L-R now used to remove from list
- Long press lets you rename the recent consist
- Long press lets you rename the recent loco
- Help Toast message to explain each
Import/Export saves/restores the consists
Import/Export saves/restores the loco names