### PR TITLE
Various fixes

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -138,6 +138,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
     private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
 
+    private boolean ignoreThisThrottleNumChange = false;
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     @Override
@@ -250,7 +251,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @Override
     protected void onDestroy() {
-        Log.d("Engine_Driver", "preferences.onDestroy() called");
+        Log.d("Engine_Driver", "settings.onDestroy() called");
         super.onDestroy();
         if (mainapp.settings_msg_handler !=null) {
             mainapp.settings_msg_handler.removeCallbacksAndMessages(null);
@@ -683,6 +684,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
+        Log.d("Engine_Driver", "Settings: onCreateOptionsMenu()");
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.settings_menu, menu);
         SAMenu = menu;
@@ -721,6 +723,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.d("Engine_Driver", "Settings: onActivityResult()");
         super.onActivityResult(requestCode, resultCode, data);
         try {
             // When an Image is picked
@@ -755,6 +758,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     protected boolean limitIntPrefValue(PreferenceScreen prefScreen, SharedPreferences sharedPreferences, String key, int minVal, int maxVal, String defaultVal) {
+        Log.d("Engine_Driver", "Settings: limitIntPrefValue()");
         boolean isValid = true;
         EditTextPreference prefText = (EditTextPreference) prefScreen.findPreference(key);
         try {
@@ -781,6 +785,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     protected boolean limitFloatPrefValue(PreferenceScreen prefScreen, SharedPreferences sharedPreferences, String key, Float minVal, Float maxVal, String defaultVal) {
+        Log.d("Engine_Driver", "Settings: limitFloatPrefValue()");
         boolean isValid = true;
         EditTextPreference prefText = (EditTextPreference) prefScreen.findPreference(key);
         try {
@@ -807,6 +812,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void checkThrottleScreenType(SharedPreferences sharedPreferences) {
+        Log.d("Engine_Driver", "Settings: checkThrottleScreenType()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
         if (!prefThrottleScreenType.equals(prefThrottleScreenTypeOriginal)) {
@@ -818,7 +824,8 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     @SuppressLint("ApplySharedPref")
-    public void limitNumThrottles(SharedPreferences sharedPreferences) {
+    public void limitNumThrottles(PreferenceScreen prefScreen, SharedPreferences sharedPreferences) {
+        Log.d("Engine_Driver", "Settings: limitNumThrottles()");
         int numThrottles = mainapp.Numeralise(sharedPreferences.getString("NumThrottle", getResources().getString(R.string.NumThrottleDefaulValue)));
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
@@ -831,15 +838,24 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         if ( ((fixed[index] == 1) && (numThrottles != max[index]))
                 || ((fixed[index] == 0) && (numThrottles > max[index])) ) {
-// //            Log.d("Engine_Driver", "Settings: limitNumThrottles: numThrottles " +  numThrottles + " fixed " + fixed[index] + " max " + max[index]);
+            Log.d("Engine_Driver", "Settings: limitNumThrottles: numThrottles " +  numThrottles + " fixed " + fixed[index] + " max " + max[index]);
 
             sharedPreferences.edit().putString("NumThrottle", textNumbers[max[index]-1]).commit();
-            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastNumThrottles, textNumbers[max[index]-1]), Toast.LENGTH_LONG).show();
-//            reload();
+            if (numThrottles > max[index]-1) { // only display the warning if the requested amount is lower than the max or fixed.
+                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastNumThrottles, textNumbers[max[index] - 1]), Toast.LENGTH_LONG).show();
+            }
+            ListPreference p = (ListPreference) prefScreen.findPreference("NumThrottle");
+            if (p != null) {
+                ignoreThisThrottleNumChange = true;
+                Log.d("Engine_Driver", "Settings: limitNumThrottles: textNumbers[max[index]-1]: " +  textNumbers[max[index]-1] + " index: " + index);
+                p.setValue(textNumbers[max[index]-1]);
+                p.setValueIndex(max[index]-1);
+            }
         }
     }
 
     boolean throttleScreenTypeSupportsWebView(SharedPreferences sharedPreferences) {
+        Log.d("Engine_Driver", "Settings: throttleScreenTypeSupportsWebView()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         boolean supportsWebView = false;
 
@@ -855,6 +871,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     int getThrottleScreenTypeArrayIndex(SharedPreferences sharedPreferences) {
+        Log.d("Engine_Driver", "Settings: getThrottleScreenTypeArrayIndex()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
         int index = -1;
@@ -939,6 +956,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void enableDisablePreference(PreferenceScreen prefScreen, String key, boolean enable) {
+        Log.d("Engine_Driver", "Settings: enableDisablePreference(): key: " + key);
         Preference p = prefScreen.findPreference(key);
         if (p != null) {
             p.setSelectable(enable);
@@ -1000,6 +1018,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void showHideThrottleSwitchPreferences(PreferenceScreen prefScreen) {
+        Log.d("Engine_Driver", "Settings: showHideThrottleSwitchPreferences()");
         prefThrottleScreenType = prefs.getString("prefThrottleScreenType",
                 getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         boolean enable = prefThrottleScreenType.equals("Simple");
@@ -1101,6 +1120,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @SuppressLint("ApplySharedPref")
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+            Log.d("Engine_Driver", "Settings: onSharedPreferenceChanged(): key: " + key);
             boolean prefForcedRestart = sharedPreferences.getBoolean("prefForcedRestart", false);
 
             if (!prefForcedRestart) {  // don't do anything if the preference have been loaded and we are about to reload the app.
@@ -1173,7 +1193,10 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                         showHideThrottleWebViewPreferences(sharedPreferences);
                     case "NumThrottle":
                         showHideThrottleNumberPreference(sharedPreferences);
-                        parentActivity.limitNumThrottles(sharedPreferences);
+                        if (!parentActivity.ignoreThisThrottleNumChange) {
+                            parentActivity.limitNumThrottles(getPreferenceScreen(), sharedPreferences);
+                        }
+                        parentActivity.ignoreThisThrottleNumChange = false;
                         break;
 
                     case "prefTheme":
@@ -1208,6 +1231,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         }
 
         void setPreferencesUI() {
+            Log.d("Engine_Driver", "Settings: setPreferencesUI()");
             prefs = parentActivity.prefs;
             defaultName = parentActivity.getApplicationContext().getResources().getString(R.string.prefThrottleNameDefaultValue);
 
@@ -1311,6 +1335,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         }
 
         private void showHideThrottleNumberPreference(SharedPreferences sharedPreferences) {
+            Log.d("Engine_Driver", "Settings: showHideThrottleNumberPreference()");
             boolean enable = true;
             parentActivity.prefThrottleScreenType = prefs.getString("prefThrottleScreenType", parentActivity.getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
             int index = parentActivity.getThrottleScreenTypeArrayIndex(sharedPreferences);
@@ -1324,6 +1349,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         }
 
         private void showHideThrottleWebViewPreferences(SharedPreferences sharedPreferences) {
+            Log.d("Engine_Driver", "Settings: showHideThrottleWebViewPreferences()");
             boolean enable = parentActivity.throttleScreenTypeSupportsWebView(sharedPreferences);
             parentActivity.enableDisablePreference(getPreferenceScreen(), "throttle_webview_preference", enable);
             parentActivity.enableDisablePreference(getPreferenceScreen(), "prefWebViewButton", enable);
@@ -1357,6 +1383,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
 
         private void showHideThrottleTypePreferences() {
+            Log.d("Engine_Driver", "Settings: showHideThrottleTypePreferences()");
             boolean enable = true;
             if ((parentActivity.prefThrottleScreenType.equals("Simple")) || (parentActivity.prefThrottleScreenType.equals("Vertical"))
                     || (parentActivity.prefThrottleScreenType.equals("Vertical Left"))  || (parentActivity.prefThrottleScreenType.equals("Vertical Right"))

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -268,7 +268,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void forceRestartApp(int forcedRestartReason) {
-        Log.d("Engine_Driver", "Settings: forceRestartApp() ");
+        Log.d("Engine_Driver", "Settings: forceRestartApp() - forcedRestartReason: " + forcedRestartReason);
 
         String prefAutoImportExport = prefs.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
@@ -834,7 +834,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 // //            Log.d("Engine_Driver", "Settings: limitNumThrottles: numThrottles " +  numThrottles + " fixed " + fixed[index] + " max " + max[index]);
 
             sharedPreferences.edit().putString("NumThrottle", textNumbers[max[index]-1]).commit();
-            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastNumThrottles, textNumbers[max[index]-1]), Toast.LENGTH_SHORT).show();
+            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastNumThrottles, textNumbers[max[index]-1]), Toast.LENGTH_LONG).show();
             reload();
         }
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -835,7 +835,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
             sharedPreferences.edit().putString("NumThrottle", textNumbers[max[index]-1]).commit();
             Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastNumThrottles, textNumbers[max[index]-1]), Toast.LENGTH_LONG).show();
-            reload();
+//            reload();
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -282,7 +282,7 @@ public class threaded_application extends Application {
     public static final int FORCED_RESTART_REASON_FORCE_WIFI = 11;
     public static final int FORCED_RESTART_REASON_IMMERSIVE_MODE = 12;
     public static final int FORCED_RESTART_REASON_DEAD_ZONE = 13;
-    public static final int FORCED_RESTART_REASON_SHAKE_THRESHOLD = 13;
+    public static final int FORCED_RESTART_REASON_SHAKE_THRESHOLD = 14;
 
     public int actionBarIconCountThrottle = 0;
     public int actionBarIconCountRoutes = 0;

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -3093,7 +3093,7 @@ public class threaded_application extends Application {
     public void applyTheme(Activity activity, boolean isPreferences) {
         int selectedTheme = getSelectedTheme(isPreferences);
         activity.setTheme(selectedTheme);
-        Log.d("Engine_Driver", "applyTheme: " + selectedTheme);
+        Log.d("Engine_Driver", "t_a: applyTheme: " + selectedTheme);
         theme = activity.getTheme();
 
     }
@@ -3159,7 +3159,7 @@ public class threaded_application extends Application {
             else if (to.equals("Portrait") && (co != ActivityInfo.SCREEN_ORIENTATION_PORTRAIT))
                 activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         } catch (Exception e) {
-            Log.e("Engine_Driver", "setActivityOrientation: Unable to change Orientation: " + e.getMessage());
+            Log.e("Engine_Driver", "t_a: setActivityOrientation: Unable to change Orientation: " + e.getMessage());
         }
         return true;
     }

--- a/EngineDriver/src/main/res/layout/throttle_simple.xml
+++ b/EngineDriver/src/main/res/layout/throttle_simple.xml
@@ -327,6 +327,13 @@
                                         android:layout_marginLeft="5dp"
                                         android:text="@string/pauseSpeedButtonLabel" />
 
+                                    <Button
+                                        android:id="@+id/device_sounds_mute_0"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_width="fill_parent"
+                                        android:layout_marginLeft="5dp"
+                                        android:text="@string/deviceSoundsMuteButton" />
+
                                     <TableLayout
                                         android:id="@+id/function_buttons_table_0"
                                         android:layout_width="fill_parent"
@@ -812,6 +819,13 @@
                                         android:layout_width="fill_parent"
                                         android:layout_marginLeft="5dp"
                                         android:text="@string/pauseSpeedButtonLabel" />
+
+                                    <Button
+                                        android:id="@+id/device_sounds_mute_1"
+                                        style="?attr/ed_normal_button_style"
+                                        android:layout_width="fill_parent"
+                                        android:layout_marginLeft="5dp"
+                                        android:text="@string/deviceSoundsMuteButton" />
 
                                     <TableLayout
                                         android:id="@+id/function_buttons_table_1"

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -208,8 +208,8 @@
     <string name="prefSelLocoWhileMovingSummary">Enables Loco Select button when moving</string>
     <string name="prefShowAddressInsteadOfNameTitle">Loco Address instead of Name?</string>
     <string name="prefShowAddressInsteadOfNameSummary">Show loco DCC Address(es) instead of the Roster Name(s) on the Throttle screen</string>
-    <string name="prefIncreaseWebViewSizeTitle">Larger throttle Web View?</string>
-    <string name="prefIncreaseWebViewSizeSummary">Increase throttle Web View size to 60% for small screens</string>
+    <string name="prefIncreaseWebViewSizeTitle">Larger Throttle Web View?</string>
+    <string name="prefIncreaseWebViewSizeSummary">Increase Throttle Web View size to 60% for small screens</string>
     <string name="prefThrottleViewImmersiveModeTitle">Use Immersive Mode for Throttle view?</string>
     <string name="prefThrottleViewImmersiveModeSummary">Display the Throttle view full screen.  Set Swipe up or down options to temporarily disable and reach the menu.</string>
     <string name="prefThrottleViewImmersiveModeHideToolbarTitle">Hide Toolbar in Immersive Mode?</string>
@@ -340,7 +340,7 @@
     <string name="prefMaximumThrottleChangeDefaultValue" translatable="false">25</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefMaximumThrottleChangeSummary">Maximum allowed throttle change in %</string>
     <string name="prefWebViewTitle">Throttle Web View Preferences</string>
-    <string name="prefWebViewSummary">Options for Throttle Web View appearance</string>
+    <string name="prefWebViewSummary">Options for Throttle Web View appearance (Web page that will appear at the bottom of the Throttle Screen)</string>
     <string name="prefInitialThrotWebPageTitle">Initial throttle Web Page</string>
     <string name="prefInitialThrotWebPageDefaultValue" translatable="false">/</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefInitialThrotWebPageSummary">Initial throttle Web Page (such as \'/panel/\')</string>
@@ -414,16 +414,16 @@
     <string name="prefDefaultAddressLengthTitle">Default Address Length</string>
     <string name="prefDefaultAddressLengthDefaultValue" translatable="false">Auto</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefDefaultAddressLengthSummary">Default Loco Address Length, (Auto will set based on # of digits)</string>
-    <string name="prefWebTitle">Web Preferences</string>
+    <string name="prefWebTitle">Web Screen Preferences</string>
     <string name="prefDisplaySpeedUnitsTitle">Speed Units</string>
     <string name="prefDisplaySpeedUnitsDefaultValue" translatable="false">100</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefDisplaySpeedUnitsSummary">Display speed as percentage, or by a specific number of steps</string>
     <string name="prefWebOrientationTitle">Web Screen Orientation</string>
     <string name="prefWebOrientationDefaultValue" translatable="false">Auto-Rotate</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefWebOrientationSummary">Select the Web Screen orientation</string>
-    <string name="prefInitialWebPageTitle">Initial Web Page</string>
+    <string name="prefInitialWebPageTitle">Initial Web Screen Page</string>
     <string name="prefInitialWebPageDefaultValue" translatable="false">/</string>  <!-- DO NOT TRANSLATE -->
-    <string name="prefInitialWebPageSummary">Enter the initial Web Page (such as \'/panel\')</string>
+    <string name="prefInitialWebPageSummary">Enter the initial Web Page (such as \'/panel\') for the Web Screen</string>
     <string name="prefConnectTitle">Connect Preferences</string>
     <string name="prefMaximumRecentConnectionsTitle">Maximum Recent Connections</string>
     <string name="prefMaximumRecentConnectionsDefaultValue" translatable="false">10</string>  <!-- DO NOT TRANSLATE -->
@@ -754,13 +754,13 @@
     <string name="toastDirectionButtonsSwapped">Direction Buttons temporarily swapped. To permanently swap them, change in preferences</string>
     <string name="toastImmersiveModeDisabled">Immersive mode temporarily disabled. To disable permanently change in preferences</string>
     <string name="toastThrottleScreenUnlocked">Throttle Screen Unlocked</string>
-    <string name="toastShakeWebViewHidden">Web View temporarily hidden. Shake again to show. To hide permanently change in preferences</string>
-    <string name="toastShakeWebViewUnavailable">Web View must be enabled in the preferences first</string>
+    <string name="toastShakeWebViewHidden">Throttle Web View temporarily hidden. Shake again to show. To hide permanently change in preferences</string>
+    <string name="toastShakeWebViewUnavailable">Throttle Web View must be enabled in the preferences first</string>
     <string name="toastShakeScreenLocked">Throttle Screen Locked - Shake again to unlock</string>
     <string name="toastShakeScreenDimmed">Throttle Screen Dimmed - Shake again to restore</string>
     <string name="toastSwipeUpDownScreenLocked">Throttle Screen Locked - Swipe again to unlock</string>
     <string name="toastSwipeUpDownScreenDimmed">Throttle Screen Dimmed - Swipe again to restore</string>
-    <string name="toastSwipeUpViewHidden">Web View temporarily hidden. To hide permanently change in preferences</string>
+    <string name="toastSwipeUpViewHidden">Throttle Web View temporarily hidden. To hide permanently change in preferences</string>
     <string name="toastThrottleAlertEstop">Alert: Engine %1$s is set to ESTOP</string>
     <string name="toastThrottleImportServerAutoSucceeded">Automatic preferences import from Web server succeeded.</string>
 
@@ -769,12 +769,12 @@
     <string name="toastPreferencesNotNumeric">Value entered is not numeric (%1$s-%2$s). Reset to %3$s.</string>
     <string name="toastPreferencesResetSucceeded">Preferences Reset to defaults!</string>
     <string name="toastPreferencesImportServerManualFailed">Preferences Import from Server failed! Check the file is correct. (%1$s)</string>
-    <string name="toastPreferencesImportServerManualSucceeded">Preferences Import from Server Succeeded. (%1$s)</string>
-    <string name="toastPreferencesImportSucceeded">Preferences Import from file Succeeded.</string>
-    <string name="toastPreferencesThemeChangeSucceeded">Theme Change Succeeded.</string>
-    <string name="toastPreferencesThrottleChangeSucceeded">Throttle Layout change Succeeded.</string>
-    <string name="toastPreferencesLocaleChangeSucceeded">Locale (Language) change Succeeded.</string>
-    <string name="toastPreferencesBackgroundChangeSucceeded">Background Change Succeeded.</string>
+    <string name="toastPreferencesImportServerManualSucceeded">Preferences Import from Server succeeded. (%1$s)</string>
+    <string name="toastPreferencesImportSucceeded">Preferences Import from file succeeded.</string>
+    <string name="toastPreferencesThemeChangeSucceeded">Theme Change succeeded.</string>
+    <string name="toastPreferencesThrottleChangeSucceeded">Throttle Layout change succeeded.</string>
+    <string name="toastPreferencesLocaleChangeSucceeded">Locale (Language) change succeeded.</string>
+    <string name="toastPreferencesBackgroundChangeSucceeded">Background Change succeeded.</string>
     <string name="toastPreferencesSwipeThroughWebDisabled">Swipe through web disabled.</string>
 
     <!--    Toast messages for the Turnout Activity -->
@@ -813,7 +813,7 @@
     <!--    Toast messages for the Select Loco Activity -->
     <string name="toastSelectLocoConfirmClear">Confirm that you want remove all the Recent Locomotives by pressing the \'Clear List\' button AGAIN.</string>
     <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists by pressing the \'Clear List\' button AGAIN.</string>
-    <string name="toastNumThrottles">Chosen Throttle Screen Layout does not support that many throttles. Reducing to %1$s.</string>
+    <string name="toastNumThrottles">Chosen Throttle Screen Layout does not support that many throttles. Changing to %1$s.</string>
     <string name="toastRecentsHelp">Touch to select a Recent Entry,\n  or change entry method.\nLong press to rename.\nSwipe Right to remove an entry.</string>
     <string name="toastRecentConsistsHelp">Touch to select a Consist Entry,\n  or change entry method.\nLong press to Rename (for entered addresses) or show Roster Details.\nSwipe Right to remove an entry.</string>
     <string name="toastRosterHelp">Touch to select a Roster Entry,\n  or change entry method.\nLong press for details.</string>
@@ -902,10 +902,10 @@
     <string name="toastFlashlightOnFailed">Sorry! There was a problem switching on the flashlight&#8230;</string>
     <string name="toastFlashlightOffFailed">Sorry! There was a problem switching off the flashlight&#8230;</string>
 
-    <string name="webViewButtonBar">Web View Button</string>
-    <string name="webViewAction">Show/Hide Web View</string>
-    <string name="prefWebViewButtonSummary">Show button in action bar to show/hide Web View.\n(requires \'Throttle Web View\' preference to be enabled)</string>
-    <string name="prefWebViewButtonTitle">Web View button?</string>
+    <string name="webViewButtonBar">Throttle Web View Button</string>
+    <string name="webViewAction">Show/Hide Throttle Web View</string>
+    <string name="prefWebViewButtonSummary">Show button in action bar to show/hide Throttle Web View.\n(requires \'Throttle Web View\' preference to be enabled)</string>
+    <string name="prefWebViewButtonTitle">Throttle Web View button?</string>
 
     <string name="logViewerTitle">LogViewerActivity | %1$s</string>
 


### PR DESCRIPTION
- add sounds options for the 'simple' layout
- clean up the wording for 'Web Screen' VS 'Throttle Web View
- stop automatically reloading the throttle page if the max/fixed number of throttles is different (now waits till the settings page is closed)