### PR TITLE
FIX - Switching/Shunting screen gamepad sounds

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -2931,12 +2931,12 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
 
     void GamepadIncrementSpeed(int whichThrottle) {
         incrementSpeed(whichThrottle, SPEED_COMMAND_FROM_GAMEPAD);
-        GamepadFeedbackSound(atMaxSpeed(whichThrottle));
+        GamepadFeedbackSound(atMaxSpeed(whichThrottle) || atMinSpeed(whichThrottle));
     }
 
     void GamepadDecrementSpeed(int whichThrottle) {
         decrementSpeed(whichThrottle, SPEED_COMMAND_FROM_GAMEPAD);
-        GamepadFeedbackSound(atMinSpeed(whichThrottle));
+        GamepadFeedbackSound(atMinSpeed(whichThrottle) || atMaxSpeed(whichThrottle));
     }
 
     void GamepadFeedbackSound(boolean invalidAction) {

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -756,7 +756,7 @@
     <string name="prefImportServerAutoTitle">Import automatique depuis tous les serveurs.</string>
     <string name="prefImportServerAutoSummary">Import automatique des préférences depuis tous les serveurs dès la connexion.\n(Si le fichier \'/engine_driver/auto_preference.ed\' est sur le serveur et si il est plus récent que lors du dernier contrôle).</string>
 
-    <string name="importServerAutoDialog">Un fichier de préférence existe sur ce serveur.\nFaut il l importer?\n\nATTENTION!\n\'Complet\' - Efface toutes vos préférences.\n\n\'Partiel\' - Efface tout sauf les themes et quelques préférences liées au type de régulateur.</string>
+    <string name="importServerAutoDialog">Un fichier de préférence existe sur ce serveur: (%1$s)\nFaut il l importer?\n\nATTENTION!\n\'Complet\' - Efface toutes vos préférences.\n\n\'Partiel\' - Efface tout sauf les themes et quelques préférences liées au type de régulateur.</string>
     <string name="importServerAutoDialogPositiveButton">Complet</string>
     <string name="importServerAutoDialogNeutralButton">Partiel</string>
 


### PR DESCRIPTION
When using the gamepad on the Switching/Shunting screen, play sounds correctly when the speed goes up through zero and down to 100% reverse