### PR TITLE
Improve invalid initial web page preference handling

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -190,8 +190,6 @@ public class web_activity extends Activity {
                     urlRestore();
                 }
             }
-            @Override pub
-
             @SuppressWarnings("deprecation")
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {


### PR DESCRIPTION
Previously an invalid initial web page preference (from a typo for instance) would result in continual reloading of the webpage.  The code now uses a loading retry counter  and stops after 3 attempts.

Noted that using onReceivedHttpError produced cleaner code but that callback is only available starting with SDK 23.  The implemented approach works with all supported SDK levels.