### PR TITLE
Add error handling

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -210,8 +210,18 @@ public class ConsistEdit extends Activity implements OnGestureListener {
             whichThrottle = mainapp.throttleCharToInt(extras.getChar("whichThrottle"));
             saveConsistsFile = extras.getChar("saveConsistsFile");
         }
+        else {
+            Log.d("debug", "ConsistEdit.onCreate: no bundle - whichThrottle undefined, setting to 0");
+            whichThrottle = 0;
+        }
 
-        consist = mainapp.consists[whichThrottle];
+        if(mainapp.consists != null) {
+            consist = mainapp.consists[whichThrottle];
+        }
+        else {
+            Log.d("debug", "ConsistEdit.onCreate: mainapp.consists[] is null");
+            this.finish();
+        }
 
         //Set up a list adapter to allow adding the list of recent connections to the UI.
         consistList = new ArrayList<>();

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -3026,7 +3026,16 @@ end force shutdown */
             case 'P':
                 return 32; // PP - power state change
         }
-        return Character.getNumericValue(cWhichThrottle);
+//        return Character.getNumericValue(cWhichThrottle);
+        int val = Character.getNumericValue((cWhichThrottle));
+        if(val < 0) {
+            Log.d("debug", "TA.throttleCharToInt: converted value " + val + " is invalid.  char was " + cWhichThrottle + " (int " + (int)cWhichThrottle + ")");
+            val = 0;
+        }
+        else {
+            Log.d("debug", "TA.throttleCharToInt: no match for argument " + cWhichThrottle + " (int " + (int)cWhichThrottle + ")");
+        }
+        return val;
     }
 
     public char throttleIntToChar(int whichThrottle) {


### PR DESCRIPTION
Adding error handling and diagnostics in ConsistEdit.onCreate to prevent reported crash.

Adding error handling and diagnostics in TA.throttleCharToInt to identify cases where the argument is invalid and to prevent returning negative values.