### PR TITLE
webview longclick refresh, safe browsing whitelist 

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -56,6 +56,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.ViewGroup;
 import android.webkit.CookieSyncManager;
+import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.Toast;
 
@@ -477,6 +478,10 @@ public class threaded_application extends Application {
                         //store ip and port in global variables
                         host_ip = new_host_ip;
                         port = new_port;
+                        // skip url checking on Play Protect
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                            WebView.setSafeBrowsingWhitelist(Collections.singletonList(host_ip), null);
+                        }
 
                         //attempt connection to WiThrottle server
                         socketWiT = new socket_WiT();

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -4415,6 +4415,16 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
         if (currentUrl == null || savedInstanceState == null || webView.restoreState(savedInstanceState) == null) {
             load_webview(); // reload if no saved state or no page had loaded when state was saved
         }
+
+        //longpress webview to reload
+        webView.setOnLongClickListener(new WebView.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                reloadWeb();
+                return true;
+            }
+        });
+
         // put pointer to this activity's handler in main app's shared variable
         mainapp.throttle_msg_handler = new throttle_handler();
 
@@ -4517,9 +4527,9 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             if (!callHiddenWebViewOnResume()) {
                 webView.resumeTimers();
             }
-            if (noUrl.equals(webView.getUrl()) && webView.canGoBack()) {    //unload static url loaded by onPause
-                webView.goBack();
-            }
+//            if (noUrl.equals(webView.getUrl()) && webView.canGoBack()) {    //unload static url loaded by onPause
+//                webView.goBack();
+//            }
         }
 
         if (mainapp.EStopActivated) {
@@ -4631,10 +4641,10 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 webView.pauseTimers();
             }
 
-            String url = webView.getUrl();
-            if (url != null && !noUrl.equals(url)) {    // if any url has been loaded 
-                webView.loadUrl(noUrl);                 // load a static url to stop any javascript
-            }
+ //           String url = webView.getUrl();
+ //           if (url != null && !noUrl.equals(url)) {    // if any url has been loaded
+ //               webView.loadUrl(noUrl);                 // load a static url to stop any javascript
+ //           }
         }
         CookieSyncManager.getInstance().stopSync();
 
@@ -4734,8 +4744,8 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             url = noUrl;                            // load static url to stop javascript
             currentUrl = null;
             firstUrl = null;
-        } else if (url == null)                       // else if initializing
-        {
+        }
+        else if (url == null) {                // else if initializing
             webViewIsOn = true;
             url = mainapp.createUrl(prefs.getString("InitialThrotWebPage",
                     getApplicationContext().getResources().getString(R.string.prefInitialThrotWebPageDefaultValue)));

--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -165,8 +165,9 @@ public class web_activity extends Activity {
 
         // enable remote debugging of all webviews
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            if (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE))
-            { WebView.setWebContentsDebuggingEnabled(true); }
+            if (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {
+                WebView.setWebContentsDebuggingEnabled(true);
+            }
         }
 
 
@@ -202,6 +203,15 @@ public class web_activity extends Activity {
         webView.setWebViewClient(EDWebClient);
         if (currentUrl == null || savedInstanceState == null || webView.restoreState(savedInstanceState) == null)
             load_webview();            // reload if no saved state or no page had loaded when state was saved
+
+        //longpress webview to reload
+        webView.setOnLongClickListener(new WebView.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                reloadWeb();
+                return true;
+            }
+        });
 
         //Set the buttons
         closeButton = findViewById(R.id.webview_button_close);
@@ -287,7 +297,7 @@ public class web_activity extends Activity {
         if (webView != null) {
             if (!callHiddenWebViewOnPause())
                 webView.pauseTimers();
-            String url = webView.getUrl();
+//            String url = webView.getUrl();
 //            if (url != null && !noUrl.equals(url)) {    // if any url has been loaded
 //                webView.loadUrl(noUrl);                // load a static url to stop any javascript
 //            }


### PR DESCRIPTION
Longclick on a webview now refreshes the display (reloads the webview).

Added host ip to safebrowsingwhitelist for API O_MR1 and later.

Removed legacy code related to loading a static url when pausing since the webview itself is now paused directly.