### PR TITLE
Suppress WiT message on exit unless connected

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -693,7 +693,8 @@ public class threaded_application extends Application {
                     }
                     //send Q to withrottle server
                     case message_type.WITHROTTLE_QUIT:
-                        withrottle_send("Q");
+                        if(socketWiT != null && socketWiT.SocketGood())
+                            withrottle_send("Q");
                         break;
 
                     //send heartbeat start command to withrottle server


### PR DESCRIPTION
Don't attempt to send a "Q" to WiT on exit unless the socket is good.  When there was no connection, this was producing a toast message on exit about failing to connect.