### PR TITLE
Recent Consists - fixes

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
@@ -289,13 +289,13 @@ public class ImportExportPreferences {
                     recent_loco_address_size_list = new ArrayList<>();
                     recent_loco_name_list = new ArrayList<>();
                     recent_loco_source_list = new ArrayList<>();
-                    getIntListDataFromPreferences(recent_loco_address_list, "prefRecentLoco", sharedPreferences);
-                    getIntListDataFromPreferences(recent_loco_address_size_list, "prefRecentLocoSize", sharedPreferences);
-                    getStringListDataFromPreferences(recent_loco_name_list, "prefRecentLocoName", sharedPreferences);
-                    getIntListDataFromPreferences(recent_loco_source_list, "prefRecentLocoSource", sharedPreferences);
+                    getIntListDataFromPreferences(recent_loco_address_list, "prefRecentLoco", sharedPreferences,-1, 0);
+                    getIntListDataFromPreferences(recent_loco_address_size_list, "prefRecentLocoSize", sharedPreferences, recent_loco_address_list.size(), 0);
+                    getStringListDataFromPreferences(recent_loco_name_list, "prefRecentLocoName", sharedPreferences, recent_loco_address_list.size(), "");
+                    getIntListDataFromPreferences(recent_loco_source_list, "prefRecentLocoSource", sharedPreferences, recent_loco_address_list.size(), WHICH_SOURCE_UNKNOWN);
                     writeRecentLocosListToFile(sharedPreferences);
 
-                    getStringListDataFromPreferences(consistNameList, "prefRecentConsistName", sharedPreferences);
+                    getStringListDataFromPreferences(consistNameList, "prefRecentConsistName", sharedPreferences, -1, "");
                     for (int i = 0; i < consistNameList.size(); i++) {
                         ArrayList<Integer> tempConsistEngineAddressList_inner = new ArrayList<>();
                         ArrayList<Integer> tempConsistAddressSizeList_inner = new ArrayList<>();
@@ -304,12 +304,12 @@ public class ImportExportPreferences {
                         ArrayList<String> tempConsistRosterNameList_inner = new ArrayList<>();
                         ArrayList<Integer> tempConsistLightList_inner = new ArrayList<>();
 
-                        getIntListDataFromPreferences(tempConsistEngineAddressList_inner, "prefRecentConsistAddress_"+i, sharedPreferences);
-                        getIntListDataFromPreferences(tempConsistAddressSizeList_inner, "prefRecentConsistSize_"+i, sharedPreferences);
-                        getIntListDataFromPreferences(tempConsistDirectionList_inner, "prefRecentConsistDirection_"+i, sharedPreferences);
-                        getIntListDataFromPreferences(tempConsistSourceList_inner, "prefRecentConsistSource_"+i, sharedPreferences);
-                        getStringListDataFromPreferences(tempConsistRosterNameList_inner, "prefRecentConsistRosterName_"+i, sharedPreferences);
-                        getIntListDataFromPreferences(tempConsistLightList_inner, "prefRecentConsistLight_"+i, sharedPreferences);
+                        getIntListDataFromPreferences(tempConsistEngineAddressList_inner, "prefRecentConsistAddress_"+i, sharedPreferences, -1, 0);
+                        getIntListDataFromPreferences(tempConsistAddressSizeList_inner, "prefRecentConsistSize_"+i, sharedPreferences, tempConsistEngineAddressList_inner.size(), 0);
+                        getIntListDataFromPreferences(tempConsistDirectionList_inner, "prefRecentConsistDirection_"+i, sharedPreferences, tempConsistEngineAddressList_inner.size(), 0);
+                        getIntListDataFromPreferences(tempConsistSourceList_inner, "prefRecentConsistSource_"+i, sharedPreferences, tempConsistEngineAddressList_inner.size(), WHICH_SOURCE_UNKNOWN);
+                        getStringListDataFromPreferences(tempConsistRosterNameList_inner, "prefRecentConsistRosterName_"+i, sharedPreferences, tempConsistEngineAddressList_inner.size(), "");
+                        getIntListDataFromPreferences(tempConsistLightList_inner, "prefRecentConsistLight_"+i, sharedPreferences, tempConsistEngineAddressList_inner.size(), LIGHT_UNKNOWN);
 
                         consistEngineAddressList.add(tempConsistEngineAddressList_inner);
                         consistAddressSizeList.add(tempConsistAddressSizeList_inner);
@@ -431,7 +431,6 @@ public class ImportExportPreferences {
         }
     }
 
-    // simliar, but different, code exists in select_loco.java, ImportExportPreferences.java. if you modify one, make sure you modify the other
     void getRecentConsistsListFromFile() {
         Log.d("Engine_Driver", "getRecentConsistsListFromFile: ImportExportPreferences: Loading recent consists list from file");
 
@@ -593,10 +592,12 @@ public class ImportExportPreferences {
     }
 
     String addOneConsistAddressHtml(Integer addr, int size, int dir, int source, int light) {
-        String rslt = "<span>" + addr.toString()+"<small><small>("+ (size==0 ? "S":"L") +")"
-        + (dir==0 ? "▲":"▼") + "</small></small>"
-        +  (light==LIGHT_OFF ? "○": (light==LIGHT_FOLLOW ? "●":"<small><small>?</small></small>"))
-        +  getSourceHtmlString(source) + " &nbsp;</span>";
+        String rslt = "<span>" + addr.toString()
+                +"<small><small>("+ (size==0 ? "S":"L") +")"  + "</small></small>"
+//                + "<small><small>" + (dir==0 ? "▲":"▼") + "</small></small>"
+//                +  (light==LIGHT_OFF ? "○": (light==LIGHT_FOLLOW ? "●":"<small><small>?</small></small>"))
+//                +  getSourceHtmlString(source)
+                + " &nbsp;</span>";
 
         return rslt;
 
@@ -735,11 +736,14 @@ public class ImportExportPreferences {
         return sharedPreferences.edit().commit();
     }
 
-    private int getIntListDataFromPreferences(ArrayList<Integer> list, String listName, SharedPreferences sharedPreferences) {
+    private int getIntListDataFromPreferences(ArrayList<Integer> list, String listName, SharedPreferences sharedPreferences, int forceSize, int defaultValue) {
         int size = sharedPreferences.getInt(listName + "_size", 0);
+        if (forceSize>0) { // get a specified number regardless of how many are stored
+            size = forceSize;
+        }
         int prefInt;
         for(int i=0 ; i<size ; i++){
-            prefInt = sharedPreferences.getInt(listName + "_" + i, 0);
+            prefInt = sharedPreferences.getInt(listName + "_" + i, defaultValue);
             list.add(prefInt);
         }
         return size;
@@ -756,11 +760,14 @@ public class ImportExportPreferences {
         return sharedPreferences.edit().commit();
     }
 
-    private int getStringListDataFromPreferences(ArrayList<String> list, String listName, SharedPreferences sharedPreferences) {
+    private int getStringListDataFromPreferences(ArrayList<String> list, String listName, SharedPreferences sharedPreferences, int forceSize, String defaultValue) {
         int size = sharedPreferences.getInt(listName + "_size", 0);
+        if (forceSize>0) { // get a specified number regardless of how many are stored
+            size = forceSize;
+        }
         String prefString;
         for(int i=0 ; i<size ; i++){
-            prefString = sharedPreferences.getString(listName + "_" + i, "");
+            prefString = sharedPreferences.getString(listName + "_" + i, defaultValue);
             list.add(prefString);
         }
         return size;
@@ -785,26 +792,27 @@ public class ImportExportPreferences {
         String engineAddressHtml = "";
         try {
             String addressLengthString = ((size == 0) ? "S" : "L");  //show L or S based on length from file
-            String addressSourceString = getSourceHtmlString(source);
-            engineAddressHtml = String.format("<span>%s<small>(%s)</small>%s </span>", addr.toString(), addressLengthString, addressSourceString);
+//            String addressSourceString = getSourceHtmlString(source);
+//            engineAddressHtml = String.format("<span>%s<small>(%s)</small>%s </span>", addr.toString(), addressLengthString, addressSourceString);
+            engineAddressHtml = String.format("<span>%s<small>(%s)</small> </span>", addr.toString(), addressLengthString);
         } catch (Exception e) {
             Log.e("Engine_Driver", "locoAddressToString. ");
         }
         return engineAddressHtml;
     }
 
-    public String getSourceHtmlString(int source) {
-        String addressSourceString = "?";
-        switch (source) {
-            case WHICH_SOURCE_ROSTER:
-                addressSourceString = " <big>≡</big> ";
-                break;
-            case WHICH_SOURCE_ADDRESS:
-                addressSourceString = "<sub><small><small><small>└─┘</small></small></small></sub>";
-                break;
-        }
-        return addressSourceString;
-    }
+//    public String getSourceHtmlString(int source) {
+//        String addressSourceString = "?";
+//        switch (source) {
+//            case WHICH_SOURCE_ROSTER:
+//                addressSourceString = " <big>≡</big> ";
+//                break;
+//            case WHICH_SOURCE_ADDRESS:
+//                addressSourceString = "<sub><small><small><small>└─┘</small></small></small></sub>";
+//                break;
+//        }
+//        return addressSourceString;
+//    }
 
 
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -522,9 +522,7 @@ public class connection_activity extends Activity implements PermissionsHelper.P
             }
         }
 
-        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectionsListHelp), Toast.LENGTH_LONG).show();
-
-    }
+   }
 
     @Override
     public void onResume() {
@@ -893,6 +891,11 @@ public class connection_activity extends Activity implements PermissionsHelper.P
                             }
                         }
                         list_reader.close();
+
+                        if (((foundDemoHost) && (connections_list.size()>1)) || (connections_list.size()>0)) {
+                            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectionsListHelp), Toast.LENGTH_LONG).show();
+                        }
+
                     }
                 } catch (IOException except) {
                     errMsg = except.getMessage();

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2931,46 +2931,6 @@ public class threaded_application extends Application {
         previousOrientation = currentOrientation;
     }
 
-//    public String locoAddressToString(Integer addr, int size, boolean sizeAsPrefix) {
-//        String engineAddressString = "";
-//        try {
-//            String addressLengthString = ((size == 0) ? "S" : "L");  //show L or S based on length from file
-//            if (!sizeAsPrefix) {
-//                engineAddressString = String.format("%s(%s)", addr.toString(), addressLengthString);  //e.g.  1009(L)
-//            } else {
-//                engineAddressString = addressLengthString + addr.toString();  //e.g.  L1009
-//            }
-//        } catch (Exception e) {
-//            Log.e("Engine_Driver", "locoAddressToString. ");
-//        }
-//        return engineAddressString;
-//    }
-//
-//    public String locoAddressToHtml(Integer addr, int size, int source) {
-//        String engineAddressHtml = "";
-//        try {
-//            String addressLengthString = ((size == 0) ? "S" : "L");  //show L or S based on length from file
-//            String addressSourceString = getSourceHtmlString(source);
-//            engineAddressHtml = String.format("<span>%s<small>(%s)</small>%s </span>", addr.toString(), addressLengthString, addressSourceString);
-//        } catch (Exception e) {
-//            Log.e("Engine_Driver", "locoAddressToString. ");
-//        }
-//        return engineAddressHtml;
-//    }
-//
-//    public String getSourceHtmlString(int source) {
-//        String addressSourceString = "?";
-//        switch (source) {
-//            case WHICH_SOURCE_ROSTER:
-//                addressSourceString = " <big>≡</big> ";
-//                break;
-//            case WHICH_SOURCE_ADDRESS:
-//                addressSourceString = "<sub><small><small><small>└─┘</small></small></small></sub>";
-//                break;
-//        }
-//        return addressSourceString;
-//    }
-//
 }
 
 

--- a/EngineDriver/src/main/res/layout/consist_item.xml
+++ b/EngineDriver/src/main/res/layout/consist_item.xml
@@ -52,4 +52,18 @@
         android:paddingTop="15dp"
         android:text="facing"
         android:textAppearance="?android:attr/textAppearanceLarge" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true">
+
+        <TextView
+            android:id="@+id/con_facing_label"
+            style="?attr/list_id_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/editConsistLocoFacingLabel" />
+
+    </LinearLayout>
 </RelativeLayout>

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -780,4 +780,7 @@
     <string name="editConsistLightsButtonLabel">Edita Llums</string>
     <string name="toastConnectionsListHelp">Toc per seleccionar.\\nPas a l\'esquerra a la dreta per eliminar una entrada.</string>
     <string name="toastConsistEditHelp">Toc per canviar de direcció.\\nPas a l\'esquerra a la dreta per eliminar una entrada.</string>
+    <string name="consistLocoFacingFront">Front</string>
+    <string name="consistLocoFacingRear">Posterior</string>
+    <string name="editConsistLocoFacingLabel">Enfront de</string>
 </resources>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -881,4 +881,7 @@
     <string name="editConsistLightsButtonLabel">Editovat Lights</string>
     <string name="toastConnectionsListHelp">Dotykem vyberte.\\nPřejeďte zleva doprava, aby se odstranily položku.</string>
     <string name="toastConsistEditHelp">Dotykem změnit směr.\\nPřejeďte zleva doprava, aby se odstranily položku.</string>
+    <string name="consistLocoFacingFront">Přední</string>
+    <string name="consistLocoFacingRear">Zadní</string>
+    <string name="editConsistLocoFacingLabel">Obložení</string>
 </resources>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -783,4 +783,7 @@
     <string name="editConsistLightsButtonLabel">Bearbeiten Lichter</string>
     <string name="toastConnectionsListHelp">Tippen auswählen.\\nSwipe links nach rechts um einen Eintrag zu entfernen.</string>
     <string name="toastConsistEditHelp">Berühren Sie, um die Richtung ändern.\\nSwipe links nach rechts um einen Eintrag zu entfernen.</string>
+    <string name="consistLocoFacingFront">Vorderseite</string>
+    <string name="consistLocoFacingRear">Rückseite</string>
+    <string name="editConsistLocoFacingLabel">Zugewandt</string>
 </resources>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -496,7 +496,7 @@
     <string name="toastConnectErrorReadingRecentConnections">Error leyendo la lista de conexiones recientes:</string>
     <string name="toastConnectErrorSavingRecentConnection">Error guardando la conexión reciente:</string>
     <string name="toastConnectRemoveDemoHostError">El servidor de demostración solo se puede eliminar modificando las preferencias.</string>
-    <string name="toastConnectRemoved">Server eliminado de la lista.</string>
+    <string name="toastConnectRemoved">Servidor eliminado de la lista.</string>
 
     <string name="toastRoutesCommandSent">"Comando enviado para establecer la ruta"</string>
     <string name="toastImportExportExportSucceeded">La exportación de preferencias a \'engine_driver/%1$s\' ha tenido éxito.</string>
@@ -771,4 +771,7 @@
     <string name="editConsistLightsButtonLabel">Editar Luces</string>
     <string name="toastConnectionsListHelp">Toque para seleccionar.\\nPase a la izquierda a la derecha para eliminar una entrada.</string>
     <string name="toastConsistEditHelp">Toque para cambiar de dirección.\\nPase a la izquierda a la derecha para eliminar una entrada.</string>
+    <string name="consistLocoFacingFront">Frente</string>
+    <string name="consistLocoFacingRear">Posterior</string>
+    <string name="editConsistLocoFacingLabel">Frente a</string>
 </resources>

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -797,4 +797,7 @@
     <string name="editConsistLightsButtonLabel">Modifier les lumières</string>
     <string name="toastConnectionsListHelp">Touchez pour sélectionner.\\nSwipe gauche à droite pour supprimer une entrée.</string>
     <string name="toastConsistEditHelp">Touchez pour changer de direction.\\nSwipe gauche à droite pour supprimer une entrée.</string>
+    <string name="consistLocoFacingFront">De face</string>
+    <string name="consistLocoFacingRear">Arrière</string>
+    <string name="editConsistLocoFacingLabel">Orienté vers</string>
 </resources>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -714,4 +714,7 @@
     <string name="editConsistLightsButtonLabel">Modifica Luci</string>
     <string name="toastConnectionsListHelp">Toccare per selezionare.\\nSwipe sinistra a destra per rimuovere una voce.</string>
     <string name="toastConsistEditHelp">Toccare per cambiare direzione.\\nSwipe sinistra a destra per rimuovere una voce.</string>
+    <string name="consistLocoFacingFront">Davanti</string>
+    <string name="consistLocoFacingRear">Posteriore</string>
+    <string name="editConsistLocoFacingLabel">Di fronte</string>
 </resources>

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -538,7 +538,7 @@
     <string name="toastConnectErrorReadingRecentConnections">Erro de leitura da lista de conexões recentes:</string>
     <string name="toastConnectErrorSavingRecentConnection">Erro salvando conexões recentes:</string>
     <string name="toastConnectRemoveDemoHostError">O servidor de demonstração só pode ser removido modificando as preferências.</string>
-    <string name="toastConnectRemoved">Server removido da lista.</string>
+    <string name="toastConnectRemoved">Servidor removido da lista.</string>
 
     <string name="toastRoutesCommandSent">"Comando enviado para escolher Rota"</string>
     <string name="toastImportExportExportSucceeded">Exportação preferências para \'engine_driver/%1$s\' realizada com sucesso.</string>
@@ -718,4 +718,7 @@
     <string name="editConsistLightsButtonLabel">Editar Luzes</string>
     <string name="toastConnectionsListHelp">Toque para selecionar.\\nSwipe esquerda para a direita para remover uma entrada.</string>
     <string name="toastConsistEditHelp">Toque para mudar de direção.\\nSwipe esquerda para a direita para remover uma entrada.</string>
+    <string name="consistLocoFacingFront">Frente</string>
+    <string name="consistLocoFacingRear">traseiro</string>
+    <string name="editConsistLocoFacingLabel">Voltado para</string>
 </resources>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -744,7 +744,7 @@
     <string name="toastConnectionsListHelp">Touch to select a Recent Connection\nor enter Server Address and Port.\nSwipe Right to remove an entry.</string>
 
     <!--    Toast messages for the Consist Edit Activity -->
-    <string name="toastConsistEditHelp">Touch to change direction. Swipe Right to remove an entry.</string>
+    <string name="toastConsistEditHelp">Touch to change facing. Swipe Right to remove an entry.</string>
 
     <string name="toastRecentCleared">Loco removed from list</string>
     <string name="toastRecentConsistCleared">Consist removed from list</string>
@@ -951,7 +951,11 @@
     <string name="edit_consist_lights_throttle_5">Edit Consist Lights Throttle 5</string>
     <string name="edit_consist_lights_throttle_6">Edit Consist Lights Throttle 6</string>
 
-    <string name="editConsistButtonLabel">Edit Order and Direction</string>
+    <string name="editConsistButtonLabel">Edit Order &amp; Facing</string>
     <string name="editConsistLightsButtonLabel">Edit Lights</string>
+
+    <string name="editConsistLocoFacingLabel">Facing</string>
+    <string name="consistLocoFacingFront">Front</string>
+    <string name="consistLocoFacingRear">Rear</string>
 
 </resources>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -498,6 +498,7 @@
  *   TODO: add preference to disable other hardware buttons in throttle screen
  *   TODO: unset all states when loco not selected
  *   TODO: option to show the turnout view instead of the webview
+ *   TODO: use the renamed locos and Consists on the Throttle page
  * select_loco:
  *   TODO: handle roster entry names with forward slash
  *   TODO: check length of text to avoid overlapping images, slide images to right
@@ -506,7 +507,7 @@
  *   TODO: for "auto" handle the Digitrax numbering, i.e. 1-128 is short
  *   TODO: remove the similar code the read and write the recents in threaded_application.java and ImportExportPreferences.java
  * consist edit:
- *   TODO: add swipe action or other action to change the lights
+ *   TODO: add swipe action or other action to change the lights and remove the Consist Lights edit page entirely
  * log_viewer:
  *
  * These require changes to WiThrottle


### PR DESCRIPTION
1) removed symbols in "Recent Locos" and "Recent Consists"
2) "Edit Order and Direction" and "Edit Lights" removed when only one loco has been selected.
4) After a Reset, suppress the "Recent Connection" toast help on the first page of the Intro.
7) Add "Direction" to the list header on the Consist Edit page
8) Consist Edit swipe not working
X) remove earlier parts of the consist as you are building it (fixed yet again)
Y) better handling older style file formats for the recent locos in server specific preferences

TBA
3) show the renamed consist name on the throttle page