### PR TITLE
Option to use a normal keyboard (bluetooth or USB) as a gamepad type

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -26,6 +26,7 @@
     <li>'Limit Speed' and 'Pause' added to the Horizontal Layouts</li>
     <li>Show roster lists from unknown servers</li>
     <li>Option for Haptic feedback on button presses</li>
+    <li>Option to use a normal keyboard (bluetooth or USB) as a gamepad type</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
@@ -57,7 +57,10 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.Spinner;
+import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -231,6 +234,10 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadUtopiaC);
                 bGamePadKeysUp = bGamePadKeys;
                 break;
+            case "Keyboard":
+                bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadNoneLabels);
+                bGamePadKeysUp = bGamePadKeys;
+                break;
             default: // "iCade" or iCade-rotate
                 bGamePadKeys = this.getResources().getIntArray(R.array.prefGamePadiCade);
                 bGamePadKeysUp = this.getResources().getIntArray(R.array.prefGamePadiCade_UpCodes);
@@ -253,6 +260,28 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
             gamePadKeys_Up[3] = bGamePadKeysUp[5];
             gamePadKeys_Up[4] = bGamePadKeysUp[3];
             gamePadKeys_Up[5] = bGamePadKeysUp[2];
+        }
+
+        LinearLayout dpad = findViewById(R.id.gamepad_dpad);
+        TableLayout btns = findViewById(R.id.gamepad_buttons);
+        RelativeLayout optn = findViewById(R.id.gamepad_test_optional_group);
+        TableLayout extra = findViewById(R.id.gamepad_buttons_extra);
+        View helpText = findViewById(R.id.gamepad_test_help);
+        View helpTextKeyboard = findViewById(R.id.gamepad_test_keyboard_help);
+        if (!whichGamePadMode.equals("Keyboard")) {
+            dpad.setVisibility(LinearLayout.VISIBLE);
+            btns.setVisibility(TableLayout.VISIBLE);
+            optn.setVisibility(RelativeLayout.VISIBLE);
+            extra.setVisibility(TableLayout.VISIBLE);
+            helpText.setVisibility(View.VISIBLE);
+            helpTextKeyboard.setVisibility(View.GONE);
+        } else {
+            dpad.setVisibility(LinearLayout.GONE);
+            btns.setVisibility(TableLayout.GONE);
+            optn.setVisibility(RelativeLayout.GONE);
+            extra.setVisibility(TableLayout.GONE);
+            helpText.setVisibility(View.GONE);
+            helpTextKeyboard.setVisibility(View.VISIBLE);
         }
     }
 

--- a/EngineDriver/src/main/res/layout/gamepad_test.xml
+++ b/EngineDriver/src/main/res/layout/gamepad_test.xml
@@ -371,6 +371,16 @@
                         android:text="@string/gamepadTestHelp"
                         android:textSize="15sp" />
 
+                    <TextView
+                        android:id="@+id/gamepad_test_keyboard_help"
+                        style="?attr/floating_text_style"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="3dp"
+                        android:text="@string/gamepadTestKeyboardHelp"
+                        android:textSize="15sp"
+                        android:visibility="gone" />
+
                 </LinearLayout>
 
             </ScrollView>

--- a/EngineDriver/src/main/res/values-fr/arrays.xml
+++ b/EngineDriver/src/main/res/values-fr/arrays.xml
@@ -231,6 +231,7 @@
         <item >MagicseeR1 Android-Game B</item>
         <item >Flydigi Wee 2</item>
         <item >Utopia 360 Android-C</item>
+        <item >Keyboard</item>
     </string-array>
 
     <string-array name="prefGamePadFlydigiWee2Labels">

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -223,6 +223,7 @@
         <item tools:ignore="Typos">MagicseeR1B</item>
         <item>FlydigiWee2</item>
         <item>UtopiaC</item>
+        <item >Keyboard</item>
     </string-array>
 
     <string-array name="prefGamePadTypeEntries">  <!-- display version -->
@@ -246,6 +247,7 @@
         <item tools:ignore="Typos">MagicseeR1 Android-Game B</item>
         <item >Flydigi Wee 2</item>
         <item >Utopia 360 Android-C</item>
+        <item >Keyboard</item>
     </string-array>
 
     <string-array name="prefSwipeUpOptionsEntryValues" translatable="false">  <!-- DO NOT TRANSLATE -->

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -716,6 +716,36 @@
     <string name="gamepadTestCompleteLabel">Test status:</string>
     <string name="gamepadTestDeviceName">BT:</string>
     <string name="gamepadTestHelp">Scroll down to see the full instructions…\n\nPress ALL Dpad AND four primary buttons or the gamepad WILL NOT WORK.\n\nIf you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your gamepad) or try a different gamepad Type (above).\n\n\'BACK\' or \'CANCEL\' will exit the test but the gamepad WILL NOT WORK.\n\'SKIP\', or pressing the \'Decrease Speed\' gamepad button three times, will force the test to pass, even if the gamepad does not work properly.\n\'RESET\' will make ED think no gamepads have been used yet.\nIf \'simple\' test is selected, a single \'Decrease Speed\' button press will skip the test.\n\nUse the \'Gamepad Test n\' menu options to get back to this screen.</string>
+    <string name="gamepadTestKeyboardHelp">Keyboard Commands
+\n-----------------
+\nUp = Increase Speed
+\nDown = Decrease Speed
+\n\'X\' = Stop
+\nLeft = Reverse (Forward if changed in preferences)
+\nRight = Forward (Reverse if changed in preferences)
+\n\'D\' = Direction - Toggle Forward/Reverse
+\n\'N\' = Next Throttle
+\n\'Z\' = All stop
+\n
+\nF00 - F28 = Function
+\nMust be \'F\' followed by two digits
+\n
+\nS000 - S100 = Speed
+\nMust be \'S\' followed by three digits
+\n
+\nIn Phone Loco Sounds (IPLS)
+\n\'B\' = Bell
+\n\'H\' = Horn / Whistle
+\n\'J\' = Short Horn
+\n\'M\' or Volume Mute = Mute IPLS
+\n
+\nT0 - T5 = Specify a throttle for next command
+\nMust be \'T\' followed by one digit
+\nThe following command will sent to the specified throttle regardless of the currently selected gamepad throttle.
+\n
+\nAll other keyCodes are ignored
+\n
+\nFailure to follow the \'F\', \'S\' or \'L\' with the correct number of digits will ignore the command</string>
     <string name="gamepadTestHelpNonForced">If you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\nYou may be required to re-test the gamepad when you first use it from the throttle screen.</string>
     <string name="gamepadTestIncomplete">"Test Incomplete"</string>
     <string name="gamepadTestComplete">"Test Complete"</string>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,5 +1,6 @@
 **Version 2.31.140
  * Option for Haptic feedback on button presses
+ * Option to use a normal keyboard (bluetooth or USB) as a gamepad type
 **Version 2.31.138
  * Fix: Auto Server preference load
  * 'Limit Speed' and 'Pause' added to the Horizontal Layouts


### PR DESCRIPTION
- in prep for creating a Arduino gamepad controller
-----------------
Keyboard Commands
Up = Increase Speed
Down = Decrease Speed
'X' = Stop 
Left = Reverse (Forward if changed in preferences)
Right = Forward (Reverse if changed in preferences)
'D' = Direction - Toggle Forward/Reverse
'N' = Next Throttle
'Z' = All stop

F00 - F28 = Function
Must be 'F' followed by two digits

S000 - S100 = Speed
Must be 'S' followed by three digits

In Phone Loco Sounds (IPLS)
'B' = Bell
'H' = Horn / Whistle
'J' = Short Horn
'M' or Volume Mute = Mute IPLS

T0 - T5 = Specify a throttle for next command
Must be 'T' followed by one digit
The following command will sent to the specified throttle regardless of the currently selected gamepad throttle. 

All other keyCodes are ignored

Failure to follow the 'F', 'S' or 'L' with the correct number of digits will ignore the command