### PR TITLE
Separate Throttle and Web initial webpage messages

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
@@ -46,7 +46,8 @@ interface message_type {
     int ROSTER_UPDATE = 23;     // ta -> ed  roster-related data updated in background
     int WIT_CON_RETRY = 24;     // ta -> ed  WiT connection lost and trying to reconnect
     int WIT_CON_RECONNECT = 25; // ta -> ed  WiT connection reestablished
-    int INITIAL_WEBPAGE = 26;   // pref -> throt or web  user changed initial webpage
+    int INITIAL_WEB_WEBPAGE = 26;   // pref -> web  user changed initial webpage
+    int INITIAL_THR_WEBPAGE = 27;   // pref -> throt   user changed initial webpage
     int TIME_CHANGED = 28;      // ta -> activities  updates current time
     int CLOCK_DISPLAY_CHANGED = 29;     // pref -> ta  clock display preference changed
     int ESTOP = 30;             // ta(sendeStopMsg) -> ta  estop requested

--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -317,10 +317,10 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                     mainapp.setActivityOrientation(this);
                     break;
                 case "InitialWebPage":
-                    mainapp.alert_activities(message_type.INITIAL_WEBPAGE, "");
+                    mainapp.alert_activities(message_type.INITIAL_WEB_WEBPAGE, "");
                     break;
                 case "InitialThrotWebPage":
-                    mainapp.alert_activities(message_type.INITIAL_WEBPAGE, "");
+                    mainapp.alert_activities(message_type.INITIAL_THR_WEBPAGE, "");
                     break;
                 case "ClockDisplayTypePreference":
                     mainapp.sendMsg(mainapp.comm_msg_handler, message_type.CLOCK_DISPLAY_CHANGED);

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -978,7 +978,7 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                     webViewIsOn = false;
                     reloadWeb();
                     break;
-                case message_type.INITIAL_WEBPAGE:
+                case message_type.INITIAL_THR_WEBPAGE:
                     initWeb();
                     break;
                 case message_type.REQ_STEAL:

--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -85,7 +85,7 @@ public class web_activity extends Activity {
                     break;
                 case message_type.WIT_CON_RECONNECT:
                     break;
-                case message_type.INITIAL_WEBPAGE:
+                case message_type.INITIAL_WEB_WEBPAGE:
                     urlRestore(true);
                     break;
                 case message_type.TIME_CHANGED:


### PR DESCRIPTION
Throttle and Web webviews were both getting reinitialized when either Initial Web Page preference was changed.  There is now a separate message for each preference change so that only the affected webview is reinitialized.