### PR TITLE
outbound heartbeat restart

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -1544,9 +1544,7 @@ public class threaded_application extends Application {
                     try {
                         outputPW.println(msg);
                         outputPW.flush();
-                        //we could restart outbound heartbeat timer here, but wit does not notify us of speed changes
-                        //(caused by other throttles for example) so just keep heartbeat going to get regular speed updates
-                        //heart.restartOutboundInterval();
+                        heart.restartOutboundInterval();
 
                         // if we get here without an exception then the socket is ok
                         if (reconInProg) {


### PR DESCRIPTION
Restart the outbound heartbeat on every successful send to WiT.  JMRI now sends speed and direction updates regardless of the source of the change for inuse engines so we don't need to rely on explicit periodic requests for speed and direction.