### PR TITLE
Fix - Shunting/Switching layout not updating correctly

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -31,6 +31,7 @@
     <li>hide "Server Roster" loco selection option if server doesn't support rosters.</li>
     <li>Fixes to the 'Special' Consist follow functions to allow it to work for forced Defualt Function labels and a single loco.</li>
     <li>avoid crashes reported to Play Store</li>
+    <li>Fix for Shunting/Switching layout not updating correctly; when direction changed on another device; when changing throttle layouts and the direction was reverse. </li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -934,6 +934,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                             if (dir != curDir) { // lead/consist direction changed from outside of ED
                                                 showDirectionRequest(whichThrottle, dir);       // update requested direction indication
                                                 setEngineDirection(whichThrottle, dir, true);   // update rest of consist to match new direction
+                                                // needed for the switching throttle layouts
+                                                speedUpdate(whichThrottle,
+                                                        getSpeedFromCurrentSliderPosition(whichThrottle, false));
                                             }
                                         } else {
                                             int locoDir = curDir;               // calc correct direction for this (non-lead) loco
@@ -6367,4 +6370,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
     }
 
+    int getSpeedFromCurrentSliderPosition(int whichThrottle, boolean useScale) {
+        // separate versions of this exist for the switching throttle layouts
+        int speed;
+        if (!useScale) {
+                speed = getSpeed(whichThrottle);
+            } else {
+                speed = getScaleSpeed(whichThrottle);
+        }
+        return speed;
+    }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_horizontal.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_horizontal.java
@@ -548,6 +548,12 @@ public class throttle_switching_horizontal extends throttle {
         // update the direction indicators
         showDirectionIndications();
 
+        // update the switching sliders if necessary
+        for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
+            speedUpdate(throttleIndex,
+                    getSpeedFromCurrentSliderPosition(throttleIndex,false));
+        }
+
 //        // update the state of each function button based on shared variable
         for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
             set_all_function_states(throttleIndex);
@@ -556,7 +562,7 @@ public class throttle_switching_horizontal extends throttle {
 
         // Log.d("Engine_Driver","ending set_labels");
 
-    }
+    } // end set_labels
 
     @Override
     void enable_disable_buttons(int whichThrottle, boolean forceDisable) {
@@ -925,6 +931,9 @@ public class throttle_switching_horizontal extends throttle {
         return (getDirection(whichThrottle) == direction);
     }
 
+    int getSpeedFromCurrentSliderPosition(int whichThrottle, boolean useScale) {
+        return getSpeedFromSliderPosition(hsbSwitchingSpeeds[whichThrottle].getProgress(), whichThrottle, useScale);
+    }
 
     int getSpeedFromSliderPosition(int sliderPosition, int whichThrottle, boolean useScale) {
         int speed;

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
@@ -364,6 +364,12 @@ public class throttle_switching_left_or_right extends throttle {
         // update the direction indicators
         showDirectionIndications();
 
+        // update the switching sliders if necessary
+        for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
+            speedUpdate(throttleIndex,
+                    getSpeedFromCurrentSliderPosition(throttleIndex,false));
+        }
+
 
         final DisplayMetrics dm = getResources().getDisplayMetrics();
         // Get the screen's density scale
@@ -872,6 +878,9 @@ public class throttle_switching_left_or_right extends throttle {
         return (getDirection(whichThrottle) == direction);
     }
 
+    int getSpeedFromCurrentSliderPosition(int whichThrottle, boolean useScale) {
+        return getSpeedFromSliderPosition(vsbSwitchingSpeeds[whichThrottle].getProgress(), whichThrottle, useScale);
+    }
 
     int getSpeedFromSliderPosition(int sliderPosition, int whichThrottle, boolean useScale) {
         int speed;


### PR DESCRIPTION
- when direction changed on another device.
- when changing throttle layouts and the direction was reverse.