### PR TITLE
Force the app to really restart on Localisation change

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/preferences.java
@@ -441,6 +441,7 @@ public class preferences extends PreferenceActivity implements OnSharedPreferenc
                     sharedPreferences.edit().putString("prefRightDirectionButtons", "").commit();
                     sharedPreferences.edit().putString("prefLeftDirectionButtonsShort", "").commit();
                     sharedPreferences.edit().putString("prefRightDirectionButtonsShort", "").commit();
+                    forceReLaunchAppOnPreferencesClose = true;
                     forceRestartApp(mainapp.FORCED_RESTART_REASON_LOCALE);
                     break;
                 case "prefDirectionButtonLongPressDelay":


### PR DESCRIPTION
Brut force restart seemed to be needed to fully reload everything with the chosen language.