### PR TITLE
Avoid crashing when updating knob position if speed-steps changed

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -3533,7 +3533,11 @@ public class throttle extends FragmentActivity implements android.gesture.Gestur
             knobPos = esuThrottleScales[whichThrottle].stepToPosition(speed);
             Log.d("Engine_Driver", "ESU_MCII: Update knob position for throttle " + mainapp.throttleIntToString(whichThrottle));
             Log.d("Engine_Driver", "ESU_MCII: New knob position: " + knobPos + " ; speedstep: " + speed);
-            esuThrottleFragment.moveThrottle(knobPos);
+            try {
+                esuThrottleFragment.moveThrottle(knobPos);
+            } catch (IllegalArgumentException ex) {
+                Log.e("Engine_Driver", "ESU_MCII: Problem moving throttle " + ex.getMessage());
+            }
         } else {
             Log.d("Engine_Driver", "ESU_MCII: This throttle not selected for control by knob");
         }


### PR DESCRIPTION
This deals with the edge-case where the linked command station changes the speedsteps setting for the currently controlled loco.

As a result, the app will no longer crash, rather ignore the knob position request. 