### PR TITLE
Reinit web_activity on pref change, remove legacy notification calls

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -34,12 +34,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.View.OnTouchListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.AdapterView;
-import android.widget.AdapterView.OnItemClickListener;
-import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
@@ -276,7 +273,6 @@ public class ConsistEdit extends Activity implements OnGestureListener {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;
@@ -287,14 +283,6 @@ public class ConsistEdit extends Activity implements OnGestureListener {
         }
         // suppress popup keyboard until EditText is touched
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {       //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
@@ -271,7 +271,6 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;
@@ -282,14 +281,6 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
         }
         // suppress popup keyboard until EditText is touched
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {       //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
@@ -17,8 +17,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import java.util.HashMap;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.os.Build;
@@ -29,6 +27,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.webkit.WebView;
 import android.widget.TextView;
+
+import java.util.HashMap;
 
 public class about_page extends Activity {
 
@@ -93,7 +93,6 @@ public class about_page extends Activity {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {        //expedite
             this.finish();
             return;
@@ -102,14 +101,6 @@ public class about_page extends Activity {
 
         if (AMenu != null) {
             mainapp.displayEStop(AMenu);
-        }
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {        //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/function_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/function_settings.java
@@ -27,6 +27,8 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.text.method.TextKeyListener;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -36,17 +38,16 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
-import android.widget.EditText;
-
-import java.util.ArrayList;
-import java.io.*;
-
-import android.text.method.TextKeyListener;
-import android.util.Log;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
 
 import jmri.enginedriver.util.PermissionsHelper;
 import jmri.enginedriver.util.PermissionsHelper.RequestCodes;
@@ -162,7 +163,6 @@ public class function_settings extends Activity implements PermissionsHelper.Per
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;
@@ -177,14 +177,6 @@ public class function_settings extends Activity implements PermissionsHelper.Per
     public void onSaveInstanceState(Bundle saveState) {     //orientation change
         move_view_to_settings();        //update settings array so onCreate can use it to initialize
         orientationChange = true;
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {       //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     @Override

--- a/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
@@ -773,21 +773,12 @@ public class gamepad_test extends Activity implements OnGestureListener {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
-       mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
+        mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
         if (CLEMenu != null) {
             mainapp.displayEStop(CLEMenu);
         }
         // suppress popup keyboard until EditText is touched
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {       //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro_activity.java
@@ -28,15 +28,15 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.widget.Toast;
 
-//import com.github.paolorotolo.appintro.AppIntro;
 import com.github.paolorotolo.appintro.AppIntro2;
 import com.github.paolorotolo.appintro.AppIntroFragment;
 import com.github.paolorotolo.appintro.model.SliderPage;
 
 import jmri.enginedriver.util.PermissionsHelper;
+
+//import com.github.paolorotolo.appintro.AppIntro;
 
 public class intro_activity extends AppIntro2 {
     private boolean introComplete = false;
@@ -208,17 +208,8 @@ public class intro_activity extends AppIntro2 {
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing() && !mainapp.introIsRunning) {       //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
 //        if (this.isFinishing()) {        //if finishing, expedite it
 //            return;
 //        }

--- a/EngineDriver/src/main/java/jmri/enginedriver/power_control.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/power_control.java
@@ -155,7 +155,6 @@ public class power_control extends Activity {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) { //expedite
             this.finish();
             return;
@@ -167,14 +166,6 @@ public class power_control extends Activity {
         }
         //update power state
         refresh_power_control_view();
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing()) {      //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -228,7 +228,6 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
             Log.d("Engine_Driver", "preferences.onResume() no dialog to kill");
         }
 
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/reconnect_status.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/reconnect_status.java
@@ -34,7 +34,6 @@ public class reconnect_status extends Activity {
     private threaded_application mainapp;  // hold pointer to mainapp
     private String prog = "";
     private boolean backOk = true;
-    private boolean navigatingAway = false; // true if another activity was selected (false in onPause if going into background)
     private boolean retryFirst = false;
 
     //Handle messages from the communication thread back to this thread (responses from withrottle)
@@ -97,7 +96,6 @@ public class reconnect_status extends Activity {
     };
 
     private void closeScreen() {
-        navigatingAway = true;
         this.finish();                  //end this activity
         connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
     }
@@ -144,23 +142,12 @@ public class reconnect_status extends Activity {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) { //expedite
             this.finish();
             return;
         }
         mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
-        navigatingAway = false;
-
         this.backOk = true;
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        if (!this.isFinishing() && !navigatingAway) {        //only invoke setContentIntentNotification when going into background
-            mainapp.addNotification(this.getIntent());
-        }
     }
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -390,7 +390,6 @@ public class routes extends Activity implements OnGestureListener {
     public void onResume() {
         //Log.d("Engine_Driver","routes.onResume()");
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -1390,7 +1390,6 @@ public class select_loco extends Activity {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -1730,7 +1730,7 @@ public class threaded_application extends Application {
      * Currently call this from each activity onPause, passing the current intent
      * to return to when reopening.
      */
-    void addNotification(Intent notificationIntent) {
+    private void addNotification(Intent notificationIntent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             String CHANNEL_ID = "ed_channel_01";// The id of the channel.
             CharSequence name = this.getString(R.string.notification_title);// The user-visible name of the channel.
@@ -1774,7 +1774,7 @@ public class threaded_application extends Application {
     }
 
     // Remove notification
-    void removeNotification() {
+    private void removeNotification() {
         NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         manager.cancel(ED_NOTIFICATION_ID);
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -981,6 +981,12 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                 case message_type.INITIAL_THR_WEBPAGE:
                     initWeb();
                     break;
+                case message_type.INITIAL_WEB_WEBPAGE:
+                    // if web activity is not open then reinit web statics for next time it is opened
+                    if (mainapp.web_msg_handler == null) {
+                        web_activity.initStatics();
+                    }
+                    break;
                 case message_type.REQ_STEAL:
                     promptForSteal( msg.obj.toString(), msg.arg1);
                     break;

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -708,7 +708,6 @@ public class turnouts extends Activity implements OnGestureListener {
     @Override
     public void onResume() {
         super.onResume();
-        mainapp.removeNotification();
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -86,6 +86,7 @@ public class web_activity extends Activity {
                 case message_type.WIT_CON_RECONNECT:
                     break;
                 case message_type.INITIAL_WEB_WEBPAGE:
+                    initStatics();
                     urlRestore(true);
                     break;
                 case message_type.TIME_CHANGED:


### PR DESCRIPTION
Reinitialize the web_activity statics if the Web initial webpage preference is changed while the web_activity is not open.  This will cause the new initial webpage to get loaded the next time the web_activity is opened.