### PR TITLE
Web and background work, Stream close

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -123,7 +123,7 @@
             android:name=".routes"
             android:label="@string/app_name_routes"
             android:alwaysRetainTaskState="true"
-            android:launchMode="singleTask" 
+            android:launchMode="singleTask"
             >
         </activity>
         <activity
@@ -135,13 +135,13 @@
         <activity
             android:name=".about_page"
             android:alwaysRetainTaskState="true"
-            android:launchMode="singleTask" 
+            android:launchMode="singleTask"
             android:label="@string/app_name_about" >
         </activity>
         <activity
             android:name=".web_activity"
             android:alwaysRetainTaskState="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:label="@string/app_name_web" >
         </activity>
         <activity

--- a/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ImportExportPreferences.java
@@ -49,6 +49,9 @@ public class ImportExportPreferences {
     boolean currentlyImporting = false;
 
     //private String exportedPreferencesFileName =  "exported_preferences.ed";
+    public static final String AUTO_IMPORT_EXPORT_OPTION_CONNECT_AND_DISCONNECT = "Connect Disconnect";
+    public static final String AUTO_IMPORT_EXPORT_OPTION_CONNECT_ONLY = "Connect Only";
+
 
     public static final String RECENT_TURNOUTS_FILENAME = "engine_driver/recent_turnouts_list.txt";
     private static final String RECENT_CONSISTS_FILENAME = "engine_driver/recent_consist_list.txt";
@@ -315,7 +318,7 @@ public class ImportExportPreferences {
                     String m = context.getResources().getString(R.string.toastImportExportImportSucceeded, exportedPreferencesFileName);
 
                     Log.d("Engine_Driver", "ImportExportPreferences: " + m);
-                    Toast.makeText(context, m, Toast.LENGTH_LONG).show();
+                    Toast.makeText(context, m, Toast.LENGTH_SHORT).show();
 
                 } catch (FileNotFoundException e) {
                     e.printStackTrace();

--- a/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
@@ -1,23 +1,10 @@
 package jmri.enginedriver.logviewer.ui;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-
-import jmri.enginedriver.R;
-import jmri.enginedriver.preferences;
-import jmri.enginedriver.threaded_application;
-import jmri.enginedriver.util.PermissionsHelper;
-
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -34,6 +21,17 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
+import jmri.enginedriver.util.PermissionsHelper;
 
 //import jmri.enginedriver.logviewer.R;
 
@@ -300,7 +298,16 @@ public class LogViewerActivity extends ListActivity {
 
                 isRunning = false;
             }
-
+            finally {
+                if(reader != null) {
+                    try {
+                        reader.close();
+                    }
+                    catch (IOException ex) {
+                        ex.printStackTrace();
+                    }
+                }
+            }
             return null;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -58,8 +59,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.List;
-
-import android.content.Context;
 
 import eu.esu.mobilecontrol2.sdk.MobileControl2;
 import jmri.enginedriver.util.PermissionsHelper;
@@ -216,9 +215,6 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
         advancedPreferences = getResources().getStringArray(R.array.advancedPreferences);
         hideAdvancedPreferences();
-
-        mainapp.checkAndSetOrientationInfo();
-
     }
 
     @Override
@@ -246,24 +242,12 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        mainapp.isRotating = false;
-    }
-
-    @Override
     protected void onPause() {
         //Log.d("Engine_Driver", "preferences.onPause() called");
         super.onPause();
 
         // Unregister the listener            
         getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
-        if (!this.isFinishing()) {
-            mainapp.checkAndSetOrientationInfo();
-            if (!mainapp.isRotating) {
-                mainapp.addNotification(this.getIntent());
-            }
-        }
     }
 
     @Override

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -73,7 +73,6 @@ public class routes extends Activity implements OnGestureListener {
 
     private GestureDetector myGesture;
     private Menu RMenu;
-    private boolean navigatingAway = false;     // flag for onPause: set to true when another activity is selected, false if going into background 
 
     public void refresh_route_view() {
 
@@ -237,7 +236,6 @@ public class routes extends Activity implements OnGestureListener {
     private void witRetry(String s) {
         Intent in = new Intent().setClass(this, reconnect_status.class);
         in.putExtra("status", s);
-        navigatingAway = true;
         startActivity(in);
         connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
     }
@@ -386,9 +384,6 @@ public class routes extends Activity implements OnGestureListener {
 
         //update route list
         refresh_route_view();
-
-        mainapp.checkAndSetOrientationInfo();
-
     }
 
     @Override
@@ -404,14 +399,11 @@ public class routes extends Activity implements OnGestureListener {
         if (!mainapp.setActivityOrientation(this)) { //set screen orientation based on prefs
             Intent in = new Intent().setClass(this, web_activity.class);      // if autoWeb and landscape, switch to Web activity
             in.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT );
-            navigatingAway = true;
             startActivity(in);
             this.finish();
             connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             return;
         }
-
-        navigatingAway = false;
 
         //restore view to last known scroll position
         ListView lv = findViewById(R.id.routes_list);
@@ -442,12 +434,6 @@ public class routes extends Activity implements OnGestureListener {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        mainapp.isRotating = false;
-    }
-
-    @Override
     public void onPause() {
         //Log.d("Engine_Driver","routes.onPause()");
         super.onPause();
@@ -460,13 +446,6 @@ public class routes extends Activity implements OnGestureListener {
         InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
         if (imm != null && rte != null) {
             imm.hideSoftInputFromWindow(rte.getWindowToken(), 0);
-        }
-
-        if (!this.isFinishing() && !navigatingAway) {        //only invoke setContentIntentNotification when going into background
-            mainapp.checkAndSetOrientationInfo();
-            if (!mainapp.isRotating) {
-                mainapp.addNotification(this.getIntent());
-            }
         }
     }
 
@@ -496,7 +475,6 @@ public class routes extends Activity implements OnGestureListener {
         if ((absDeltaX > threaded_application.min_fling_distance) &&
                 (Math.abs(velocityX) > threaded_application.min_fling_velocity) &&
                 (absDeltaX > Math.abs(e2.getY() - e1.getY()))) {
-            navigatingAway = true;
             // left to right swipe goes to throttle
             if (deltaX > 0.0) {
                 this.finish();
@@ -558,20 +536,17 @@ public class routes extends Activity implements OnGestureListener {
         Intent in;
         switch (item.getItemId()) {
             case R.id.throttle_mnu:
-                navigatingAway = true;
                 this.finish();
                 connection_activity.overridePendingTransition(this, R.anim.push_right_in, R.anim.push_right_out);
                 break;
             case R.id.turnouts_mnu:
                 in = new Intent().setClass(this, turnouts.class);
-                navigatingAway = true;
                 startActivity(in);
                 this.finish();
                 connection_activity.overridePendingTransition(this, R.anim.push_left_in, R.anim.push_left_out);
                 break;
             case R.id.web_mnu:
                 in = new Intent().setClass(this, web_activity.class);
-                navigatingAway = true;
                 mainapp.webMenuSelected = true;
                 startActivity(in);
                 this.finish();
@@ -582,25 +557,21 @@ public class routes extends Activity implements OnGestureListener {
                 break;
             case R.id.power_control_mnu:
                 in = new Intent().setClass(this, power_control.class);
-                navigatingAway = true;
                 startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
             case R.id.preferences_mnu:
                 in = new Intent().setClass(this, preferences.class);
-                navigatingAway = true;
                 startActivityForResult(in, 0);   // refresh view on return
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
             case R.id.logviewer_menu:
                 Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
-                navigatingAway = true;
                 startActivity(logviewer);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;
             case R.id.about_mnu:
                 in = new Intent().setClass(this, about_page.class);
-                navigatingAway = true;
                 startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 break;

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -45,7 +45,6 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
-import android.view.animation.ScaleAnimation;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -64,11 +63,7 @@ import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 import android.widget.Toast;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -78,9 +73,8 @@ import java.util.List;
 import java.util.Map;
 
 import jmri.enginedriver.Consist.ConLoco;
-import jmri.jmrit.roster.RosterEntry;
-
 import jmri.enginedriver.util.SwipeDetector;
+import jmri.jmrit.roster.RosterEntry;
 
 //import java.util.Arrays;
 //import java.util.Collection;
@@ -1271,9 +1265,6 @@ public class select_loco extends Activity {
         });
 
         set_labels();
-
-        mainapp.checkAndSetOrientationInfo();
-
         overrideThrottleName = "";
     }
 
@@ -1415,24 +1406,7 @@ public class select_loco extends Activity {
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
     }
 
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        mainapp.isRotating = false;
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing() && !navigatingAway) {        //only invoke setContentIntentNotification when going into background
-            mainapp.checkAndSetOrientationInfo();
-            if (!mainapp.isRotating) {
-                mainapp.addNotification(this.getIntent());
-            }
-        }
-    }
-
-    @Override
+   @Override
     public void onDestroy() {
         Log.d("Engine_Driver", "select_loco.onDestroy() called");
         mainapp.select_loco_msg_handler = null;

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -25,7 +25,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
 import android.text.Editable;
@@ -52,18 +51,15 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
-//import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
-//import android.widget.RelativeLayout;
 import android.widget.SimpleAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 import android.widget.Toast;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -691,15 +687,6 @@ public class turnouts extends Activity implements OnGestureListener {
         //update turnout list
         refresh_turnout_view();
         refreshTurnoutViewStates();
-
-        mainapp.checkAndSetOrientationInfo();
-
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        mainapp.isRotating = false;
     }
 
     @Override
@@ -715,13 +702,6 @@ public class turnouts extends Activity implements OnGestureListener {
         InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
         if (imm != null && trn != null) {
             imm.hideSoftInputFromWindow(trn.getWindowToken(), 0);
-        }
-
-        if (!this.isFinishing() && !navigatingAway) {        //only invoke setContentIntentNotification when going into background
-            mainapp.checkAndSetOrientationInfo();
-            if (!mainapp.isRotating) {
-                mainapp.addNotification(this.getIntent());
-            }
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/jmrit/roster/RosterLoader.java
+++ b/EngineDriver/src/main/java/jmri/jmrit/roster/RosterLoader.java
@@ -1,5 +1,11 @@
 package jmri.jmrit.roster;
 
+import android.util.Log;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -8,12 +14,6 @@ import java.util.HashMap;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import android.util.Log;
 
 public class RosterLoader {
     final URL rosterUrl;
@@ -39,8 +39,9 @@ public class RosterLoader {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         HashMap<String, RosterEntry> roster = new HashMap<String, RosterEntry>();
         try {
+            InputStream rosterStream = this.getInputStream();
             DocumentBuilder builder = factory.newDocumentBuilder();
-            Document dom = builder.parse(this.getInputStream());
+            Document dom = builder.parse(rosterStream);
             Element root = dom.getDocumentElement();
             NodeList items = root.getElementsByTagName("locomotive");
             for (int i = 0; i < items.getLength(); i++) {
@@ -48,6 +49,7 @@ public class RosterLoader {
                 entry.setHostURLs(rosterUrl.getHost() + ":" + rosterUrl.getPort());
                 roster.put(entry.getId(), entry);
             }
+            rosterStream.close();
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
Changed Web activity back to SingleTask. Webview state is preserved across rotations and navigation.

Webview handling in Web and Throttle activities improved. scale preserved properly.

Notifications are now handled in an ApplicationLifecycleHandler. Much cleaner code and no false notifications when rotating.


Explicitly close InputStream in RosterLoader.parse() and BufferedReader in LogViewerActivity.doInBackground.