### PR TITLE
FIX - Recent Turnouts

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
@@ -42,6 +42,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import static java.lang.Math.min;
+
 public class ImportExportPreferences {
 
     boolean currentlyImporting = false;
@@ -850,17 +852,22 @@ public class ImportExportPreferences {
         PrintWriter list_output;
         String smrl = sharedPreferences.getString("maximum_recent_locos_preference", "10"); //retrieve pref for max recent locos to show
         try {
-            int numberOfRecentTurnoutsToWrite = Integer.parseInt(smrl);
+            int numberOfRecentTurnoutsToWrite = Integer.parseInt(smrl) * 2;
+            numberOfRecentTurnoutsToWrite = min(numberOfRecentTurnoutsToWrite, recent_turnout_address_list.size());
             list_output = new PrintWriter(engine_list_file);
             if (numberOfRecentTurnoutsToWrite > 0) {
-                for (int i = 0; i < recent_turnout_address_list.size() && numberOfRecentTurnoutsToWrite > 0; i++) {
+//                for (int i = 0; i < recent_turnout_address_list.size() && numberOfRecentTurnoutsToWrite > 0; i++) {
+                for (int i = 0; i < numberOfRecentTurnoutsToWrite; i++) {
                     list_output.format("%s:%d<~>%s<~>%s\n",
                             recent_turnout_address_list.get(i),
                             recent_turnout_source_list.get(i),
                             recent_turnout_server_list.get(i),
                             recent_turnout_name_list.get(i));
-                    numberOfRecentTurnoutsToWrite--;
+//                    numberOfRecentTurnoutsToWrite--;
                 }
+            } else {
+                deleteRecentTurnoutsListFile();
+                return;
             }
             list_output.flush();
             list_output.close();
@@ -876,7 +883,24 @@ public class ImportExportPreferences {
         }
     }
 
-    void getRecentTurnoutsListFromFile() {
+    void deleteRecentTurnoutsListFile() {
+        Log.d("Engine_Driver", "deleteRecentTurnoutsListFile: ImportExportPreferences: delete file");
+
+        File sdcard_path = Environment.getExternalStorageDirectory();
+        File engine_list_file = new File(sdcard_path,
+                "engine_driver/recent_turnouts_list.txt");
+        if (engine_list_file.exists()) {
+            try {
+                engine_list_file.delete();
+            } catch (Exception except) {
+                Log.e("Engine_Driver",
+                        "deleteRecentTurnoutsListFile: ImportExportPreferences: Error deleting Recent Turnouts file: "
+                                + except.getMessage());
+            }
+        }
+    }
+
+        void getRecentTurnoutsListFromFile() {
         Log.d("Engine_Driver", "getRecentTurnoutsListFromFile: ImportExportPreferences: Loading recent turnouts list from file");
         try {
             // Populate the List with the recent engines saved in a file. This

--- a/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
@@ -64,4 +64,5 @@ interface message_type {
     int IMPORT_SERVER_MANUAL_SUCCESS = 42;    //
     int IMPORT_SERVER_MANUAL_FAIL = 43;    //
     int IMPORT_SERVER_AUTO_AVAILABLE = 44;    //
+    int WIT_TURNOUT_NOT_DEFINED = 45;    //
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -94,6 +94,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;
@@ -926,6 +928,15 @@ public class threaded_application extends Application {
                         }
                     } else if (response_str.charAt(1) == 'M') { //alert message sent from server to throttle
                         show_toast_message(response_str.substring(2), Toast.LENGTH_LONG); // copy to UI as toast message
+                        //see if it is a turnout fail
+                        if ((response_str.contains("Turnout")) || (response_str.contains("create not allowed"))) {
+                            Pattern pattern = Pattern.compile(".*\\\'(.*)\\\'.*");
+                            Matcher matcher = pattern.matcher(response_str);
+                            if(matcher.find()) {
+                                sendMsg(turnouts_msg_handler, message_type.WIT_TURNOUT_NOT_DEFINED, matcher.group(1));
+                            }
+                        }
+
                     } else if (response_str.charAt(1) == 'm') { //info message sent from server to throttle
                         show_toast_message(response_str.substring(2), Toast.LENGTH_SHORT); // copy to UI as toast message
                     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -3959,6 +3959,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         @Override
         public void onStopTrackingTouch(SeekBar sb) {
             mAutoIncrement = false;
+            kidsTimerActions(KIDS_TIMER_STARTED,0);
         }
     }
 


### PR DESCRIPTION
- re-working of when the Recent list is shown to stop it showing on the bottom of the defined list
- reduce how often the list is saved
- remove recent entries if the server responds with an error

FIX - start the Children's timer of vertical seek bar action