### PR TITLE
Support for custom (user defined) loco sounds

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -139,6 +139,10 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
 
     private boolean ignoreThisThrottleNumChange = false;
+
+    private static String[] deviceSoundsEntryValuesArray;
+    private static String[] deviceSoundsEntriesArray; // display version
+
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     @Override
@@ -182,7 +186,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
             Log.d("Engine_Driver", "Settings: Set toolbar");
         }
 
-    }
+    } // end onCreate
 
     @Override
     public boolean onPreferenceStartScreen(PreferenceFragmentCompat preferenceFragmentCompat,
@@ -1274,6 +1278,29 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     parentActivity.enableDisablePreference(getPreferenceScreen(),  "prefImportServerManual", false);
                 }
 
+                mainapp.getIplsList();
+                int ipslCount = mainapp.iplsNames.size();
+                int deviceSoundsCount = this.getResources().getStringArray(R.array.deviceSoundsEntries).length;
+                deviceSoundsEntriesArray = new String[deviceSoundsCount + ipslCount];
+                deviceSoundsEntryValuesArray = new String[deviceSoundsCount + ipslCount];
+                for (int i=0; i<deviceSoundsCount; i++) {
+                    deviceSoundsEntriesArray[i] = this.getResources().getStringArray(R.array.deviceSoundsEntries)[i];
+                    deviceSoundsEntryValuesArray[i] = this.getResources().getStringArray(R.array.deviceSoundsEntryValues)[i];
+                }
+                if (!mainapp.iplsNames.isEmpty()) {
+                    for (int i=0; i<ipslCount; i++) {
+                        deviceSoundsEntriesArray[deviceSoundsCount+i] = mainapp.iplsNames.get(i);
+                        deviceSoundsEntryValuesArray[deviceSoundsCount+i] = mainapp.iplsFileNames.get(i);
+                    }
+                }
+
+                ListPreference lp = (ListPreference) findPreference("prefDeviceSounds0");
+                lp.setEntries(deviceSoundsEntriesArray);
+                lp.setEntryValues(deviceSoundsEntryValuesArray);
+
+                lp = (ListPreference) findPreference("prefDeviceSounds1");
+                lp.setEntries(deviceSoundsEntriesArray);
+                lp.setEntryValues(deviceSoundsEntryValuesArray);
             }
 
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/device_sounds_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/device_sounds_settings.java
@@ -211,6 +211,22 @@ public class device_sounds_settings extends AppCompatActivity implements OnGestu
         mainapp = (threaded_application) this.getApplication();
         prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
 
+        mainapp.getIplsList();        //see if there any custom ipls files
+        int ipslCount = mainapp.iplsNames.size();
+        int deviceSoundsCount = this.getResources().getStringArray(R.array.deviceSoundsEntries).length;
+        deviceSoundsEntriesArray = new String[deviceSoundsCount + ipslCount];
+        deviceSoundsEntryValuesArray = new String[deviceSoundsCount + ipslCount];
+        for (int i=0; i<deviceSoundsCount; i++) {
+            deviceSoundsEntriesArray[i] = this.getResources().getStringArray(R.array.deviceSoundsEntries)[i];
+            deviceSoundsEntryValuesArray[i] = this.getResources().getStringArray(R.array.deviceSoundsEntryValues)[i];
+        }
+        if (!mainapp.iplsNames.isEmpty()) {
+            for (int i=0; i<ipslCount; i++) {
+                deviceSoundsEntriesArray[deviceSoundsCount+i] = mainapp.iplsNames.get(i);
+                deviceSoundsEntryValuesArray[deviceSoundsCount+i] = mainapp.iplsFileNames.get(i);
+            }
+        }
+
         //Set the buttons
         Button closeButton = findViewById(R.id.device_sounds_settings_button_close);
         close_button_listener close_click_listener = new close_button_listener();
@@ -218,14 +234,16 @@ public class device_sounds_settings extends AppCompatActivity implements OnGestu
 
         // Set the options for the sounds
         Spinner dss_throttle0 = findViewById(R.id.dss_throttle0);
-        ArrayAdapter<?> spinner_adapter0 = ArrayAdapter.createFromResource(this, R.array.deviceSoundsEntries, android.R.layout.simple_spinner_item);
+//        ArrayAdapter<?> spinner_adapter0 = ArrayAdapter.createFromResource(this, R.array.deviceSoundsEntries, android.R.layout.simple_spinner_item);
+        ArrayAdapter<String> spinner_adapter0 = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deviceSoundsEntriesArray);
         spinner_adapter0.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         dss_throttle0.setAdapter(spinner_adapter0);
         dss_throttle0.setOnItemSelectedListener(new spinner_listener_0());
 
         // Set the options for the sounds
         Spinner dss_throttle1 = findViewById(R.id.dss_throttle1);
-        ArrayAdapter<?> spinner_adapter1 = ArrayAdapter.createFromResource(this, R.array.deviceSoundsEntries, android.R.layout.simple_spinner_item);
+//        ArrayAdapter<?> spinner_adapter1 = ArrayAdapter.createFromResource(this, R.array.deviceSoundsEntries, android.R.layout.simple_spinner_item);
+        ArrayAdapter<String> spinner_adapter1 = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deviceSoundsEntriesArray);
         spinner_adapter1.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         dss_throttle1.setAdapter(spinner_adapter1);
         dss_throttle1.setOnItemSelectedListener(new spinner_listener_1());
@@ -233,10 +251,8 @@ public class device_sounds_settings extends AppCompatActivity implements OnGestu
         //put pointer to this activity's handler in main app's shared variable
         mainapp.device_sounds_settings_msg_handler = new device_sounds_settings_handler();
 
-        deviceSoundsEntryValuesArray = this.getResources().getStringArray(R.array.deviceSoundsEntryValues);
-//        final List<String> deviceSoundsList = new ArrayList<>(Arrays.asList(deviceSoundsEntryValuesArray));
-        deviceSoundsEntriesArray = this.getResources().getStringArray(R.array.deviceSoundsEntries);
-//        final List<String> deviceSoundsEntriesList = new ArrayList<>(Arrays.asList(deviceSoundsEntriesArray));
+//        deviceSoundsEntryValuesArray = this.getResources().getStringArray(R.array.deviceSoundsEntryValues);
+//        deviceSoundsEntriesArray = this.getResources().getStringArray(R.array.deviceSoundsEntries);
 
         mainapp.prefDeviceSounds[0] = prefs.getString("prefDeviceSounds0", getResources().getString(R.string.prefDeviceSoundsDefaultValue));
         mainapp.prefDeviceSounds[1] = prefs.getString("prefDeviceSounds1", getResources().getString(R.string.prefDeviceSoundsDefaultValue));

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -52,6 +52,7 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.SoundPool;
 import android.media.ToneGenerator;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -6860,135 +6861,150 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
 
         for (int i = 0; i <= 1; i++) {
-            switch (mainapp.prefDeviceSounds[i]) {
-                default:
-                case "steam":
-                case "steamSlow":
-                case "steamClass64":
-                case "diesel645turbo":
-                case "diesel7FDL":
-                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_BELL, i ,SOUNDS_BELL_HORN_START,this, R.raw.bell_start);
-                  loadSound(SOUNDS_TYPE_BELL, i ,SOUNDS_BELL_HORN_LOOP ,this, R.raw.bell_loop);
-                  loadSound(SOUNDS_TYPE_BELL, i ,SOUNDS_BELL_HORN_END  ,this, R.raw.bell_end);
-                    break;
-                case "steamClass94":
-                  loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_START, this, R.raw.bell_br_64_glocke_22_start);
-                  loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_LOOP , this, R.raw.bell_br_64_glocke_22_loop);
-                  loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_END  , this, R.raw.bell_br_64_glocke_22_end);
-                    break;
-            }
-        }
-
-        for (int i = 0; i <= 1; i++) {
-            switch (mainapp.prefDeviceSounds[i]) {
-                default:
-                case "steam":
-                case "steamSlow":
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_start);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP , this, R.raw.whistle_loop);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END  , this, R.raw.whistle_end);
-                    break;
-
-                case "diesel645turbo":
-                case "diesel7FDL":
-                case "dieselNW2":
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.horn_start);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP , this, R.raw.horn_loop);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END  , this, R.raw.horn_end);
-                    break;
-
-                case "steamClass64":
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_class64_long_start);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP , this, R.raw.whistle_class64_long_mid);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END  , this, R.raw.whistle_class64_long_end);
-                    break;
-
-                case "steamClass94":
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_start);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP , this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_loop);
-                    loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END  , this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_end);
-                break;
-            }
-        }
-
-        for (int i = 0; i <= 1; i++) {
-            mainapp.prefDeviceSoundsCurrentlyLoaded[i] = mainapp.prefDeviceSounds[i];
-            switch (mainapp.prefDeviceSounds[i]) {
-                default:
-                case "steam":
-                case "steamSlow":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0, this, R.raw.steam_loco_stationary_med);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1, this, R.raw.steam_piston_stroke3);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2, this, R.raw.steam_loop_30rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,3, this, R.raw.steam_loop_35rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,4, this, R.raw.steam_loop_40rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,5, this, R.raw.steam_loop_50rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,6, this, R.raw.steam_loop_60rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,7, this, R.raw.steam_loop_75rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,8, this, R.raw.steam_loop_90rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,9, this, R.raw.steam_loop_100rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,10, this, R.raw.steam_loop_125rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,11, this, R.raw.steam_loop_150rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,12, this, R.raw.steam_loop_175rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,13, this, R.raw.steam_loop_200rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,14, this, R.raw.steam_loop_250rpm);
-                    loadSound(SOUNDS_TYPE_LOCO,i,15, this, R.raw.steam_loop_300rpm);
-                    if (mainapp.prefDeviceSounds[i].equals("steam")) {
-                        mainapp.soundsLocoSteps[i] = 15;
-                    } else {
-                        mainapp.soundsLocoSteps[i] = 7;
+            if (mainapp.prefDeviceSounds[i].toLowerCase(Locale.ROOT).contains(".ipls")) {
+                // load the custom sounds
+                mainapp.getIplsDetails(mainapp.prefDeviceSounds[i]);
+                if (!mainapp.iplsFileName.equals("")) {
+                    for (int j = 0; j <= 2; j++) {
+                        loadSoundFromFile(SOUNDS_TYPE_BELL, i, j, this, mainapp.iplsBellSoundsFileName[j]);
+                        loadSoundFromFile(SOUNDS_TYPE_HORN, i, j, this, mainapp.iplsHornSoundsFileName[j]);
                     }
-                    break;
+                    for (int j = 0; j <= mainapp.iplsLocoSoundsCount; j++) {
+                        loadSoundFromFile(SOUNDS_TYPE_LOCO, i, j, this, mainapp.iplsLocoSoundsFileName[j]);
+                    }
+                } else { // can't find the file name or some other issue
+                    mainapp.prefDeviceSounds[i] = "none";
+                    prefs.edit().putString("prefDeviceSoundsBellVolume", "none").commit();
+                }
+                mainapp.soundsLocoSteps[i] = mainapp.iplsLocoSoundsCount;
 
-                case "diesel645turbo":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0, this, R.raw.diesel_645turbo_idle);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1, this, R.raw.diesel_645turbo_d1_d2);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2, this, R.raw.diesel_645turbo_d2_d3);
-                    loadSound(SOUNDS_TYPE_LOCO,i,3, this, R.raw.diesel_645turbo_d3_d4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,4, this, R.raw.diesel_645turbo_d4);
-                    mainapp.soundsLocoSteps[i] = 4;
-                    break;
+            } else {
+                switch (mainapp.prefDeviceSounds[i]) {
+                    default:
+                    case "steam":
+                    case "steamSlow":
+                    case "steamClass64":
+                    case "diesel645turbo":
+                    case "diesel7FDL":
+                    case "dieselNW2":
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_START, this, R.raw.bell_start);
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.bell_loop);
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_END, this, R.raw.bell_end);
+                        break;
+                    case "steamClass94":
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_START, this, R.raw.bell_br_64_glocke_22_start);
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.bell_br_64_glocke_22_loop);
+                        loadSound(SOUNDS_TYPE_BELL, i, SOUNDS_BELL_HORN_END, this, R.raw.bell_br_64_glocke_22_end);
+                        break;
+                }
 
-                case "diesel7FDL":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0,this, R.raw.diesel_7fdl_idle_1a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1,this, R.raw.diesel_7fdl_idle_2a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2,this, R.raw.diesel_7fdl_idle_3a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,3,this, R.raw.diesel_7fdl_idle_4a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,4,this, R.raw.diesel_7fdl_idle_5a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,5,this, R.raw.diesel_7fdl_idle_6a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,6,this, R.raw.diesel_7fdl_idle_7a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,7,this, R.raw.diesel_7fdl_idle_8a);
-                    mainapp.soundsLocoSteps[i] = 7; // fast steam
-                    break;
+                switch (mainapp.prefDeviceSounds[i]) {
+                    default:
+                    case "steam":
+                    case "steamSlow":
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_start);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.whistle_loop);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END, this, R.raw.whistle_end);
+                        break;
 
-                case "dieselNW2":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0,this, R.raw.diesel_nw7_motor);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1,this, R.raw.diesel_nw7_motor_2);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2,this, R.raw.diesel_nw7_motor_1);
-                    mainapp.soundsLocoSteps[i] = 2;
-                    break;
+                    case "diesel645turbo":
+                    case "diesel7FDL":
+                    case "dieselNW2":
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.horn_start);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.horn_loop);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END, this, R.raw.horn_end);
+                        break;
 
-                case "steamClass64":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0, this, R.raw.steam_class64_idle_sound);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1, this, R.raw.steam_class64_chuff1_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2, this, R.raw.steam_class64_chuff2_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,3, this, R.raw.steam_class64_chuff3_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,4, this, R.raw.steam_class64_chuff4_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,5, this, R.raw.steam_class64_chuff5_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,6, this, R.raw.steam_class64_chuff6_1_4);
-                    mainapp.soundsLocoSteps[i] = 6;
-                    break;
+                    case "steamClass64":
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_class64_long_start);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.whistle_class64_long_mid);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END, this, R.raw.whistle_class64_long_end);
+                        break;
 
-                case "steamClass94":
-                    loadSound(SOUNDS_TYPE_LOCO,i,0, this, R.raw.steam_class94_idle2a);
-                    loadSound(SOUNDS_TYPE_LOCO,i,1, this, R.raw.steam_class94_speed0a_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,2, this, R.raw.steam_class94_speed2g_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,3, this, R.raw.steam_class94_speed3g_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,4, this, R.raw.steam_class94_speed4g_1_4);
-                    loadSound(SOUNDS_TYPE_LOCO,i,5, this, R.raw.steam_class94_speed5g_1_4);
-                    mainapp.soundsLocoSteps[i] = 5;
-                    break;
+                    case "steamClass94":
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_START, this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_start);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_LOOP, this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_loop);
+                        loadSound(SOUNDS_TYPE_HORN, i, SOUNDS_BELL_HORN_END, this, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_end);
+                        break;
+                }
+
+                mainapp.prefDeviceSoundsCurrentlyLoaded[i] = mainapp.prefDeviceSounds[i];
+                switch (mainapp.prefDeviceSounds[i]) {
+                    default:
+                    case "steam":
+                    case "steamSlow":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.steam_loco_stationary_med);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.steam_piston_stroke3);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.steam_loop_30rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 3, this, R.raw.steam_loop_35rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 4, this, R.raw.steam_loop_40rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 5, this, R.raw.steam_loop_50rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 6, this, R.raw.steam_loop_60rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 7, this, R.raw.steam_loop_75rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 8, this, R.raw.steam_loop_90rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 9, this, R.raw.steam_loop_100rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 10, this, R.raw.steam_loop_125rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 11, this, R.raw.steam_loop_150rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 12, this, R.raw.steam_loop_175rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 13, this, R.raw.steam_loop_200rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 14, this, R.raw.steam_loop_250rpm);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 15, this, R.raw.steam_loop_300rpm);
+                        if (mainapp.prefDeviceSounds[i].equals("steam")) {
+                            mainapp.soundsLocoSteps[i] = 15;
+                        } else {
+                            mainapp.soundsLocoSteps[i] = 7;
+                        }
+                        break;
+
+                    case "diesel645turbo":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.diesel_645turbo_idle);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.diesel_645turbo_d1_d2);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.diesel_645turbo_d2_d3);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 3, this, R.raw.diesel_645turbo_d3_d4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 4, this, R.raw.diesel_645turbo_d4);
+                        mainapp.soundsLocoSteps[i] = 4;
+                        break;
+
+                    case "diesel7FDL":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.diesel_7fdl_idle_1a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.diesel_7fdl_idle_2a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.diesel_7fdl_idle_3a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 3, this, R.raw.diesel_7fdl_idle_4a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 4, this, R.raw.diesel_7fdl_idle_5a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 5, this, R.raw.diesel_7fdl_idle_6a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 6, this, R.raw.diesel_7fdl_idle_7a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 7, this, R.raw.diesel_7fdl_idle_8a);
+                        mainapp.soundsLocoSteps[i] = 7; // fast steam
+                        break;
+
+                    case "dieselNW2":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.diesel_nw7_motor);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.diesel_nw7_motor_2);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.diesel_nw7_motor_1);
+                        mainapp.soundsLocoSteps[i] = 2;
+                        break;
+
+                    case "steamClass64":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.steam_class64_idle_sound);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.steam_class64_chuff1_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.steam_class64_chuff2_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 3, this, R.raw.steam_class64_chuff3_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 4, this, R.raw.steam_class64_chuff4_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 5, this, R.raw.steam_class64_chuff5_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 6, this, R.raw.steam_class64_chuff6_1_4);
+                        mainapp.soundsLocoSteps[i] = 6;
+                        break;
+
+                    case "steamClass94":
+                        loadSound(SOUNDS_TYPE_LOCO, i, 0, this, R.raw.steam_class94_idle2a);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 1, this, R.raw.steam_class94_speed0a_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 2, this, R.raw.steam_class94_speed2g_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 3, this, R.raw.steam_class94_speed3g_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 4, this, R.raw.steam_class94_speed4g_1_4);
+                        loadSound(SOUNDS_TYPE_LOCO, i, 5, this, R.raw.steam_class94_speed5g_1_4);
+                        mainapp.soundsLocoSteps[i] = 5;
+                        break;
+                }
             }
         }
         mainapp.soundsReloadSounds = false;
@@ -7016,7 +7032,36 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
     }
 
-    void soundsStopAllSoundsForLoco(int whichThrottle) {
+    void loadSoundFromFile(int soundType, int whichThrottle, int soundNo, Context context, String fileName) {
+        int duration = 0;
+
+        File file = new File(context.getExternalFilesDir(null), fileName);
+
+        MediaPlayer player = MediaPlayer.create(context, Uri.fromFile(file));
+        if (player!=null)
+            duration = player.getDuration();
+
+        switch (soundType) {
+            default:
+            case SOUNDS_TYPE_LOCO: // loco
+                mainapp.soundsLoco[whichThrottle][soundNo]
+                        = mainapp.soundPool.load(context.getExternalFilesDir(null)+"/"+fileName, 1);
+                mainapp.soundsLocoDuration[whichThrottle][soundNo] = duration;
+                break;
+            case SOUNDS_TYPE_BELL: // bell
+                mainapp.soundsBell[whichThrottle][soundNo]
+                        = mainapp.soundPool.load(context.getExternalFilesDir(null)+"/"+fileName, 1);
+                mainapp.soundsBellDuration[whichThrottle][soundNo] = duration;
+                break;
+            case SOUNDS_TYPE_HORN: // horn
+                mainapp.soundsHorn[whichThrottle][soundNo]
+                        = mainapp.soundPool.load(context.getExternalFilesDir(null)+"/"+fileName, 1);
+                mainapp.soundsHornDuration[whichThrottle][soundNo] = duration;
+                break;
+        }
+    }
+
+        void soundsStopAllSoundsForLoco(int whichThrottle) {
 //        Log.d("Engine_Driver", "soundsStopAllSoundsForLoco : (locoSound) wt: " + whichThrottle);
         if (mainapp.soundPool != null) {
             for (int i = 0; i < 17; i++) {


### PR DESCRIPTION
sample .ipls file format...

/ sample custom 'In-Phone Loco Sounds' (.ipls) file
/
/ - the first character of each line is the instruction/sound type
/ - Lines starting with "/" are comments
/ - Avoid additional spaces (it will try to trim leading and trailing spaces)
/   i.e don't put a space before or after the colon.
/ - this .ipls file MUST be placed in ../Android/data/jmri.enginedriver/files/
/ - By default, the sound files are expected to be in ../Android/data/jmri.enginedriver/files/
/   however you can put them in subfolders by prepending the sound file name with <folder name><forward slash>
/   e.g. sample/bell_start.mp3     - will look for ../Android/jmri.enginedriver/files/sample/bell_start.mp3
/ - The files used for the inbuilt sounds (and this sample) can be copied from here: https://github.com/flash62au/EngineDriver/tree/master/EngineDriver/src/main/res/raw
/ - Sounds files can be .wav or .mp3 format.  Other formats may usable but are untested.
/ - Each sound is internally limited to one megabyte storage, which represents approximately 5.6 seconds at 44.1kHz stereo
/
/ n: = name that will appear in the drop lists in Engine Driver
/
n:Diesel Loco - 4 steps
/
/ b0: Bell start sound  b1: Bell loop sound  b2: Bell end sound
/
b0:sample/bell_start.mp3
b1:sample/bell_loop.mp3
b2:sample/bell_end.mp3
/
/ h0: Horn/Whistle start sound  h1: Horn/Whistle loop sound  h2: Horn/Whistle end sound
/
h0:sample/horn_start.mp3
h1:sample/horn_loop.mp3
h2:sample/horn_end.mp3
/
/ l0: Loco idle  l1:.. l16: Loco steps/notches
/ - MAX 16
/ - Not all 16 are required, but there must not be any missing steps between 0 and the last
/
l0:sample/diesel_645turbo_idle.mp3
l1:sample/diesel_645turbo_d1_d2.mp3
l2:sample/diesel_645turbo_d2_d3.mp3
l3:sample/diesel_645turbo_d3_d4.mp3
l4:sample/diesel_645turbo_d4.mp3