### PR TITLE
Initial fastclock value shown as 00:00

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -471,6 +471,7 @@ public class threaded_application extends Application {
 
                         //clear app.thread shared variables so they can be reinitialized
                         initShared();
+                        fastClockSeconds = 0L;
 
                         //store ip and port in global variables
                         host_ip = new_host_ip;
@@ -494,7 +495,6 @@ public class threaded_application extends Application {
                             host_ip = null;  //clear vars if failed to connect
                             port = 0;
                         }
-                        fastClockSeconds = 0L;
                         break;
 
                     //Release one or all locos on the specified throttle.  addr is in msg (""==all), arg1 holds whichThrottle.
@@ -2571,8 +2571,6 @@ public class threaded_application extends Application {
      */
     public String getFastClockTime() {
         String f = "";
-        int gmtOffset = TimeZone.getTimeZone("GMT").getRawOffset();
-
         if (fastClockFormat == 2) {
             f = "HH:mm"; // display in 24 hr format
         } else if (fastClockFormat == 1){
@@ -2580,7 +2578,7 @@ public class threaded_application extends Application {
         }
         SimpleDateFormat sdf = new SimpleDateFormat(f, Locale.getDefault());
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-        Date date = new java.util.Date((fastClockSeconds * 1000L) - gmtOffset);
+        Date date = new java.util.Date((fastClockSeconds * 1000L));
         return sdf.format(date);
     }
 


### PR DESCRIPTION
On a CONNECT message, the TA comm_handler sets fastClockSeconds to 0.  However the handler code was opening the WiT socket first and then later setting fastClockSeconds to 0.   As a result it was possible that the WiT Socket handler could receive the initial PFT time update and set fastClockSeconds first, and then the CONNECT handler would set it back to 0.  To prevent this case from happening I rearranged the CONNECT message handler code so that it sets fastClockSeconds before opening the WiTSocket.

Also removed the use of time offset from getFastClockTime() since this routine now does its work in GMT and the offset is by definition 0.