### PR TITLE
consists null debugging and fixes

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -215,13 +215,16 @@ public class ConsistEdit extends Activity implements OnGestureListener {
             whichThrottle = 0;
         }
 
-        if(mainapp.consists != null) {
-            consist = mainapp.consists[whichThrottle];
-        }
-        else {
-            Log.d("debug", "ConsistEdit.onCreate: mainapp.consists[] is null");
+        if(mainapp.consists==null || mainapp.consists[whichThrottle]==null) {
+            if(mainapp.consists==null)
+                Log.d("Engine_Driver", "consistEdit onCreate consists is null");
+            else
+                Log.d("Engine_Driver", "consistEdit onCreate consists[" + whichThrottle + "] is null");
             this.finish();
+            return;
         }
+
+        consist = mainapp.consists[whichThrottle];
 
         //Set up a list adapter to allow adding the list of recent connections to the UI.
         consistList = new ArrayList<>();

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistLightsEdit.java
@@ -192,6 +192,15 @@ public class ConsistLightsEdit extends Activity implements OnGestureListener {
         LIGHT_TEXT_FOLLOW = getApplicationContext().getResources().getString(R.string.lightsTextFollow);
         LIGHT_TEXT_UNKNOWN = getApplicationContext().getResources().getString(R.string.lightsTextUnknown);
 
+        if(mainapp.consists==null || mainapp.consists[whichThrottle]==null) {
+            if(mainapp.consists==null)
+                Log.d("Engine_Driver", "consistLightsEdit onCreate consists is null");
+            else
+                Log.d("Engine_Driver", "consistLightsEdit onCreate consists[" + whichThrottle + "] is null");
+            this.finish();
+            return;
+        }
+
         consist = mainapp.consists[whichThrottle];
 
         //Set up a list adapter to allow adding the list of recent connections to the UI.

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -455,6 +455,15 @@ public class select_loco extends Activity {
             l.setRosterName(null); //make sure rosterName is null
             l.setFunctionLabelDefaults(mainapp, whichThrottle);
         }
+        if(mainapp.consists==null || mainapp.consists[whichThrottle]==null) {
+            if(mainapp.consists==null)
+                Log.d("Engine_Driver", "acquireEngine consists is null");
+            else if(mainapp.consists[whichThrottle]==null)
+                Log.d("Engine_Driver", "acquireEngine consists["+whichThrottle+"] is null");
+            end_this_activity();
+            return;
+        }
+
         Consist consist = mainapp.consists[whichThrottle];
 
         // if we already have it do nothing

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -3077,7 +3077,7 @@ end force shutdown */
                 Log.d("debug", "TA.throttleCharToInt: no match for argument " + cWhichThrottle);
                 break;
         }
-        if(val > maxThrottlesCurrentScreen) {
+        if(val > maxThrottlesCurrentScreen) 
             Log.d("debug", "TA.throttleCharToInt: argument exceeds max number of throttles for current screen " + cWhichThrottle );
         return val;
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -867,15 +867,18 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             switch (msg.what) {
                 case message_type.RESPONSE: { // handle messages from WiThrottle server
                     if (response_str.length() < 2)
-                        return;  //bail if too short, to avoid crash
-                    char com1 = response_str.charAt(0);
-                    int whichThrottle = mainapp.throttleCharToInt(response_str.charAt(1)); // '0', '1'',2' etc.
+                        break;  //bail if too short, to avoid crash
+                    char com0 = response_str.charAt(0);
+                    char com1 = response_str.charAt(1);
+//                    int whichThrottle = mainapp.throttleCharToInt(response_str.charAt(1)); // '0', '1'',2' etc.
+                    int whichThrottle;
 
-                    switch (com1) {
+                    switch (com0) {
                         // various MultiThrottle messages
                         case 'M':  // multi-throttle
                             if (response_str.length() < 3)
-                                return;  //bail if too short, to avoid crash
+                                break;  //bail if too short, to avoid crash
+                            whichThrottle = mainapp.throttleCharToInt(com1); // '0', '1'',2' etc.
                             char com2 = response_str.charAt(2);
                             String[] ls = threaded_application.splitByString(response_str, "<;>");
                             String addr;
@@ -971,11 +974,12 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                         case '3':
                         case '4':
                         case '5':
-                            enable_disable_buttons(com1); // pass whichthrottle
+                            enable_disable_buttons(com0); // pass whichthrottle
                             set_labels();
                             break;
-
+/* dead code ***
                         case 'R':  // Roster info
+                            whichThrottle = mainapp.throttleCharToInt(com1); // '0', '1'',2' etc.
                             if (whichThrottle >= 0 && whichThrottle <= mainapp.numThrottles) {
                                 set_function_labels_and_listeners_for_view(whichThrottle);
                                 enable_disable_buttons_for_view(fbs[whichThrottle], true);
@@ -992,14 +996,13 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
                                 }
                             }
                             break;
+ *** end dead code */
                         case 'P': // panel info
-//                            if (whichThrottle == 'W') { // PW - web server port info
-                            if (whichThrottle == 39) { // PW - web server port info
+                            if (com1 == 'W') { // PW - web server port info
                                 initWeb();
                                 set_labels();
                             }
-//                            if (whichThrottle == 'P') { // PP - power state change
-                            if (whichThrottle == 32) { // PP - power state change
+                            else if (com1 == 'P') { // PP - power state change
                                 set_labels();
                             }
                             break;
@@ -5019,50 +5022,55 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
     }
 
     private void showHideConsistMenus(){
-        if ((mainapp.consists==null) || (mainapp.consists[0]==null)) return;
+        if (mainapp.consists==null) {
+            Log.d("Engine_Driver", "showHideConsistMenu consists[] is null");
+            return;
+        }
 
         if (TMenu != null) {
-            boolean any = false;
+            boolean anyConsist = false;
             for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
-
+                Consist con = mainapp.consists[throttleIndex];
+                if (con == null) {
+                    Log.d("Engine_Driver", "showHideConsistMenu consists[" + throttleIndex + "] is null");
+                    break;
+                }
+                boolean isMulti = con.isMulti();
                 switch (throttleIndex) {
                     case 0:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditConsist0_menu).setVisible(mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist0_menu).setVisible(mainapp.consists[0].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditConsist0_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditLightsConsist0_menu).setVisible(isMulti);
                         break;
                     case 1:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist1_menu).setVisible(mainapp.consists[1].isMulti());
-                        TMenu.findItem(R.id.EditConsist1_menu).setVisible(mainapp.consists[1].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditLightsConsist1_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditConsist1_menu).setVisible(isMulti);
                         break;
                     case 2:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist2_menu).setVisible(mainapp.consists[2].isMulti());
-                        TMenu.findItem(R.id.EditConsist2_menu).setVisible(mainapp.consists[2].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditLightsConsist2_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditConsist2_menu).setVisible(isMulti);
                         break;
                     case 3:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist3_menu).setVisible(mainapp.consists[3].isMulti());
-                        TMenu.findItem(R.id.EditConsist3_menu).setVisible(mainapp.consists[3].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditLightsConsist3_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditConsist3_menu).setVisible(isMulti);
                         break;
                     case 4:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist4_menu).setVisible(mainapp.consists[4].isMulti());
-                        TMenu.findItem(R.id.EditConsist4_menu).setVisible(mainapp.consists[4].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditLightsConsist4_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditConsist4_menu).setVisible(isMulti);
                         break;
                     case 5:
-                        any = (any || mainapp.consists[0].isMulti());
-                        TMenu.findItem(R.id.EditLightsConsist5_menu).setVisible(mainapp.consists[5].isMulti());
-                        TMenu.findItem(R.id.EditConsist5_menu).setVisible(mainapp.consists[5].isMulti());
+                        anyConsist |= isMulti;
+                        TMenu.findItem(R.id.EditLightsConsist5_menu).setVisible(isMulti);
+                        TMenu.findItem(R.id.EditConsist5_menu).setVisible(isMulti);
                         break;
                 }
             }
-            if (any) {
-                TMenu.findItem(R.id.edit_consists_menu).setVisible(any);
-            }
+            TMenu.findItem(R.id.edit_consists_menu).setVisible(anyConsist);
         }
-
     }
 
     @Override

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_full.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_full.java
@@ -209,19 +209,30 @@ public class throttle_full extends throttle {
         final double minTextScale = 0.5;
         String bLabel;
         String bLabelPlainText;
+
+        if(mainapp.consists==null) {
+            Log.d("Engine_Driver", "throttle_full.setLabels consists is null");
+            return;
+        }
+
         for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
             Button b = bSels[throttleIndex];
             bLabel = getApplicationContext().getResources().getString(R.string.locoPressToSelect);
             bLabelPlainText = bLabel;
-            if ((mainapp.consists != null) && (mainapp.consists[throttleIndex] != null)) {
-                if (mainapp.consists[throttleIndex].isActive()) {
+
+            Consist con = mainapp.consists[throttleIndex];
+            if(con==null) {
+                Log.d("Engine_Driver", "throttle_full setLabels consists[" + throttleIndex + "] is null");
+            }
+            else {
+                if (con.isActive()) {
                     if (!prefShowAddressInsteadOfName) {
                         if (!overrideThrottleNames[throttleIndex].equals("")) {
                             bLabel = overrideThrottleNames[throttleIndex];
                             bLabelPlainText = overrideThrottleNames[throttleIndex];
                         } else {
-                            bLabel = mainapp.consists[throttleIndex].toHtml();
-                            bLabelPlainText = mainapp.consists[throttleIndex].toString();
+                            bLabel = con.toHtml();
+                            bLabelPlainText = con.toString();
                         }
 
 //                        bLabel = mainapp.consists[throttleIndex].toString();
@@ -229,7 +240,7 @@ public class throttle_full extends throttle {
 //                        bLabel = mainapp.consists[throttleIndex].toHtml();
                     } else {
                         if (overrideThrottleNames[throttleIndex].equals("")) {
-                            bLabel = mainapp.consists[throttleIndex].formatConsistAddr();
+                            bLabel = con.formatConsistAddr();
                         } else {
                             bLabel = overrideThrottleNames[throttleIndex];
                         }
@@ -353,6 +364,8 @@ public class throttle_full extends throttle {
             // update the state of each function button based on shared variable
             set_all_function_states(throttleIndex);
         }
+
+
         if ( (screenHeight > throttleMargin) && (mainapp.consists!=null)) { // don't do this if height is invalid
             //Log.d("Engine_Driver","starting screen height adjustments, screenHeight=" + screenHeight);
             // determine how to split the screen (evenly if all three, 45/45/10 for two, 80/10/10 if only one)


### PR DESCRIPTION
Added more tests for null consists and null consists[i] entries.

Added try/catch block in TA.initShared() to log any instance where consists and function arrays can't be instantiated.

Corrected logic in throttle.showHideConsistMenu().

Updated throttleCharToInt() for better debug error reporting, removed unused case statements and clarified code.

Revised throttle message handler so whichThrottle is only calculated when the message actually contains a whichThrottle value.  This suppresses error messages generated by throttleCharToInt from getting passed non-throttle values.

Commented out dead WiT 'R' case block in throttle message handler.

Simplified tests in WiT 'P' case block in throttle message handler.