### PR TITLE
Revise restart mechanism following Preference change

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -159,6 +159,7 @@ public class ConsistEdit extends Activity implements OnGestureListener {
                 case message_type.WIT_CON_RECONNECT:
                     refreshConsistLists();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
@@ -141,6 +141,7 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
                 case message_type.WIT_CON_RECONNECT:
                     refreshConsistLists();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
@@ -66,4 +66,5 @@ interface message_type {
     int IMPORT_SERVER_MANUAL_FAIL = 43;    //
     int IMPORT_SERVER_AUTO_AVAILABLE = 44;    //
     int WIT_TURNOUT_NOT_DEFINED = 45;    //
+    int RESTART_APP = 46;   //
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/power_control.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/power_control.java
@@ -61,6 +61,7 @@ public class power_control extends Activity {
                 case message_type.WIT_CON_RECONNECT:
                     refresh_power_control_view();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -449,8 +449,12 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                 saveSharedPreferencesToFile(sharedPreferences, exportedPreferencesFileName, false);
             }
         }
-
-        mainapp.forceRestartApp(forcedRestartReason);
+        this.finish();
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+        Message msg = Message.obtain();
+        msg.what = message_type.RESTART_APP;
+        msg.arg1 = forcedRestartReason;
+        mainapp.comm_msg_handler.sendMessage(msg);
     }
 
     @SuppressLint("ApplySharedPref")

--- a/EngineDriver/src/main/java/jmri/enginedriver/reconnect_status.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/reconnect_status.java
@@ -55,6 +55,7 @@ public class reconnect_status extends Activity {
                     refresh_reconnect_status(msg.obj.toString());
                     reconnected();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -226,6 +226,7 @@ public class routes extends Activity implements OnGestureListener {
                 case message_type.TIME_CHANGED:
                     setActivityTitle();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -411,6 +411,7 @@ public class select_loco extends Activity {
                     roster_list_adapter.notifyDataSetChanged();
                     set_labels();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                     Log.d("Engine_Driver", "select_loco: select_loco_handler - DISCONNECT");
                     end_this_activity();

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -336,6 +336,7 @@ public class turnouts extends Activity implements OnGestureListener {
                 case message_type.TIME_CHANGED:
                     setActivityTitle();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();

--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -92,6 +92,7 @@ public class web_activity extends Activity {
                 case message_type.TIME_CHANGED:
                     setActivityTitle();
                     break;
+                case message_type.RESTART_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
                     disconnect();


### PR DESCRIPTION
Changed the mechanism used when a Preference change (ex. theme change) necessitates a restart.  The new approach is basically to disconnect from WiT, close all activities and restart CA without ever exiting ED.

There is a new RESTART_APP message type associated with the change. If a restart is required then Prefs or Throttle sends this message to TA.  TA closed the WiT connection and then sends the message to all Activities.  Most activities treat this message the same as DISCONNECT.  Throttle or CA (whichever is alive) launch a new CA instance then finish.