### PR TITLE
Ensure WiT gets final speed value

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -36,6 +36,8 @@
     <li>Add fastclock to other activities</li>
     <li>New longpress to reload web view</li>
     <li>Eliminated erroneous background notifications when device is rotated</li>
+    <li>Reduced JMRI communication during throttle speed changes to improve reliability</li>
+    <li>Improved JMRI communication timeout handling</li>
     <li>Invalid initial web page preference setting now handled gracefully by web view</li>
     <li>Additional French Translations by Alain Carasso</li>
     <li>Prevent crash reported to Play Console</li>

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
@@ -747,7 +747,7 @@ public class throttle_switching_left_or_right extends throttle {
             speedWiT = 0;
 
         int sliderPosition;
-        if (!changeTimers[whichThrottle].delayInProg) {
+        if (!changeTimers[whichThrottle].isDelayInProgress()) {
             sliderPosition = getNewSliderPositionFromSpeed(speedWiT, whichThrottle, false);
             vsbSwitchingSpeeds[whichThrottle].setProgress(sliderPosition);
         }


### PR DESCRIPTION
Sends the last speed value to WiT after the pacing delay expires if it hasn't already been sent.  This ensures WiT has the latest speed value.