### PR TITLE
API update - Android 4 problem

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     android:versionName="2.30.134" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />

--- a/EngineDriver/src/main/java/jmri/enginedriver/ImportExportConnectionList.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ImportExportConnectionList.java
@@ -92,8 +92,8 @@ class ImportExportConnectionList {
                     }
                 }
                 list_reader.close();
-
-
+            } else {
+                Log.d("connection_activity", "Recent connections not found");
             }
         } catch (IOException except) {
             errMsg = except.getMessage();

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -1449,6 +1449,8 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                         }
                     }
                     list_reader.close();
+                } else {
+                    Log.d("settingActivity", "getConnectionsList: Recent connections not found");
                 }
             } catch (IOException except) {
                 errMsg = except.getMessage();

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -1051,11 +1051,16 @@ public class connection_activity extends AppCompatActivity implements Permission
 
     protected void checkForLegacyFilesImpl() {
         File sdcard_path = Environment.getExternalStorageDirectory();
-        File legacy_dir = new File(sdcard_path, "engine_driver/");
+        File legacy_dir = new File(sdcard_path, "engine_driver");
+        if (legacy_dir.isDirectory()) {
+            Log.d("Engine_Driver", "ca: checkForLegacyFilesImpl - legacy folder found:");
+        }
 
         File connection_file = new File(context.getExternalFilesDir(null), "connections_list.txt");
+        File legacyConnection_file = new File(sdcard_path, "engine_driver/connections_list.txt");
 
-        if ( (!connection_file.exists()) && (legacy_dir!=null) ) {
+//        if ( (!connection_file.exists()) && (legacy_dir!=null) ) {
+        if ( (!connection_file.exists()) && (legacyConnection_file.exists()) ) {
 
             String[] childFiles = legacy_dir.list();
             if (childFiles!=null) {


### PR DESCRIPTION
- Android 4 does not have permission to Scoped Storage unless WRITE_EXTERNAL_STORAGE is also granted (which is ignored in all other versions)API update - Android 4 
This is not mentioned in any doco I found