### PR TITLE
Rework of Recent and Recent Consists

### DIFF
--- a/EngineDriver/src/main/assets/about_page-ca.html
+++ b/EngineDriver/src/main/assets/about_page-ca.html
@@ -22,7 +22,7 @@
     <li>Reproducir sonido y vibrar cuando se desconecta el dispositivo</li>
     <li>Recordeu recents Consta i restaurar-los des de la pantalla de selecció de boig</li>
     <li>Afegit botó de tancament i la imatge plantilla de diàleg de detalls roster</li>
-    <li>correcció d'errors, on bojos seleccionats per DCC o Direcció Recents no actualitzar el valor Operat Últim</li>
+    <li>La represa de l'ús del nom de llista quan s'introdueix una adreça</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-cs.html
+++ b/EngineDriver/src/main/assets/about_page-cs.html
@@ -21,7 +21,7 @@
     <li>Přehrát zvuk a vibrovat, když odpojení zařízení</li>
     <li>Pamatovat Nedávná Skládá a obnovit je z obrazovky výběru lokomotivy</li>
     <li>Přidalo tlačítko a seznam obraz dialogu s podrobnostmi soupiska</li>
-    <li>Fix chyba, kdy lokomotivy vybrané DCC adresa nebo Recents nebude aktualizovat posledního použití hodnoty</li>
+    <li>Přepracování užívání názvu roster, když je zadána adresa</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
+++ b/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
@@ -22,7 +22,7 @@
     <li>Wiedergabe starten und vibrieren, wenn das Gerät die Verbindung trennt</li>
     <li>Denken Sie daran, Recent besteht und diese wiederherstellen, aus der Auswahl Lok Bildschirm</li>
     <li>Hinzugefügt Schließen-Schaltfläche und Roster Bild Roster Details Dialog</li>
-    <li>Fix: Fehler, durch DCC-Adresse oder Recents ausgewählt locos nicht den letzten Operated Wert aktualisieren würde</li>
+    <li>Nacharbeits Roster Name Verwendung, wenn eine Adresse eingegeben wird</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-de.html
+++ b/EngineDriver/src/main/assets/about_page-de.html
@@ -22,7 +22,7 @@
     <li>Wiedergabe starten und vibrieren, wenn das Gerät die Verbindung trennt</li>
     <li>Denken Sie daran, Recent besteht und diese wiederherstellen, aus der Auswahl Lok Bildschirm</li>
     <li>Hinzugefügt Schließen-Schaltfläche und Roster Bild Roster Details Dialog</li>
-    <li>Fix: Fehler, durch DCC-Adresse oder Recents ausgewählt locos nicht den letzten Operated Wert aktualisieren würde</li>
+    <li>Nacharbeits Roster Name Verwendung, wenn eine Adresse eingegeben wird</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-es.html
+++ b/EngineDriver/src/main/assets/about_page-es.html
@@ -22,7 +22,7 @@
     <li>Reproducir sonido y vibrar cuando se desconecta el dispositivo</li>
     <li>Recuerde recientes Consta y restaurarlos desde la pantalla de selección de loco</li>
     <li>Añadido botón de cierre y la imagen plantilla de diálogo de detalles roster</li>
-    <li>corrección de errores, donde locos seleccionados por DCC o Dirección Recientes no actualizar el valor Operado Último</li>
+    <li>La reanudación del uso del nombre de lista cuando se introduce una dirección</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-fr.html
+++ b/EngineDriver/src/main/assets/about_page-fr.html
@@ -22,7 +22,7 @@
     <li>Lire le son et vibre lorsque l'appareil se déconnecte</li>
     <li>Rappelez-vous et récente Consiste les restaurer à partir de l'écran de sélection loco</li>
     <li>Ajout d'un bouton Fermer l'image et liste de détails sur la formation de dialogue</li>
-    <li>Correction d'un bug où les locos sélectionnés par adresse DCC ou Recents ne mettre à jour la dernière valeur Exploité</li>
+    <li>Rework de l'utilisation du nom de fichier lorsqu'une adresse est saisie</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -24,7 +24,7 @@
     <li>Play sound and vibrate when device disconnects</li>
     <li>Remember Recent Consists and restore them from the select loco screen</li>
     <li>Added close button and roster image to roster details dialog</li>
-    <li>Fix bug where locos selected by DCC Address or Recents would not update the Last Operated value</li>
+    <li>Rework of roster name usage when an adress is entered</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -445,6 +445,7 @@ public class select_loco extends Activity {
         if (locoSource!=WHICH_SOURCE_ADDRESS) {
             roster_name = sWhichThrottle.substring(1);
             l.setDesc(roster_name);       //use rosterName if present
+            roster_name = mainapp.findLocoNameInRoster(roster_name);  // confirm that the loco is actually in the roster
             l.setRosterName(roster_name); //use rosterName if present
             l.setIsFromRoster(true);
         } else {

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -67,6 +67,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -102,6 +103,15 @@ public class select_loco extends Activity {
     private ArrayList<Integer> recent_loco_address_list;
     private ArrayList<Integer> recent_loco_address_size_list; // Look at address_type.java
     private ArrayList<String> recent_loco_name_list;
+    private ArrayList<Integer> recent_loco_source_list;
+
+    private static final int WHICH_SOURCE_UNKNOWN = 0;
+    private static final int WHICH_SOURCE_ADDRESS = 1;
+    private static final int WHICH_SOURCE_ROSTER = 2;
+
+//    private static final int LIGHT_OFF = 0;
+//    private static final int LIGHT_FOLLOW = 1;
+    private static final int LIGHT_UNKNOWN = 2;
 
     // recent consists
     ArrayList<HashMap<String, String>> recent_consists_list;
@@ -110,6 +120,9 @@ public class select_loco extends Activity {
     private ArrayList<ArrayList<Integer>> consistEngineAddressList = new ArrayList<>();
     private ArrayList<ArrayList<Integer>> consistAddressSizeList = new ArrayList<>();
     private ArrayList<ArrayList<Integer>> consistDirectionList = new ArrayList<>();
+    private ArrayList<ArrayList<Integer>> consistSourceList = new ArrayList<>();
+    private ArrayList<ArrayList<String>> consistRosterNameList = new ArrayList<>();
+    private ArrayList<ArrayList<Integer>> consistLightList = new ArrayList<>();  // placeholder - not currently use
     private ArrayList<String> consistNameList = new ArrayList<>();
 
     ListView consists_list_view;
@@ -123,6 +136,9 @@ public class select_loco extends Activity {
 
     private int engine_address;
     private int address_size;
+    private String locoName = "";
+    private int locoSource = 0;
+
     private String sWhichThrottle = "0";  // "0" or "1" or "2" + roster name
     int whichThrottle = 0;
     private int result;
@@ -247,33 +263,27 @@ public class select_loco extends Activity {
         } // if roster_entries not null
     }
 
-    private String getLocoNameFromRoster(String engineAddressString) {
-        if (prefRosterRecentLocoNames) {
-            if ((mainapp.roster_entries != null) && (mainapp.roster_entries.size() > 0)) {
-                for (String rostername : mainapp.roster_entries.keySet()) {  // loop thru roster entries,
-                    if (mainapp.roster_entries.get(rostername).equals(engineAddressString)) { //looking for value = input parm
-//                        return engineAddressString + " - " + rostername;  //if found, return the roster name (key)
-                        return rostername;  //if found, return the roster name (key)
-                    }
-                }
-            }
-            if (mainapp.getConsistNameFromAddress(engineAddressString) != null) { //check for a JMRI consist for this address
-                return mainapp.getConsistNameFromAddress(engineAddressString);
-            }
-        }
-        return engineAddressString;
-    }
-
-    private String getLocoIconUrlFromRoster(String engineAddressString) {
+    private String getLocoIconUrlFromRoster(String engineAddress, String engineName) {
         if (prefRosterRecentLocoNames) {
             if ((mainapp.roster_entries != null) && (mainapp.roster_entries.size() > 0) && (mainapp.roster != null)) {
                 for (String rostername : mainapp.roster_entries.keySet()) {  // loop thru roster entries,
-                    if (mainapp.roster_entries.get(rostername).equals(engineAddressString)) { //looking for value = input parm
-                        RosterEntry rosterentry = mainapp.roster.get(rostername);
-                        if (rosterentry == null) return "";
-                        String iconPath = rosterentry.getIconPath();  //if found, return the icon url
-                        if (iconPath == null) return "";
-                        return iconPath;
+                    if (engineName.equals("")) {
+                        if (mainapp.roster_entries.get(rostername).equals(engineAddress)) {
+                            RosterEntry rosterentry = mainapp.roster.get(rostername);
+                            if (rosterentry == null) return "";
+                            String iconPath = rosterentry.getIconPath();  //if found, return the icon url
+                            if (iconPath == null) return "";
+                            return iconPath;
+                        }
+                    } else { // if there is a name as well, confirm they match (for entries with the same address)
+                        if (rostername.equals(engineName)) {
+                            RosterEntry rosterentry = mainapp.roster.get(rostername);
+                            if (rosterentry == null) return "";
+                            String iconPath = rosterentry.getIconPath();  //if found, return the icon url
+                            if (iconPath == null) return "";
+                            return iconPath;
+                        }
+
                     }
                 }
             }
@@ -427,26 +437,29 @@ public class select_loco extends Activity {
     boolean saveUpdateList;         // save value across ConsistEdit activity 
     boolean newEngine;              // save value across ConsistEdit activity
 
-    void acquire_engine(boolean bUpdateList) {
-        String roster_name = sWhichThrottle.substring(1);
-//        String sAddr = (address_size == address_type.LONG ? "L" : "S") + engine_address;
+    void acquire_engine(boolean bUpdateList, boolean showConsistEdit) {
+        String roster_name = "";
         String sAddr = locoAddressToString(engine_address, address_size, true);
-        String addr = sAddr;
-        Loco l = new Loco(addr);
-        if (!roster_name.equals("")) {
+        Loco l = new Loco(sAddr);
+//        if (!roster_name.equals("")) {
+        if (locoSource!=WHICH_SOURCE_ADDRESS) {
+            roster_name = sWhichThrottle.substring(1);
             l.setDesc(roster_name);       //use rosterName if present
             l.setRosterName(roster_name); //use rosterName if present
             l.setIsFromRoster(true);
         } else {
-            l.setDesc(mainapp.getRosterNameFromAddress(l.toString()));  //lookup rostername from address if not set
+//            l.setDesc(mainapp.getRosterNameFromAddress(l.toString(),false));  //lookup rostername from address if not set
+            l.setDesc(locoName);
             l.setRosterName(null); //make sure rosterName is null
-            l.setFunctionLabelDefaults(mainapp, whichThrottle); //make sure rosterName is null
+            l.setFunctionLabelDefaults(mainapp, whichThrottle);
         }
         Consist consist = mainapp.consists[whichThrottle];
 
-        if (sWhichThrottle.length() > 1) // add roster selection info if present
-            addr += "<;>" + sWhichThrottle.substring(1);
-
+//        if ((sWhichThrottle.length() > 1) && (source!=WHICH_SOURCE_ADDRESS)) {// add roster selection info if present
+        if (!roster_name.equals("")) {// add roster selection info if present
+//            addr += "<;>" + sWhichThrottle.substring(1);
+            sAddr += "<;>" + roster_name;
+        }
 
         //user preference set to not consist, or consisting not supported in this JMRI, so drop before adding
         if (prefs.getBoolean("drop_on_acquire_preference", false)) {
@@ -465,18 +478,18 @@ public class select_loco extends Activity {
             consist.setLeadAddr(l.getAddress());
             consist.setTrailAddr(l.getAddress());
 //            consist.setConfirmed(l.getAddress()); //this happens after response from WiTS
-            mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQ_LOCO_ADDR, addr, whichThrottle);
+            mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQ_LOCO_ADDR, sAddr, whichThrottle);
             updateRecentEngines(bUpdateList);
 //            updateRecentConsists(bUpdateList);
             result = RESULT_OK;
             end_this_activity();
 
         } else {                                // else consist exists so bring up editor
-            ConLoco cl = consist.getLoco(addr);
+            ConLoco cl = consist.getLoco(sAddr);
             newEngine = (cl == null);
             if (newEngine || !cl.isConfirmed()) {        // if engine is not already in the consist, or if it is but never got acquired
                 consist.add(l);
-                mainapp.sendMsg(mainapp.comm_msg_handler, message_type. REQ_LOCO_ADDR, addr, whichThrottle);
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type. REQ_LOCO_ADDR, sAddr, whichThrottle);
 
                 saveUpdateList = bUpdateList;
                 Intent consistEdit = new Intent().setClass(this, ConsistEdit.class);
@@ -484,9 +497,11 @@ public class select_loco extends Activity {
 
                 consist.setTrailAddr(l.getAddress());  // set the newly added loco as the trailing loco
 
-                navigatingAway = true;
-                startActivityForResult(consistEdit, throttle.ACTIVITY_CONSIST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+                if (showConsistEdit) { // don't show the Consist edit screen.  Only used for Recent Consists
+                    navigatingAway = true;
+                    startActivityForResult(consistEdit, throttle.ACTIVITY_CONSIST);
+                    connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+                }
             }
         }
     }
@@ -525,23 +540,29 @@ public class select_loco extends Activity {
                 if (!removingLocoOrForceReload) {
                     mrl--;
                     // Add this engine to the head of recent engines list.
-                    String locoName = locoAddressToString(engine_address, address_size,false);
+                    String tempLocoName = (locoName.equals("") ? locoAddressToString(engine_address, address_size,false) : locoName);
+
+                    // check if it is already in the list and remove it if necessary
                     for (int i = 0; i < recent_loco_address_list.size() && mrl > 0; i++) {
-                        if (engine_address == recent_loco_address_list.get(i) && address_size == recent_loco_address_size_list.get(i)) {
-                            locoName = recent_loco_name_list.get(i); // grab the current name
+                        if (engine_address == recent_loco_address_list.get(i)
+                                && address_size == recent_loco_address_size_list.get(i)
+                                && tempLocoName.equals(recent_loco_name_list.get(i))) {
+//                            tempLocoName = recent_loco_name_list.get(i); // grab the current name
                             recent_loco_address_list.remove(i);      // before removing it from its current location in the list
                             recent_loco_address_size_list.remove(i);
                             recent_loco_name_list.remove(i);
+                            recent_loco_source_list.remove(i);
                         }
                     }
-                    list_output.format("%d:%d~%s\n", engine_address, address_size, locoName);
+                    list_output.format("%d:%d%d~%s\n", engine_address, address_size, locoSource, tempLocoName);
                 }
                 removingLocoOrForceReload = false;
                 for (int i = 0; i < recent_loco_address_list.size() && mrl > 0; i++) {
-//                    if (engine_address != recent_loco_address_list.get(i) || address_size != recent_loco_address_size_list.get(i)) {
-                        list_output.format("%d:%d~%s\n", recent_loco_address_list.get(i), recent_loco_address_size_list.get(i), recent_loco_name_list.get(i));
-//                        mrl--;
-//                    }
+                    list_output.format("%d:%d%d~%s\n",
+                            recent_loco_address_list.get(i),
+                            recent_loco_address_size_list.get(i),
+                            recent_loco_source_list.get(i),
+                            recent_loco_name_list.get(i));
                 }
             }
             list_output.flush();
@@ -560,6 +581,7 @@ public class select_loco extends Activity {
         recent_loco_address_list = new ArrayList<>();
         recent_loco_address_size_list = new ArrayList<>();
         recent_loco_name_list = new ArrayList<>();
+        recent_loco_source_list = new ArrayList<>();
         if (reload) {
             recent_engine_list = new ArrayList<>();
         }
@@ -583,38 +605,49 @@ public class select_loco extends Activity {
                         String line = list_reader.readLine();
                         Integer splitPos = line.indexOf(':');
                         if (splitPos > 0) {
-                            Integer ea, as;
-                            String ln = "";
+                            Integer addr, size, source = 0;
+                            String locoName = "";
                             try {
-                                ea = Integer.decode(line.substring(0, splitPos));
-                                as = Integer.decode(line.substring(splitPos + 1,splitPos + 2));
+                                addr = Integer.decode(line.substring(0, splitPos));
+                                size = Integer.decode(line.substring(splitPos + 1,splitPos + 2));
                                 if (line.length()>splitPos+2) { // has the name extras
-                                    if (line.substring(splitPos + 2,splitPos + 3).equals("~")) { // get the name
-                                        ln = line.substring(splitPos + 3);
+                                    if (line.substring(splitPos + 2,splitPos + 3).equals("~")) { // old format
+                                        locoName = line.substring(splitPos + 3);
+                                    } else {
+                                        if (line.substring(splitPos + 3,splitPos + 4).equals("~")) { // new format. Includes the source
+                                            source = Integer.decode(line.substring(splitPos + 2,splitPos + 3));
+                                            locoName = line.substring(splitPos + 4);
+                                        }
                                     }
                                 }
                             } catch (Exception e) {
-                                ea = -1;
-                                as = -1;
-                                ln = "";
+                                addr = -1;
+                                size = -1;
+                                locoName = "";
+                                source = -1;
                             }
 
-                            if ((ea >= 0) && (as >= 0)) {
-                                recent_loco_address_list.add(ea);
-                                recent_loco_address_size_list.add(as);
+                            if ((addr >= 0) && (size >= 0)) {
+                                recent_loco_address_list.add(addr);
+                                recent_loco_address_size_list.add(size);
                                 HashMap<String, String> hm = new HashMap<>();
-//                                String addressLengthString = ((as == 0) ? "S" : "L");  //show L or S based on length from file
-                                String engineAddressString = locoAddressToString(ea, as, false);
-                                if ((ln.length()==0  || ln.equals(engineAddressString))) { // if nothing is stored, or what is stored is the same as the address, look for it in the roster
-                                    ln = getLocoNameFromRoster(engineAddressString);
-                                }
-                                recent_loco_name_list.add(ln);
+                                String engineAddressString = locoAddressToString(addr, size, false);
+                                String engineAddressHtml = locoAddressToHtml(addr, size, source);
 
-                                String engineIconUrl = getLocoIconUrlFromRoster(engineAddressString);
+                                if ((locoName.length()==0  || locoName.equals(engineAddressString)) // if nothing is stored, or what is stored is the same as the address
+                                        && (source==WHICH_SOURCE_UNKNOWN)) { // as long as the source is listed as unknown
+                                    // if nothing is stored, or what is stored is the same as the address, look for it in the roster
+                                    locoName = mainapp.getRosterNameFromAddress(engineAddressString, false);
+                                }
+                                recent_loco_name_list.add(locoName);
+                                recent_loco_source_list.add(source);
+
+                                String engineIconUrl = getLocoIconUrlFromRoster(engineAddressString,locoName);
 //                                engineAddressString = getLocoNameFromRoster(engineAddressString);
                                 hm.put("engine_icon", engineIconUrl);
-                                hm.put("engine", ln);
-                                hm.put("engine_name", engineAddressString);
+                                hm.put("engine", locoName);
+//                                hm.put("engine_name", engineAddressString);
+                                hm.put("engine_name", engineAddressHtml);
                                 recent_engine_list.add(hm);
                             } //if ea>=0&&as>=0
                         } //if splitPos>0
@@ -642,6 +675,9 @@ public class select_loco extends Activity {
         consistEngineAddressList = new ArrayList<>();
         consistAddressSizeList = new ArrayList<>();
         consistDirectionList = new ArrayList<>();
+        consistLightList = new ArrayList<>();
+        consistSourceList = new ArrayList<>();
+        consistRosterNameList = new ArrayList<>();
         consistNameList = new ArrayList<>();
         if (reload) {
             recent_consists_list = new ArrayList<>();
@@ -650,6 +686,9 @@ public class select_loco extends Activity {
         ArrayList<Integer> tempConsistEngineAddressList_inner;
         ArrayList<Integer> tempConsistAddressSizeList_inner;
         ArrayList<Integer> tempConsistDirectionList_inner;
+        ArrayList<Integer> tempConsistSourceList_inner;
+        ArrayList<String> tempConsistRosterNameList_inner;
+        ArrayList<Integer> tempConsistLightList_inner;
 
         //if no SD Card present then there is no recent consists list
         if (!android.os.Environment.getExternalStorageState().equals(android.os.Environment.MEDIA_MOUNTED)) {
@@ -670,37 +709,69 @@ public class select_loco extends Activity {
                         tempConsistEngineAddressList_inner = new ArrayList<>();
                         tempConsistAddressSizeList_inner = new ArrayList<>();
                         tempConsistDirectionList_inner = new ArrayList<>();
+                        tempConsistSourceList_inner = new ArrayList<>();
+                        tempConsistRosterNameList_inner = new ArrayList<>();
+                        tempConsistLightList_inner = new ArrayList<>();
 
                         String consistName = "";
-                        int splitName = line.indexOf('~');
-                        if (splitName!=-1) { // see if there is a name saved as well
-                            consistName = line.substring(splitName+1);
-                            line = line.substring(0,splitName);
+                        String splitOn = "<~>";
+                        if (line.indexOf("<~>")==-1) { // must be the old format
+                            splitOn = "~";
+                        }
+                        String[] splitLine = line.split(splitOn, -1);
+
+                        if (splitLine.length>1) { // see if there is a name saved as well
+                            consistName = splitLine[1];
+                            line = splitLine[0];
+                            if (splitLine.length>2) {  // see if there is roster names saved as well
+                                String[] rosterNames = splitLine[2].split("<,>", -1);
+                                tempConsistRosterNameList_inner.addAll(Arrays.asList(rosterNames));
+                            }
                         }
 
                         int splitLoco = line.indexOf(',');
                         if (splitLoco!=-1) {
-                            oneConsist.append(addOneConsistAddress(line, 0, splitLoco, tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner, tempConsistDirectionList_inner));
+                            oneConsist.append(addOneConsistAddress(line, 0, splitLoco,
+                                    tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner,
+                                    tempConsistDirectionList_inner,
+                                    tempConsistSourceList_inner,
+                                    tempConsistLightList_inner));
 
                             boolean foundOne = true;
                             while (foundOne) {
                                 Integer prevSplitLoco = splitLoco + 1;
                                 splitLoco = line.indexOf(',', prevSplitLoco);
                                 if (splitLoco != -1) {
-                                    oneConsist.append(addOneConsistAddress(line, prevSplitLoco, splitLoco, tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner, tempConsistDirectionList_inner));
+                                    oneConsist.append(addOneConsistAddress(line, prevSplitLoco, splitLoco,
+                                            tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner,
+                                            tempConsistDirectionList_inner,
+                                            tempConsistSourceList_inner,
+                                            tempConsistLightList_inner));
                                 } else {
-                                    oneConsist.append(addOneConsistAddress(line, prevSplitLoco, line.length(), tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner, tempConsistDirectionList_inner));
+                                    oneConsist.append(addOneConsistAddress(line, prevSplitLoco, line.length(),
+                                            tempConsistEngineAddressList_inner, tempConsistAddressSizeList_inner,
+                                            tempConsistDirectionList_inner,
+                                            tempConsistSourceList_inner,
+                                            tempConsistLightList_inner));
                                     foundOne = false;
+                                }
+                            }
+                            if (splitLine.length<3) {  // old format - need to add some dummy roster names
+                                for (int j=0; j<tempConsistEngineAddressList_inner.size(); j++) {
+                                    tempConsistRosterNameList_inner.add("");
                                 }
                             }
                             consistEngineAddressList.add(tempConsistEngineAddressList_inner);
                             consistAddressSizeList.add(tempConsistAddressSizeList_inner);
                             consistDirectionList.add(tempConsistDirectionList_inner);
+                            consistSourceList.add(tempConsistSourceList_inner);
+                            consistRosterNameList.add(tempConsistRosterNameList_inner);
+                            consistLightList.add(tempConsistLightList_inner);
                             if (consistName.length()==0) { consistName = oneConsist.toString(); }
                             consistNameList.add(consistName);
 
                             HashMap<String, String> hm = new HashMap<>();
-                            hm.put("consist_name", getLocoNameFromRoster(oneConsist.toString()));
+                            hm.put("consist_name", mainapp.getRosterNameFromAddress(oneConsist.toString(), false));
                             hm.put("consist", consistName);
                             recent_consists_list.add(hm);
                         }
@@ -722,19 +793,36 @@ public class select_loco extends Activity {
             }
         }
     }
-    String addOneConsistAddress(String line, Integer start, Integer end, ArrayList<Integer> tempConsistEngineAddressList_inner, ArrayList<Integer> tempConsistAddressSizeList_inner, ArrayList<Integer> tempConsistDirectionList_inner) {
+
+
+    String addOneConsistAddress(String line, Integer start, Integer end,
+                                ArrayList<Integer> tempConsistEngineAddressList_inner,
+                                ArrayList<Integer> tempConsistAddressSizeList_inner,
+                                ArrayList<Integer> tempConsistDirectionList_inner,
+                                ArrayList<Integer> tempConsistSourceList_inner,
+                                ArrayList<Integer> tempConsistLightList_inner) {
         String rslt = "";
         String splitLine = line.substring(start, end);
         int splitPos = splitLine.indexOf(':');
         if (splitPos!=-1) {
             Integer addr = Integer.decode(splitLine.substring(0, splitPos));
-            Integer size = Integer.decode(splitLine.substring(splitPos + 1, splitPos + 2));
-            Integer dir = Integer.decode(splitLine.substring(splitPos + 2, splitPos + 3));
+            int size = Integer.decode(splitLine.substring(splitPos + 1, splitPos + 2));
+            int dir = Integer.decode(splitLine.substring(splitPos + 2, splitPos + 3));
+            int source = WHICH_SOURCE_UNKNOWN; //default to unknown
+            int light = LIGHT_UNKNOWN; //default to unknown
+            if (splitLine.length()>splitPos + 3) {  // if short, then this is the first format that did not include the source or light value
+                source = Integer.decode(splitLine.substring(splitPos + 3, splitPos + 4));
+                light = Integer.decode(splitLine.substring(splitPos + 4, splitPos + 5));
+            }
             tempConsistEngineAddressList_inner.add(addr);
             tempConsistAddressSizeList_inner.add(size);
             tempConsistDirectionList_inner.add(dir);
-            rslt = "<span>" + addr.toString()+"<small><small>("+ (size==0 ? "S":"L") +")</small>"+ (dir==0 ? "▲":"▼") + "</small> &nbsp;</span>";
-//            rslt = addr.toString() + " " + (dir==0 ? "F>":"<R") + " ";
+            tempConsistSourceList_inner.add(source);
+            tempConsistLightList_inner.add(light);
+
+            rslt = "<span>" + addr.toString()+"<small><small>("+ (size==0 ? "S":"L") +")</small>"
+                    + (dir==0 ? "▲":"▼") + "</small> " +  getSourceHtmlString(source) + " &nbsp;</span>";
+//                    +  (light==0 ? "○": (light==1 ? "● ":"≡")) + "</small> &nbsp;</span>";
         }
         return rslt;
     }
@@ -744,6 +832,9 @@ public class select_loco extends Activity {
         ArrayList<Integer> tempConsistEngineAddressList_inner = new ArrayList<>();
         ArrayList<Integer> tempConsistAddressSizeList_inner = new ArrayList<>();
         ArrayList<Integer> tempConsistDirectionList_inner = new ArrayList<>();
+        ArrayList<Integer> tempConsistSourceList_inner = new ArrayList<>();
+        ArrayList<String> tempConsistRosterNameList_inner = new ArrayList<>();
+        ArrayList<Integer> tempConsistLightList_inner = new ArrayList<>();
         boolean haveConsist = false;
 
         //if not updating list or no SD Card present then nothing else to do
@@ -758,9 +849,16 @@ public class select_loco extends Activity {
             for (ConLoco l : conLocos) {
                 tempConsistEngineAddressList_inner.add(l.getIntAddress());
                 tempConsistAddressSizeList_inner.add(l.getIntAddressLength());
-//                String addr = (l.getIntAddressLength() == 0 ? "S" : "L") + l.getIntAddress().toString();
                 String addr = locoAddressToString(l.getIntAddress(), l.getIntAddressLength(), true);
                 tempConsistDirectionList_inner.add((consist.isBackward(addr) ? 1 : 0));
+                String rosterName = "";
+                if (l.getRosterName() != null) {
+                    rosterName = l.getRosterName();
+                }
+                tempConsistSourceList_inner.add(rosterName.equals("") ? WHICH_SOURCE_ADDRESS : WHICH_SOURCE_ROSTER);
+                tempConsistRosterNameList_inner.add(rosterName);
+//                tempConsistLightList_inner.add((consist.isLight(addr)));
+                tempConsistLightList_inner.add(2);  // for now just default to unknown
             }
 
             // check if we already have it
@@ -794,6 +892,9 @@ public class select_loco extends Activity {
                     consistEngineAddressList.remove(0);
                     consistAddressSizeList.remove(0);
                     consistDirectionList.remove(0);
+                    consistSourceList.remove(0);
+                    consistRosterNameList.remove(0);
+                    consistLightList.remove(0);
                     consistNameList.remove(0);
                     haveConsist = false;
                 }
@@ -807,6 +908,9 @@ public class select_loco extends Activity {
                 consistEngineAddressList.add(0, tempConsistEngineAddressList_inner);
                 consistAddressSizeList.add(0, tempConsistAddressSizeList_inner);
                 consistDirectionList.add(0, tempConsistDirectionList_inner);
+                consistSourceList.add(0, tempConsistSourceList_inner);
+                consistRosterNameList.add(0, tempConsistRosterNameList_inner);
+                consistLightList.add(0, tempConsistLightList_inner);
                 String consistName = consist.toString();
                 consistNameList.add(0, consistName);
             }
@@ -828,11 +932,27 @@ public class select_loco extends Activity {
                     mrl--;
 
                     for (int i = 0; i < consistEngineAddressList.size() && mrl > 0; i++) {
-                        list_output.format("%d:%d%d", consistEngineAddressList.get(i).get(0), consistAddressSizeList.get(i).get(0), consistDirectionList.get(i).get(0));
-                        for (int j = 1; j < consistAddressSizeList.get(i).size(); j++) {
-                            list_output.format(",%d:%d%d", consistEngineAddressList.get(i).get(j), consistAddressSizeList.get(i).get(j), consistDirectionList.get(i).get(j));
+
+                        for (int j = 0; j < consistAddressSizeList.get(i).size(); j++) {
+                            if (j>0) {
+                                list_output.format(",");
+                            }
+                            list_output.format("%d:%d%d%d%d",
+                                    consistEngineAddressList.get(i).get(j),
+                                    consistAddressSizeList.get(i).get(j),
+                                    consistDirectionList.get(i).get(j),
+                                    consistSourceList.get(i).get(j),
+                                    consistLightList.get(i).get(j));
                         }
-                        list_output.format("~%s",consistNameList.get(i));
+                        list_output.format("<~>%s<~>",consistNameList.get(i));
+                        for (int j = 0; j < consistRosterNameList.get(i).size(); j++) {
+                            if (j>0) {
+                                list_output.format("<,>");
+                            }
+                            list_output.format("%s",
+                                    consistRosterNameList.get(i).get(j));
+                        }
+
                         list_output.format("\n");
                         mrl--;
                     }
@@ -847,7 +967,7 @@ public class select_loco extends Activity {
         }
     }
 
-
+    // listener for the Acquire button when entering a DCC Address
     public class button_listener implements View.OnClickListener {
         public void onClick(View v) {
             EditText entry = findViewById(R.id.loco_address);
@@ -859,9 +979,12 @@ public class select_loco extends Activity {
             }
             Spinner spinner = findViewById(R.id.address_length);
             address_size = spinner.getSelectedItemPosition();
-            sWhichThrottle += getLocoNameFromRoster(locoAddressToString(engine_address, address_size, false));
+//            locoName = mainapp.getRosterNameFromAddress(locoAddressToString(engine_address, address_size, false),false);
+            locoName = locoAddressToString(engine_address, address_size, false);
+            sWhichThrottle += locoName;
+            locoSource = WHICH_SOURCE_ADDRESS;
 
-            acquire_engine(true);
+            acquire_engine(true,true);
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             imm.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
@@ -882,6 +1005,7 @@ public class select_loco extends Activity {
         }
     }
 
+    // onClick for the Recent Locos list items
     public class engine_item implements AdapterView.OnItemClickListener {
         // When an item is clicked, acquire that engine.
         public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
@@ -893,21 +1017,33 @@ public class select_loco extends Activity {
             } else {  //no swipe
                 engine_address = recent_loco_address_list.get(position);
                 address_size = recent_loco_address_size_list.get(position);
-                sWhichThrottle += getLocoNameFromRoster(locoAddressToString(engine_address, address_size, false));
-                acquire_engine(true);
+                locoSource = recent_loco_source_list.get(position);
+                locoName = recent_loco_name_list.get(position);
+                if (locoSource==WHICH_SOURCE_UNKNOWN ) {
+                    locoName = mainapp.getRosterNameFromAddress(locoAddressToString(engine_address, address_size, false),true);
+                }
+
+                sWhichThrottle += locoName;
+                acquire_engine(true,true);
             }
         }
     }
 
+    // onClick for the Recent Consists list items
     public class consist_item implements AdapterView.OnItemClickListener {
         // When an item is clicked, acquire that consist.
         public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
 
-            Integer addr;
+//            Integer addr;
             String sAddr;
-            Integer size;
-            Integer dir;
+//            int size;
+            int dir;
+//            int source;
+            String rosterName;
+//            int light;
             Consist consist = mainapp.consists[whichThrottle];
+
+            String tempsWhichThrottle = sWhichThrottle;
 
             if(recentConsistsSwipeDetector.swipeDetected()) {
                 if(recentConsistsSwipeDetector.getAction() == SwipeDetector.Action.LR) {
@@ -916,28 +1052,24 @@ public class select_loco extends Activity {
                 }
             } else {  //no swipe
 
-                // use the normal acquire process to get the first loco, that way the function buttons will be correct.
-                engine_address = consistEngineAddressList.get(position).get(0);
-                address_size = consistAddressSizeList.get(position).get(0);
-                sWhichThrottle += getLocoNameFromRoster(locoAddressToString(engine_address, address_size, false));
-                acquire_engine(true);
+                for (int i = 0; i < consistEngineAddressList.get(position).size(); i++) {
 
-                for (int i = 1; i < consistEngineAddressList.get(position).size(); i++) {
-                    addr = consistEngineAddressList.get(position).get(i);
-                    size = consistAddressSizeList.get(position).get(i);
+                    engine_address = consistEngineAddressList.get(position).get(i);
+                    address_size = consistAddressSizeList.get(position).get(i);
+                    locoSource = consistSourceList.get(position).get(i);
+                    locoName = mainapp.getRosterNameFromAddress(locoAddressToString(engine_address, address_size, false), false);
+                    if ( (locoSource!=WHICH_SOURCE_ADDRESS) && (!consistRosterNameList.get(position).get(i).equals("")) ) {
+                            locoName = consistRosterNameList.get(position).get(i);
+                    }
+                    sWhichThrottle = tempsWhichThrottle
+                            + locoName;
+
+                    acquire_engine(true,false);
+
                     dir = consistDirectionList.get(position).get(i);
-
-//                    sAddr = (size==0 ? "S":"L") + addr.toString();  // convert 0/1 to S/L
-                    sAddr = locoAddressToString(addr, size, true);  // convert 0/1 to S/L + addr
-                    consist.add(sAddr);
-                    Log.d("Engine_Driver", "select_loco Acquiring Consist. loco: " + locoAddressToString(addr, size, false) + (dir==0 ? "↑":"↓"));
-
-    //                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQ_LOCO_ADDR, sAddr, whichThrottle);
-                    mainapp.sendMsgDelay(mainapp.comm_msg_handler, i*50, message_type.REQ_LOCO_ADDR, sAddr, whichThrottle,0);
-
                     if (dir==1) {
                         consist = mainapp.consists[whichThrottle];
-                        consist.setBackward(sAddr, true);
+                        consist.setBackward(locoName, true);
                     }
                 }
 
@@ -976,6 +1108,7 @@ public class select_loco extends Activity {
         }
     }
 
+    // onClick Listener for the Roster list items
     public class roster_item_ClickListener implements
             AdapterView.OnItemClickListener {
         // When a roster item is clicked, send request to acquire that engine.
@@ -1000,11 +1133,15 @@ public class select_loco extends Activity {
                     return; //get out, don't try to acquire
                 }
                 if ("loco".equals(rosterEntryType)) {
+                    locoName = rosterNameString;
                     sWhichThrottle += rosterNameString;     //append rostername if type is loco (not consist) 
                 }
+                locoSource = WHICH_SOURCE_ROSTER;
+
                 boolean bRosterRecent = prefs.getBoolean("roster_recent_locos_preference",
                         getResources().getBoolean(R.bool.prefRosterRecentLocosDefaultValue));
-                acquire_engine(bRosterRecent);
+
+                acquire_engine(bRosterRecent, true);
             }
         }
     }
@@ -1353,6 +1490,9 @@ public class select_loco extends Activity {
             consistEngineAddressList.clear();
             consistAddressSizeList.clear();
             consistDirectionList.clear();
+            consistSourceList.clear();
+            consistRosterNameList.clear();
+            consistLightList.clear();
         }
     }
 
@@ -1443,27 +1583,35 @@ public class select_loco extends Activity {
         return txtLen;
     }
 
+    // long click handler for the Roster List items.  Shows the details of the enter in a dialog.
     protected boolean onLongListItemClick(View v, int position, long id) {
         if (mainapp.roster == null) {
             Log.w("Engine_Driver", "No roster details found.");
             return true;
         }
         HashMap<String, String> hm = roster_list.get(position);
-        String rosternamestring = hm.get("roster_name");
-        RosterEntry re = mainapp.roster.get(rosternamestring);
+        String rosterNameString = hm.get("roster_name");
+        RosterEntry re = mainapp.roster.get(rosterNameString);
         if (re == null) {
-            Log.w("Engine_Driver", "Roster entry " + rosternamestring + " not available.");
+            Log.w("Engine_Driver", "Roster entry " + rosterNameString + " not available.");
             return true;
         }
-        Log.d("Engine_Driver", "Showing details for roster entry " + rosternamestring);
+        String iconURL = hm.get("roster_icon");
+
+        showRosterDetailsDialog(re, rosterNameString, iconURL);
+
+        return true;
+    }
+
+    protected void showRosterDetailsDialog(RosterEntry re, String rosterNameString, String iconURL) {
+        Log.d("Engine_Driver", "Showing details for roster entry " + rosterNameString);
         final Dialog dialog = new Dialog(select_loco.this, mainapp.getSelectedTheme());
-        dialog.setTitle(getApplicationContext().getResources().getString(R.string.rosterDetailsDialogTitle) + rosternamestring);
+        dialog.setTitle(getApplicationContext().getResources().getString(R.string.rosterDetailsDialogTitle) + rosterNameString);
         dialog.setContentView(R.layout.roster_entry);
         String res = re.toString();
         TextView tv = dialog.findViewById(R.id.rosterEntryText);
         tv.setText(res);
 
-        String iconURL = hm.get("roster_icon");
         ImageView imageView = dialog.findViewById(R.id.rosterEntryImage);
         if ((iconURL != null) && (iconURL.length() > 0)) {
             mainapp.imageDownloader.download(iconURL, imageView);
@@ -1480,15 +1628,25 @@ public class select_loco extends Activity {
 
         dialog.setCancelable(true);
         dialog.show();
-        return true;
+
     }
 
     // long click for the recent loco list items.
     protected boolean onLongRecentListItemClick(View v, int position, long id) {
 //        clearRecentListItem(v, position, id);
-        showEditRecentsNameDialog(position);
+        if (recent_loco_source_list.get(position)==WHICH_SOURCE_ROSTER) {
+            String rosterEntryName = recent_loco_name_list.get(position);
+            RosterEntry re = mainapp.roster.get(rosterEntryName);
+            if (re == null) {
+                Log.w("Engine_Driver", "Roster entry " + rosterEntryName + " not available.");
+                return true;
+            }
+            showRosterDetailsDialog(re, rosterEntryName, "");
+        } else {
+            showEditRecentsNameDialog(position);
+        }
         return true;
-}
+    }
 
     //  Clears the entry from the list
     protected boolean clearRecentListItem(View v, int position, long id) {
@@ -1497,16 +1655,18 @@ public class select_loco extends Activity {
         recent_loco_address_list.remove(position);
         recent_loco_address_size_list.remove(position);
         recent_loco_name_list.remove(position);
+        recent_loco_source_list.remove(position);
 
         removingLocoOrForceReload = true;
         updateRecentEngines(true);
         engine_list_view.invalidateViews();
+        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentCleared), Toast.LENGTH_SHORT).show();
+
         return true;
     }
 
     // long click for the recent consists list items.  Clears the entry from the list
     protected boolean onLongRecentConsistsListItemClick(View v, int position, long id) {
-//        clearRecentConsistsListItem(v, position, id);
         showEditRecentConsistsNameDialog(position);
         return true;
     }
@@ -1518,12 +1678,17 @@ public class select_loco extends Activity {
         consistEngineAddressList.remove(position);
         consistAddressSizeList.remove(position);
         consistDirectionList.remove(position);
+        consistSourceList.remove(position);
+        consistRosterNameList.remove(position);
+        consistLightList.remove(position);
         consistNameList.remove(position);
 
         removingConsistOrForceRewite = true;
 
         updateRecentConsists(true);
         consists_list_view.invalidateViews();
+        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentConsistCleared), Toast.LENGTH_SHORT).show();
+
         return true;
     }
 
@@ -1600,7 +1765,8 @@ public class RecentSimpleAdapter extends SimpleAdapter {
         String str = hm.get("engine_name");
         if (str != null) {
             TextView name = view.findViewById(R.id.engine_name_label);
-            name.setText(str);
+//            name.setText(str);
+            name.setText(Html.fromHtml(str));
         }
 
         str = hm.get("engine");
@@ -1674,7 +1840,7 @@ public class RecentSimpleAdapter extends SimpleAdapter {
         final View dialogView = inflater.inflate(R.layout.edit_recent_name, null);
         dialogBuilder.setView(dialogView);
 
-        final EditText edt = (EditText) dialogView.findViewById(R.id.editRecentName);
+        final EditText edt = dialogView.findViewById(R.id.editRecentName);
         edt.setText(consistNameList.get(pos));
 
         dialogBuilder.setTitle(getApplicationContext().getResources().getString(R.string.RecentConsistsNameEditTitle));
@@ -1706,7 +1872,7 @@ public class RecentSimpleAdapter extends SimpleAdapter {
         final View dialogView = inflater.inflate(R.layout.edit_recent_name, null);
         dialogBuilder.setView(dialogView);
 
-        final EditText edt = (EditText) dialogView.findViewById(R.id.editRecentName);
+        final EditText edt = dialogView.findViewById(R.id.editRecentName);
         edt.setText(recent_loco_name_list.get(pos));
 
         dialogBuilder.setTitle(getApplicationContext().getResources().getString(R.string.RecentsNameEditTitle));
@@ -1745,6 +1911,31 @@ public class RecentSimpleAdapter extends SimpleAdapter {
             Log.e("Engine_Driver", "locoAddressToString. ");
         }
         return engineAddressString;
+    }
+
+    String locoAddressToHtml(Integer addr, int size, int source) {
+        String engineAddressHtml = "";
+        try {
+            String addressLengthString = ((size == 0) ? "S" : "L");  //show L or S based on length from file
+            String addressSourceString = getSourceHtmlString(source);
+            engineAddressHtml = String.format("<span>%s<small>(%s)</small> %s </span>", addr.toString(), addressLengthString, addressSourceString);
+        } catch (Exception e) {
+            Log.e("Engine_Driver", "locoAddressToString. ");
+        }
+        return engineAddressHtml;
+    }
+
+    String getSourceHtmlString(int source) {
+        String addressSourceString = "?";
+        switch (source) {
+            case WHICH_SOURCE_ROSTER:
+                addressSourceString = "<big>≡</big>";
+                break;
+            case WHICH_SOURCE_ADDRESS:
+                addressSourceString = "<small><small><small><sub>└─┘</sub></small></small></small>";
+                break;
+        }
+        return addressSourceString;
     }
 
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -822,7 +822,7 @@ public class select_loco extends Activity {
             tempConsistLightList_inner.add(light);
 
             rslt = "<span>" + addr.toString()+"<small><small>("+ (size==0 ? "S":"L") +")</small>"
-                    + (dir==0 ? "▲":"▼") + "</small> " +  getSourceHtmlString(source) + " &nbsp;</span>";
+                    + (dir==0 ? "▲":"▼") + "</small>" +  getSourceHtmlString(source) + " &nbsp;</span>";
 //                    +  (light==0 ? "○": (light==1 ? "● ":"≡")) + "</small> &nbsp;</span>";
         }
         return rslt;
@@ -1565,22 +1565,29 @@ public class select_loco extends Activity {
         Button ba = findViewById(R.id.acquire);
         EditText la = findViewById(R.id.loco_address);
         int txtLen = la.getText().toString().trim().length();
+        int addr = 0;
+        if (txtLen>0) {
+            addr = Integer.parseInt(la.getText().toString().trim());
+        }
 
         // don't allow acquire button if nothing entered
         if (txtLen > 0) {
             ba.setEnabled(true);
+
+            // set address length
+            Spinner al = findViewById(R.id.address_length);
+            if (default_address_length.equals("Long") ||
+                    ( default_address_length.equals("Auto") && (addr > 127)) ) {
+//                    ( default_address_length.equals("Auto") && (txtLen > 2)) ) {
+                al.setSelection(1);
+            } else {
+                al.setSelection(0);
+            }
+
         } else {
             ba.setEnabled(false);
         }
 
-        // set address length
-        Spinner al = findViewById(R.id.address_length);
-        if (default_address_length.equals("Long")
-                || (default_address_length.equals("Auto") && txtLen > 2)) {
-            al.setSelection(1);
-        } else {
-            al.setSelection(0);
-        }
         return txtLen;
     }
 
@@ -1919,7 +1926,7 @@ public class RecentSimpleAdapter extends SimpleAdapter {
         try {
             String addressLengthString = ((size == 0) ? "S" : "L");  //show L or S based on length from file
             String addressSourceString = getSourceHtmlString(source);
-            engineAddressHtml = String.format("<span>%s<small>(%s)</small> %s </span>", addr.toString(), addressLengthString, addressSourceString);
+            engineAddressHtml = String.format("<span>%s<small>(%s)</small>%s </span>", addr.toString(), addressLengthString, addressSourceString);
         } catch (Exception e) {
             Log.e("Engine_Driver", "locoAddressToString. ");
         }
@@ -1930,10 +1937,10 @@ public class RecentSimpleAdapter extends SimpleAdapter {
         String addressSourceString = "?";
         switch (source) {
             case WHICH_SOURCE_ROSTER:
-                addressSourceString = "<big>≡</big>";
+                addressSourceString = " <big>≡</big> ";
                 break;
             case WHICH_SOURCE_ADDRESS:
-                addressSourceString = "<small><small><small><sub>└─┘</sub></small></small></small>";
+                addressSourceString = "<small><small><sub>└─┘</sub></small></small>";
                 break;
         }
         return addressSourceString;

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2076,6 +2076,17 @@ public class threaded_application extends Application {
         return addr_str; //return input if not found
     }
 
+    public String findLocoNameInRoster(String searchName) {
+        if ((roster_entries != null) && (roster_entries.size() > 0)) {
+            for (String rosterName : roster_entries.keySet()) {  // loop thru roster entries,
+                if (roster_entries.get(rosterName).equals(searchName)) { //looking for value = input parm
+                    return searchName;  //if found, return the roster name (key)
+                }
+            }
+        }
+        return ""; //return blank if not found
+    }
+
     public String getConsistNameFromAddress(String addr_str) {
         if (addr_str.charAt(0) == 'S' || addr_str.charAt(0) == 'L') { //convert from S123 to 123(S) formatting if needed
             addr_str = cvtToAddrP(addr_str);

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -867,11 +867,13 @@ public class threaded_application extends Application {
                         Log.d("Engine_Driver", "threaded_application: loco " + addr + " dropped from " + throttleIntToString(whichThrottle));
 
                     } else if (com2 == 'L') { //list of function buttons
-                        String lead;
-                        lead = consists[whichThrottle].getLeadAddr();
-                        if (lead.equals(addr))                        //*** temp - only process if for lead engine in consist
-                            process_roster_function_string("RF29}|{1234(L)" + ls[1], whichThrottle);  //prepend some stuff to match old-style
-                        consists[whichThrottle].setFunctionLabels(addr,"RF29}|{1234(L)" + ls[1], threaded_application.this);
+                        if (consists[whichThrottle].isLeadFromRoster()) { // if not from the roster ignore the function labels that WiT has sent back
+                            String lead;
+                            lead = consists[whichThrottle].getLeadAddr();
+                            if (lead.equals(addr))                        //*** temp - only process if for lead engine in consist
+                                process_roster_function_string("RF29}|{1234(L)" + ls[1], whichThrottle);  //prepend some stuff to match old-style
+                            consists[whichThrottle].setFunctionLabels(addr, "RF29}|{1234(L)" + ls[1], threaded_application.this);
+                        }
 
                     } else if (com2 == 'A') { //process change in function value  MTAL4805<;>F028
                         if (ls.length == 2 && "F".equals(ls[1].substring(0, 1))) {
@@ -2053,18 +2055,23 @@ public class threaded_application extends Application {
     }
 
     // get the roster name from address string 123(L).  Return input if not found in roster or in consist
-    public String getRosterNameFromAddress(String addr_str) {
+    public String getRosterNameFromAddress(String addr_str, boolean returnBlankIfNotFound) {
+        boolean prefRosterRecentLocoNames = prefs.getBoolean("prefRosterRecentLocoNames",
+                getResources().getBoolean(R.bool.prefRosterRecentLocoNamesDefaultValue));
 
-        if ((roster_entries != null) && (roster_entries.size() > 0)) {
-            for (String rostername : roster_entries.keySet()) {  // loop thru roster entries,
-                if (roster_entries.get(rostername).equals(addr_str)) { //looking for value = input parm
-                    return rostername;  //if found, return the roster name (key)
+        if (prefRosterRecentLocoNames) {
+            if ((roster_entries != null) && (roster_entries.size() > 0)) {
+                for (String rosterName : roster_entries.keySet()) {  // loop thru roster entries,
+                    if (roster_entries.get(rosterName).equals(addr_str)) { //looking for value = input parm
+                        return rosterName;  //if found, return the roster name (key)
+                    }
                 }
             }
+            if (getConsistNameFromAddress(addr_str) != null) { //check for a JMRI consist for this address
+                return getConsistNameFromAddress(addr_str);
+            }
         }
-        if (getConsistNameFromAddress(addr_str) != null) { //check for a JMRI consist for this address
-            return getConsistNameFromAddress(addr_str);
-        }
+        if (returnBlankIfNotFound) return "";
 
         return addr_str; //return input if not found
     }

--- a/EngineDriver/src/main/res/layout/connections_list_item.xml
+++ b/EngineDriver/src/main/res/layout/connections_list_item.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingLeft="3px"
+    android:paddingRight="3px">
 
     <TextView
         android:id="@+id/ip_item_label"
@@ -15,8 +17,8 @@
         style="?attr/list_item_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingBottom="10dp"
         android:paddingTop="10dp"
+        android:paddingBottom="10dp"
         android:text="test.test.test"
         android:textAppearance="?android:attr/textAppearanceLarge" />
 

--- a/EngineDriver/src/main/res/layout/consists_list_item.xml
+++ b/EngineDriver/src/main/res/layout/consists_list_item.xml
@@ -2,13 +2,15 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content"
+    android:paddingLeft="3px">
 
     <TextView
         android:id="@+id/consist_name_label"
         style="?attr/list_id_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:includeFontPadding="false"
         android:paddingLeft="2dp"
         android:text="TestAddress"
         tools:ignore="HardcodedText" />
@@ -18,8 +20,8 @@
         style="?attr/list_item_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingBottom="5dp"
         android:paddingTop="12dp"
+        android:paddingBottom="5dp"
         android:textAppearance="?android:attr/textAppearanceLarge"
         tools:ignore="RelativeOverlap" />
 </RelativeLayout>

--- a/EngineDriver/src/main/res/layout/engine_list_item.xml
+++ b/EngineDriver/src/main/res/layout/engine_list_item.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content"
+    android:paddingLeft="3px">
 
     <ImageView
         android:id="@+id/engine_icon_image"
@@ -10,14 +11,14 @@
         android:layout_height="54dp"
         android:layout_alignParentRight="true"
         android:contentDescription="roster icon"
-        tools:ignore="HardcodedText,RtlHardcoded">
-    </ImageView>
+        tools:ignore="HardcodedText,RtlHardcoded"></ImageView>
 
     <TextView
         android:id="@+id/engine_name_label"
         style="?attr/list_id_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:includeFontPadding="false"
         android:paddingLeft="2dp"
         android:text="TestAddress"
         tools:ignore="HardcodedText" />
@@ -27,8 +28,8 @@
         style="?attr/list_item_style"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingBottom="5dp"
         android:paddingTop="12dp"
+        android:paddingBottom="5dp"
         android:textAppearance="?android:attr/textAppearanceLarge"
         tools:ignore="RelativeOverlap" />
 </RelativeLayout>

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -774,4 +774,6 @@
     <string name="prefLimitSpeedPercentSummary">Ajust el \\% de l\\\'acceleració que la velocitat es limitarà a.</string>
     <string name="prefLimitSpeedPercentTitle">\\\'Límit de velocitat\\\' a \\%</string>
     <string name="rosterDetailsDialogTitle">"Seleccionar de Llista / Consisteix entrades "</string>
+    <string name="toastRecentCleared">Boig elimina de la llista</string>
+    <string name="toastRecentConsistCleared">Consisteixen eliminat de la llista</string>
 </resources>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -875,4 +875,6 @@
     <string name="prefLimitSpeedPercentSummary">Nastavení \\% z ceny plynu, že rychlost bude omezena na.</string>
     <string name="prefLimitSpeedPercentTitle">Rychlostní limit na \\%</string>
     <string name="rosterDetailsDialogTitle">Vyberte si z Roster / Skládá se Příspěvky</string>
+    <string name="toastRecentConsistCleared">Skládat odstraněn ze seznamu</string>
+    <string name="toastRecentCleared">Loco odstraněn ze seznamu</string>
 </resources>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -777,4 +777,6 @@
     <string name="RecentsNameEditText">Geben Sie einen Namen für die Loco</string>
     <string name="RecentsNameEditTitle">Aktuelle Lokname</string>
     <string name="rosterDetailsDialogTitle">"Wählen Sie aus Roster / Consist Einträge "</string>
+    <string name="toastRecentCleared">Loco entfernt von der Liste</string>
+    <string name="toastRecentConsistCleared">Consist aus der Liste entfernt</string>
 </resources>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -765,4 +765,6 @@
     <string name="RecentsNameEditText">Introduzca un nombre para el Loco</string>
     <string name="RecentsNameEditTitle">Nombre reciente Loco</string>
     <string name="rosterDetailsDialogTitle">"Seleccionar de Lista / Consiste entradas "</string>
+    <string name="toastRecentCleared">Loco elimina de la lista</string>
+    <string name="toastRecentConsistCleared">Consisten eliminado de la lista</string>
 </resources>

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -791,4 +791,6 @@
     <string name="RecentsNameEditText">Entrez un nom pour la Loco</string>
     <string name="RecentsNameEditTitle">Nom Loco récente</string>
     <string name="rosterDetailsDialogTitle">"Choisissez parmi la liste d'/ Consiste Entrées "</string>
+    <string name="toastRecentCleared">Loco supprimé de la liste</string>
+    <string name="toastRecentConsistCleared">Rayé de la liste sont composés</string>
 </resources>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -708,4 +708,6 @@
     <string name="RecentsNameEditText">Inserire un nome per il Loco</string>
     <string name="RecentsNameEditTitle">Recenti Nome Loco</string>
     <string name="rosterDetailsDialogTitle">"Selezionare tra Roster / Consistono Entries "</string>
+    <string name="toastRecentCleared">Loco rimosso dalla lista</string>
+    <string name="toastRecentConsistCleared">Consistono rimosso dalla lista</string>
 </resources>

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -712,4 +712,6 @@
     <string name="RecentsNameEditText">Digite um nome para o Loco</string>
     <string name="RecentsNameEditTitle">Recentes Nome Loco</string>
     <string name="rosterDetailsDialogTitle">"Seleccione a partir Roster / Consistem Entradas "</string>
+    <string name="toastRecentCleared">Loco removido da lista</string>
+    <string name="toastRecentConsistCleared">Consistem removido da lista</string>
 </resources>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -739,9 +739,12 @@
     <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists by pressing the \'Clear List\' button AGAIN.</string>
     <string name="toastNumThrottles">Chosen Throttle Screen Type does not support that many throttles. Reducing to %1$s.</string>
     <string name="toastRecentsHelp">Touch to select.\nLong press to rename.\nSwipe Left to Right to remove an entry.</string>
-    <string name="toastRecentConsistsHelp">Touch to select.\nLong press to rename.\nSwipe Left to Right to remove an entry.</string>
+    <string name="toastRecentConsistsHelp">Touch to select.\nLong press to Rename (for entered addresses) or show Roster Details.\nSwipe Left to Right to remove an entry.</string>
     <string name="toastRosterHelp">Touch to Select.\nLong press for details.</string>
     <string name="toastConnectionsListHelp">Touch to Select.\nSwipe Left to Right to remove an entry.</string>
+
+    <string name="toastRecentCleared">Loco removed from list</string>
+    <string name="toastRecentConsistCleared">Consist removed from list</string>
 
     <!--    Toast messages for the Log Viewer Activity -->
     <string name="toastSaveLogFile">Logging Started in file %1$s. Logging will continue until you exit the Engine Driver app.</string>


### PR DESCRIPTION
Loco Selection
- Pick from roster - get roster name and roster function buttons
- Enter address - get address as the name and generic functions per Prefs
- Pick from recent locos - whichever was originally set, including the edited name (see below)
- Pick from recent consists - whichever was originally set, including the edited name (see below)

Recent Locos
- if loco was selected from the roster, long press get you roster details
- if loco was from an entered address, long press allows you to edit the name

Recent Consists
- allow you edit the name

General
- it remembers the correct loco if more than one with the same address
- if you edit the name of a recent, then re-enter the same address, it considers it to be different to the remembered one.