### PR TITLE
Clean up of Force restart on change of the WiFi / Mobile Data preference

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -406,6 +406,10 @@ public class connection_activity extends Activity implements PermissionsHelper.P
             mainapp = (threaded_application) this.getApplication();
             mainapp.connection_msg_handler = new ui_handler();
 
+            mainapp.connectedHostName = "";
+            mainapp.connectedHostip = "";
+            mainapp.connectedPort = 0;
+
             connToast = Toast.makeText(this, "", Toast.LENGTH_LONG);    // save toast obj so it can be cancelled
             // setTitle(getApplicationContext().getResources().getString(R.string.app_name_connect));	//set title to long form of label
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -113,6 +113,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
     private boolean forceRestartAppOnPreferencesClose = false;
     private int forceRestartAppOnPreferencesCloseReason = 0;
+    private boolean forceReLaunchAppOnPreferencesClose = false;
 
     SharedPreferences sharedPreferences;
     /**
@@ -161,7 +162,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
             preference = (ListPreference) findPreference("prefHostImportExport");
             preference.setEntries(prefHostImportExportEntriesFound);
             preference.setEntryValues(prefHostImportExportEntryValuesFound);
+            enableDisablePreference("prefAllowMobileData", true);
         } else {
+            enableDisablePreference("prefAllowMobileData", false);
             enableDisablePreference("prefHostImportExport", false);
         }
 
@@ -277,6 +280,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
         }
         if (forceRestartAppOnPreferencesClose) {
             forceRestartApp(forceRestartAppOnPreferencesCloseReason);
+        }
+        if (forceReLaunchAppOnPreferencesClose) {
+            forceReLaunchApp(forceRestartAppOnPreferencesCloseReason);
         }
     }
 
@@ -476,7 +482,9 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
 
                 case "prefAllowMobileData":
                     mainapp.haveForcedWiFiConnection = false;
-                    forceReLaunchApp(mainapp.FORCED_RESTART_REASON_FORCE_WIFI);
+//                    forceReLaunchApp(mainapp.FORCED_RESTART_REASON_FORCE_WIFI);
+                    forceRestartAppOnPreferencesCloseReason = mainapp.FORCED_RESTART_REASON_FORCE_WIFI;
+                    forceReLaunchAppOnPreferencesClose = true;
                     break;
             }
         }


### PR DESCRIPTION
Hide preference if the hostname is not blank
Restart app on close of preferences
Clear hostname,ip,port in onCreate of CA