### PR TITLE
Local roster images

### DIFF
--- a/EngineDriver/src/main/assets/about_page-ca.html
+++ b/EngineDriver/src/main/assets/about_page-ca.html
@@ -25,8 +25,9 @@
     <li>Limitar la velocitat "i" pausa "s'afegeixen als dissenys horitzontals</li>
     <li>Mostra les llistes de plantes de servidors desconeguts</li>
     <li>Opció per a comentaris hàptics sobre premses de botó</li>
-    <li>Opció per a comentaris hàptics sobre premses de botó</li>
     <li>Els jocs de games continuen funcionant a la majoria de les pantalles (exclou els teclats)</li>
+    <li>Les imatges per a qualsevol local seleccionat estiguin a la memòria cau localment</li>
+    <li>Opció de seleccionar una imatge local per a la llista Locos (per a servidors de ritme que no admeten imatges)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-cs.html
+++ b/EngineDriver/src/main/assets/about_page-cs.html
@@ -26,6 +26,8 @@
     <li>Zobrazit seznamy seznamuz neznámých serverů</li>
     <li>Možnost pro haptickou zpětnou vazbu na stisknutí tlačítka</li>
     <li>Gamepads i nadále fungovat ve většině obrazovek (vylučuje klávesnice)</li>
+    <li>Obrázky pro všechny vybrané lokomotory jsou uloženy do mezipaměti</li>
+    <li>Možnost vybrat lokální snímek pro Roster Locos (pro Servery WithRottle, které nepodporují obrázky)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
+++ b/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
@@ -26,6 +26,8 @@
     <li>Roster-Listen anzeigen von unbekannten Servern</li>
     <li>Option für das HAPTIC-Feedback auf Knopfdruck</li>
     <li>Gamepads funktionieren weiterhin in den meisten Screens (ausgenommen Keyboards)</li>
+    <li>Bilder für jeden ausgewählten Lok werden lokal zwischengespeichert</li>
+    <li>Option zum Auswählen eines lokalen Bildes für Dienstplan Locos (für mit Rutlerservern, die keine Bilder unterstützen)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-de.html
+++ b/EngineDriver/src/main/assets/about_page-de.html
@@ -26,6 +26,8 @@
     <li>Roster-Listen anzeigen von unbekannten Servern</li>
     <li>Option für das HAPTIC-Feedback auf Knopfdruck</li>
     <li>Gamepads funktionieren weiterhin in den meisten Screens (ausgenommen Keyboards)</li>
+    <li>Bilder für jeden ausgewählten Lok werden lokal zwischengespeichert</li>
+    <li>Option zum Auswählen eines lokalen Bildes für Dienstplan Locos (für mit Rutlerservern, die keine Bilder unterstützen)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-es.html
+++ b/EngineDriver/src/main/assets/about_page-es.html
@@ -26,6 +26,8 @@
     <li>Mostrar listas de la lista de servidores desconocidos</li>
     <li>Opción para la retroalimentación háptica en presiones de botón</li>
     <li>Los gamepads continúan funcionando en la mayoría de las pantallas (excluye teclados)</li>
+    <li>Las imágenes para cualquier lugar seleccionado se almacenan en caché localmente</li>
+    <li>Opción para seleccionar una imagen local para Locos Locos (para servidores WithRottle que no admiten imágenes)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page-fr.html
+++ b/EngineDriver/src/main/assets/about_page-fr.html
@@ -26,6 +26,8 @@
     <li>Afficher les listes de la liste des serveurs inconnus</li>
     <li>Option pour les commentaires haptiques sur les appuie sur le bouton</li>
     <li>Les cartes de jeu continuent de fonctionner dans la plupart des écrans (exclut les claviers)</li>
+    <li>Images pour tout loco sélectionné est mise en cache localement</li>
+    <li>Option Pour sélectionner une image locale pour les locos de la liste (pour les serveurs de rochette qui ne prennent pas en charge les images)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -23,7 +23,7 @@
     <li>Option to use a normal keyboard (bluetooth or USB) as a gamepad type</li>
     <li>Gamepads continue to function in most screens (excludes keyboards)</li>
     <li>Images for any selected loco is cached locally</li>
-    <li>Option to select a local image for roster locos</li>
+    <li>Option to select a local image for roster locos (For wiThrottle servers that don't support images)</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -674,11 +674,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     protected void loadImagefromGallery() {
 //        if (PermissionsHelper.getInstance().isPermissionGranted(this, PermissionsHelper.READ_PREFERENCES)) {
-            loadImagefromGalleryImpl();
+//            loadImagefromGalleryImpl();
 //        }
-    }
-
-    public void loadImagefromGalleryImpl() {
+//    }
+//
+//    public void loadImagefromGalleryImpl() {
         // Create intent to Open Image applications like Gallery, Google Photos
         Intent galleryIntent = new Intent(Intent.ACTION_PICK,
                 android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -154,11 +154,11 @@ public class connection_activity extends AppCompatActivity implements Permission
     }
 
     private void connect() {
-        navigateToHandler(PermissionsHelper.CONNECT_TO_SERVER);
-    }
-
-    //Request connection to the WiThrottle server.
-    private void connectImpl() {
+//        navigateToHandler(PermissionsHelper.CONNECT_TO_SERVER);
+//    }
+//
+//    //Request connection to the WiThrottle server.
+//    private void connectImpl() {
         //	  sendMsgErr(0, message_type.CONNECT, connected_hostip, connected_port, "ERROR in ca.connect: comm thread not started.");
         Log.d("Engine_Driver", "in connection_activity.connect()");
         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.CONNECT, connected_hostip, connected_port);
@@ -435,6 +435,10 @@ public class connection_activity extends AppCompatActivity implements Permission
         mainapp.connectedHostip = "";
         mainapp.connectedPort = 0;
         mainapp.logged_host_ip = null;
+
+        mainapp.roster_entries = null;
+        mainapp.consist_entries = null;
+        mainapp.roster = null;
 
         connToast = Toast.makeText(this, "", Toast.LENGTH_LONG);    // save toast obj so it can be cancelled
         // setTitle(getApplicationContext().getResources().getString(R.string.app_name_connect));	//set title to long form of label
@@ -846,13 +850,12 @@ public class connection_activity extends AppCompatActivity implements Permission
 
     private void clearConnectionsList() {
 //            navigateToHandler(PermissionsHelper.CLEAR_CONNECTION_LIST);
-        clearConnectionsListImpl();
-        ;
-    }
-
-    //Jeffrey M added 7/3/2013
-    //Clears recent connection list.
-    private void clearConnectionsListImpl() {
+//        clearConnectionsListImpl();
+//        ;
+//    }
+//
+//    //Clears recent connection list.
+//    private void clearConnectionsListImpl() {
         //if no SD Card present then nothing to do
         if (!android.os.Environment.getExternalStorageState().equals(android.os.Environment.MEDIA_MOUNTED)) {
             Toast.makeText(getApplicationContext(), "Error no recent connections exist", Toast.LENGTH_SHORT).show();
@@ -948,10 +951,10 @@ public class connection_activity extends AppCompatActivity implements Permission
 
     private void saveSharedPreferencesToFile() {
 //            navigateToHandler(PermissionsHelper.STORE_PREFERENCES);
-        saveSharedPreferencesToFileImpl();
-    }
-
-    private void saveSharedPreferencesToFileImpl() {
+//        saveSharedPreferencesToFileImpl();
+//    }
+//
+//    private void saveSharedPreferencesToFileImpl() {
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
@@ -972,13 +975,14 @@ public class connection_activity extends AppCompatActivity implements Permission
         }
     }
 
+    @SuppressLint("ApplySharedPref")
     private void loadSharedPreferencesFromFile() {
 //            navigateToHandler(PermissionsHelper.READ_PREFERENCES);
-        loadSharedPreferencesFromFileImpl();
-    }
-
-    @SuppressLint("ApplySharedPref")
-    private void loadSharedPreferencesFromFileImpl() {
+//        loadSharedPreferencesFromFileImpl();
+//    }
+//
+//    @SuppressLint("ApplySharedPref")
+//    private void loadSharedPreferencesFromFileImpl() {
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue)).trim();
 
@@ -1031,7 +1035,8 @@ public class connection_activity extends AppCompatActivity implements Permission
 //                        break;
                 case PermissionsHelper.CONNECT_TO_SERVER:
                     Log.d("Engine_Driver", "Got permission for READ_PHONE_STATE - navigate to connectImpl()");
-                    connectImpl();
+//                    connectImpl();
+                    connect();
                     break;
                 default:
                     // do nothing

--- a/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
@@ -233,10 +233,10 @@ public class function_consist_settings extends AppCompatActivity implements Perm
     //(and updated by saveSettings() when required) so just copy it
     void initSettings() {
 //        navigateToHandler(PermissionsHelper.READ_FUNCTION_SETTINGS);
-        initSettingsImpl();
-    }
-
-    private void initSettingsImpl() {
+//        initSettingsImpl();
+//    }
+//
+//    private void initSettingsImpl() {
         mainapp.set_default_function_labels(true);
 
         aLbl.clear();
@@ -389,11 +389,11 @@ public class function_consist_settings extends AppCompatActivity implements Perm
 
     void saveSettings() {
 //        navigateToHandler(PermissionsHelper.STORE_FUNCTION_SETTINGS);
-        saveSettingsImpl();
-    }
-
-    //save function and labels to file
-    void saveSettingsImpl() {
+//        saveSettingsImpl();
+//    }
+//
+//    //save function and labels to file
+//    void saveSettingsImpl() {
         //SD Card required to save settings
         if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED))
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/function_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/function_settings.java
@@ -281,10 +281,10 @@ public class function_settings extends AppCompatActivity implements PermissionsH
     //(and updated by saveSettings() when required) so just copy it
     void initSettings() {
 //        navigateToHandler(PermissionsHelper.READ_FUNCTION_SETTINGS);
-        initSettingsImpl();
-    }
-
-    private void initSettingsImpl() {
+//        initSettingsImpl();
+//    }
+//
+//    private void initSettingsImpl() {
         mainapp.set_default_function_labels(true);
 
         aLbl.clear();
@@ -460,11 +460,11 @@ public class function_settings extends AppCompatActivity implements PermissionsH
 
     void saveSettings() {
 //        navigateToHandler(PermissionsHelper.STORE_FUNCTION_SETTINGS);
-        saveSettingsImpl();
-    }
-
-    //save function and labels to file
-    void saveSettingsImpl() {
+//        saveSettingsImpl();
+//    }
+//
+//    //save function and labels to file
+//    void saveSettingsImpl() {
         //SD Card required to save settings
         if (!android.os.Environment.getExternalStorageState().equals(android.os.Environment.MEDIA_MOUNTED))
             return;

--- a/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
@@ -234,10 +234,10 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 
     private void saveLogFile() {
 //        navigateToHandler(PermissionsHelper.STORE_LOG_FILES);
-        saveLogFileImpl();
-    }
-
-    private void saveLogFileImpl() {
+//        saveLogFileImpl();
+//    }
+//
+//    private void saveLogFileImpl() {
 //        File path = Environment.getExternalStorageDirectory();
 //        File engine_driver_dir = new File(path, ENGINE_DRIVER_DIR);
 //        engine_driver_dir.mkdir();            // create directory if it doesn't exist

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -578,8 +578,13 @@ public class select_loco extends AppCompatActivity {
                     String imgpath = cursor.getString(columnIndex);
                     cursor.close();
 
-                    File image_file = new File(imgpath);
-                    if (image_file.exists()) {
+                    File image_file = null;
+                    try {
+                        image_file = new File(imgpath);
+                    } catch (Exception e) {    // isBackward returns null if address is not in consist - should not happen since address was selected from consist list
+                        Log.d("Engine_Driver", "Load image failed : " + imgpath);
+                    }
+                    if ( (image_file != null) && (image_file.exists()) ) {
                         try {
                             int inWidth = 0;
                             int inHeight = 0;

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -34,6 +34,9 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.RectF;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -77,7 +80,10 @@ import android.widget.TextView.OnEditorActionListener;
 import android.widget.Toast;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,6 +147,7 @@ public class select_loco extends AppCompatActivity {
     boolean hasLocalRosterImage = false;
     boolean LocalRosterImageRemoved = false;
     Button buttonRemoveRosterImage;
+    Button buttonClose;
 
     private String sWhichThrottle = "0";  // "0" or "1" or "2" + roster name
     int whichThrottle = 0;
@@ -574,13 +581,59 @@ public class select_loco extends AppCompatActivity {
                     File image_file = new File(imgpath);
                     if (image_file.exists()) {
                         try {
-                            detailsRosterImageView.setImageBitmap(BitmapFactory.decodeFile(image_file.getPath()));
+                            int inWidth = 0;
+                            int inHeight = 0;
+
+                            InputStream in = new FileInputStream(image_file.getPath());
+
+                            // decode image size (decode metadata only, not the whole image)
+                            BitmapFactory.Options options = new BitmapFactory.Options();
+                            options.inJustDecodeBounds = true;
+                            BitmapFactory.decodeStream(in, null, options);
+                            in.close();
+
+                            // save width and height
+                            inWidth = options.outWidth;
+                            inHeight = options.outHeight;
+
+                            // decode full image pre-resized
+                            in = new FileInputStream(image_file.getPath());
+                            options = new BitmapFactory.Options();
+                            // calc rough re-size (this is no exact resize)
+                            options.inSampleSize = Math.max(inWidth/150, inHeight/150);
+                            // decode full image
+                            Bitmap roughBitmap = BitmapFactory.decodeStream(in, null, options);
+
+                            // calc exact destination size
+                            Matrix m = new Matrix();
+                            RectF inRect = new RectF(0, 0, roughBitmap.getWidth(), roughBitmap.getHeight());
+                            RectF outRect = new RectF(0, 0, 150, 150);
+                            m.setRectToRect(inRect, outRect, Matrix.ScaleToFit.CENTER);
+                            float[] values = new float[9];
+                            m.getValues(values);
+
+                            // resize bitmap
+                            Bitmap resizedBitmap = Bitmap.createScaledBitmap(roughBitmap, (int) (roughBitmap.getWidth() * values[0]), (int) (roughBitmap.getHeight() * values[4]), true);
+
+                            int degree = getRotateDegreeFromExif(image_file.getPath());
+                            Matrix matrix = new Matrix();
+                            matrix.postRotate(degree);/*from   w  w w.  j  a v  a2 s  .co  m*/
+                            if (degree!=0) {
+                                Bitmap rotatedImage = Bitmap.createBitmap(resizedBitmap, 0, 0,
+                                        resizedBitmap.getWidth(), resizedBitmap.getHeight(), matrix, true);
+                                detailsRosterImageView.setImageBitmap(rotatedImage);
+                            } else {
+                                detailsRosterImageView.setImageBitmap(resizedBitmap);
+                            }
+
+//                            detailsRosterImageView.setImageBitmap(BitmapFactory.decodeFile(image_file.getPath()));
                             detailsRosterImageView.setVisibility(View.VISIBLE);
                             detailsRosterImageView.invalidate();
                             newRosterImageSelected = true;
                             hasLocalRosterImage = true;
                             LocalRosterImageRemoved = false;
                             buttonRemoveRosterImage.setVisibility(VISIBLE);
+                            buttonClose.setText(getString(R.string.rosterEntryImageSaveButtonText));
                         } catch (Exception e) {
                             Log.d("Engine_Driver", "select_loco - load image - image file found but could not loaded");
                         }
@@ -600,7 +653,7 @@ public class select_loco extends AppCompatActivity {
 
         if (!removingLocoOrForceReload) {
 
-            // check if it already in the list and remove it
+            // check if it is already in the list and remove it
             for (int i = 0; i < importExportPreferences.recent_loco_address_list.size(); i++) {
                 Log.d("Engine_Driver", "vLocoName='"+locoName+"', address="+engine_address+", size="+address_size);
                 Log.d("Engine_Driver", "sLocoName='"+importExportPreferences.recent_loco_name_list.get(i)+
@@ -1158,7 +1211,6 @@ public class select_loco extends AppCompatActivity {
         prefRosterRecentLocoNames = prefs.getBoolean("prefRosterRecentLocoNames",
                 getResources().getBoolean(R.bool.prefRosterRecentLocoNamesDefaultValue));
 
-
         // Set the options for the address length.
         Spinner address_spinner = findViewById(R.id.address_length);
         ArrayAdapter<?> spinner_adapter = ArrayAdapter.createFromResource(this,
@@ -1180,7 +1232,7 @@ public class select_loco extends AppCompatActivity {
         roster_list_view.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> av, View v, int pos, long id) {
-                return onLongListItemClick(pos);
+                return onLongRosterListItemClick(pos);
             }
         });
 
@@ -1674,42 +1726,43 @@ public class select_loco extends AppCompatActivity {
     }
 
     // long click handler for the Roster List items.  Shows the details of the enter in a dialog.
-    protected boolean onLongListItemClick(int position) {
-        if (mainapp.roster == null) {
-            Log.w("Engine_Driver", "No roster details found.");
-            return true;
-        }
+    protected boolean onLongRosterListItemClick(int position) {
+        String iconURL = "";
+        RosterEntry re = null;
         HashMap<String, String> hm = roster_list.get(position);
         String rosterNameString = hm.get("roster_name");
-        if (mainapp.roster == null) {
-            Log.w("Engine_Driver", "select_loco: Roster is null.");
-            return true;
+        String rosterAddressString = hm.get("roster_address");
+        if (mainapp.roster != null) {
+            re = mainapp.roster.get(rosterNameString);
+            if (re == null) {
+                Log.w("Engine_Driver", "select_loco: Roster entry " + rosterNameString + " not available.");
+                return true;
+            }
         }
-        RosterEntry re = mainapp.roster.get(rosterNameString);
-        if (re == null) {
-            Log.w("Engine_Driver", "select_loco: Roster entry " + rosterNameString + " not available.");
-            return true;
-        }
-        String iconURL = hm.get("roster_icon");
-
-        showRosterDetailsDialog(re, rosterNameString, iconURL);
-
+        iconURL = hm.get("roster_icon");
+        showRosterDetailsDialog(re, rosterNameString, rosterAddressString, iconURL);
         return true;
     }
 
-    protected void showRosterDetailsDialog(RosterEntry re, String rosterNameString, String iconURL) {
+    protected void showRosterDetailsDialog(RosterEntry re, String rosterNameString, String rosterAddressString, String iconURL) {
+        String res = "";
         Log.d("Engine_Driver", "select_loco: Showing details for roster entry " + rosterNameString);
         final Dialog dialog = new Dialog(select_loco.this, mainapp.getSelectedTheme());
         dialog.setTitle(getApplicationContext().getResources().getString(R.string.rosterDetailsDialogTitle) + rosterNameString);
         dialog.setContentView(R.layout.roster_entry);
-        String res = re.toString();
+        if (re != null) {
+            res = re.toString();
+        } else {
+            res = "\n DCC Address: " + rosterAddressString +"\n Roster Entry: " + rosterNameString + "\n";
+        }
         TextView tv = dialog.findViewById(R.id.rosterEntryText);
         tv.setText(res);
 
         detailsRosterImageView = dialog.findViewById(R.id.rosterEntryImage);
+        detailsRosterImageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
         loadRosterOrRecentImage(rosterNameString, detailsRosterImageView, iconURL);
 
-        Button buttonClose = dialog.findViewById(R.id.rosterEntryButtonClose);
+        buttonClose = dialog.findViewById(R.id.rosterEntryButtonClose);
         buttonClose.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (newRosterImageSelected) {
@@ -1751,6 +1804,13 @@ public class select_loco extends AppCompatActivity {
             }
         });
 
+        if ((iconURL != null) && (!iconURL.equals(""))) {
+            buttonSelectRosterImage.setVisibility(GONE);
+            TextView rosterEntryImageHelpText = dialog.findViewById(R.id.rosterEntryImageHelpText);
+            rosterEntryImageHelpText.setText(getString(R.string.rosterEntryImageServerImageHelpText));
+            buttonRemoveRosterImage.setVisibility(GONE);
+        }
+
         if (!hasLocalRosterImage) {
             buttonRemoveRosterImage.setVisibility(GONE);
         }
@@ -1764,6 +1824,7 @@ public class select_loco extends AppCompatActivity {
     protected boolean onLongRecentListItemClick(int position) {
         if (importExportPreferences.recent_loco_source_list.get(position) == WHICH_SOURCE_ROSTER) {
             String rosterEntryName = importExportPreferences.recent_loco_name_list.get(position);
+            Integer rosterEntryAddress = importExportPreferences.recent_loco_address_list.get(position);
             RosterEntry re = null;
             if (mainapp.roster != null) {
                 re = mainapp.roster.get(rosterEntryName);
@@ -1772,7 +1833,7 @@ public class select_loco extends AppCompatActivity {
                 Log.w("Engine_Driver", "Roster entry " + rosterEntryName + " not available.");
                 return true;
             }
-            showRosterDetailsDialog(re, rosterEntryName, "");
+            showRosterDetailsDialog(re, rosterEntryName, Integer.toString(rosterEntryAddress),"");
         } else {
             showEditRecentsNameDialog(position);
         }
@@ -1942,7 +2003,7 @@ public class select_loco extends AppCompatActivity {
     private void loadRosterOrRecentImage(String engineName, ImageView imageView, String iconURL) {
         //see if there is a saved file and preload it, even if it gets written over later
         boolean foundSavedImage = false;
-        String imgFileName = mainapp.fixFilename(engineName) + ".jpg";
+        String imgFileName = mainapp.fixFilename(engineName) + ".png";
         File image_file = new File(getApplicationContext().getExternalFilesDir(null), "/"+RECENT_LOCO_DIR+"/"+imgFileName);
         if (image_file.exists()) {
             try {
@@ -2099,24 +2160,39 @@ public class select_loco extends AppCompatActivity {
         }
     }
 
-    private static Bitmap viewToBitmap(View view, int widh, int hight)
+    private static Bitmap viewToBitmap(View view, int maxHeight)
     {
-        Bitmap bitmap=Bitmap.createBitmap(widh,hight, Bitmap.Config.ARGB_8888);
-        Canvas canvas=new Canvas(bitmap); view.draw(canvas);
-        return bitmap;
+        int originalWidth = view.getWidth();
+        int originalHeight = view.getHeight();
+
+        Bitmap bitmap = Bitmap.createBitmap(originalWidth, originalHeight, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        view.draw(canvas);
+
+        if (maxHeight>0) {
+            //scale the image based on th max allowed height
+            int scaledHeight = (int) (((double) maxHeight) * context.getResources().getDisplayMetrics().density);  //52dp
+            double ratio = ((float) scaledHeight) / originalHeight;
+            int scaledWidth = (int) (((double) originalWidth) * ratio);
+            Bitmap resizedBitmap = Bitmap.createScaledBitmap(bitmap, scaledWidth, scaledHeight, true);
+            return resizedBitmap;
+        } else {
+            Bitmap resizedBitmap = Bitmap.createScaledBitmap(bitmap, originalWidth, originalHeight, true);
+            return resizedBitmap;
+        }
     }
 
     private boolean writeLocoImageToFile(String rosterNameString, ImageView imageView) {
         try {
             File dir = new File(context.getExternalFilesDir(null), RECENT_LOCO_DIR);
             if (!dir.exists()) dir.mkdir(); // in case the folder does not already exist
-            String imgFileName = mainapp.fixFilename(rosterNameString + ".jpg");
+            String imgFileName = mainapp.fixFilename(rosterNameString + ".png");
             File imageFile = new File(context.getExternalFilesDir(null) + "/" + RECENT_LOCO_DIR + "/" + imgFileName);
             if (dir.exists()) imageFile.delete(); // delete the old version if it exists
             FileOutputStream fileOutputStream =
                     new FileOutputStream(context.getExternalFilesDir(null) + "/" + RECENT_LOCO_DIR + "/" + imgFileName);
-            Bitmap bitmap = viewToBitmap(detailsRosterImageView, detailsRosterImageView.getWidth(), detailsRosterImageView.getHeight());
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fileOutputStream);
+            Bitmap bitmap = viewToBitmap(imageView, 52);   //52dp
+            bitmap.compress(Bitmap.CompressFormat.PNG, 90, fileOutputStream);
             fileOutputStream.flush();
             fileOutputStream.close();
             return true;
@@ -2130,7 +2206,7 @@ public class select_loco extends AppCompatActivity {
         try {
             File dir = new File(context.getExternalFilesDir(null), RECENT_LOCO_DIR);
             if (!dir.exists()) dir.mkdir(); // in case the folder does not already exist
-            String imgFileName = mainapp.fixFilename(rosterNameString + ".jpg");
+            String imgFileName = mainapp.fixFilename(rosterNameString + ".png");
             File imageFile = new File(context.getExternalFilesDir(null) + "/" + RECENT_LOCO_DIR + "/" + imgFileName);
             if (dir.exists()) imageFile.delete();
             return true;
@@ -2139,4 +2215,42 @@ public class select_loco extends AppCompatActivity {
             return false;
         }
     }
+
+//    private void cropLocoImage() {
+//        int crop = detailsRosterImageView.getHeight() / 10;
+//        Bitmap bitmap = viewToBitmap(detailsRosterImageView, 0);
+//        Bitmap croppedBitmap = Bitmap.createBitmap(bitmap, 0, crop, detailsRosterImageView.getWidth(), detailsRosterImageView.getHeight()-(crop*2) );
+//        detailsRosterImageView.setScaleY((float) 10/8);
+//
+//        detailsRosterImageView.setImageBitmap(croppedBitmap);
+//        detailsRosterImageView.invalidate();
+//        detailsRosterImageView.setVisibility(VISIBLE);
+//        newRosterImageSelected = true;
+//        hasLocalRosterImage = true;
+//        LocalRosterImageRemoved = false;
+//    }
+
+    // from http://www.java2s.com/example/android/android.graphics/read-bitmap-from-file-and-rotate.html
+    static private int getRotateDegreeFromExif(String filePath) {
+        int degree = 0;
+        try {
+            ExifInterface exifInterface = new ExifInterface(filePath);
+            int orientation = exifInterface.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_UNDEFINED);
+            if (orientation == ExifInterface.ORIENTATION_ROTATE_90) {
+                degree = 90;
+            } else if (orientation == ExifInterface.ORIENTATION_ROTATE_180) {
+                degree = 180;
+            } else if (orientation == ExifInterface.ORIENTATION_ROTATE_270) {
+                degree = 270;
+            }
+        } catch (IOException e) {
+            degree = -1;
+            e.printStackTrace();
+        }
+
+        return degree;
+    }
+
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -3635,11 +3635,11 @@ public class threaded_application extends Application {
     // use this method if exiting since we don't want to prompt for permissions at this point if they have not been granted
     private void saveSharedPreferencesToFileIfAllowed() {
 //        if (PermissionsHelper.getInstance().isPermissionGranted(threaded_application.context, PermissionsHelper.STORE_PREFERENCES)) {
-            saveSharedPreferencesToFileImpl();
-//        }
-    }
-
-    private void saveSharedPreferencesToFileImpl() {
+//            saveSharedPreferencesToFileImpl();
+////        }
+//    }
+//
+//    private void saveSharedPreferencesToFileImpl() {
         Log.d("Engine_Driver", "TA: saveSharedPreferencesToFileImpl: start");
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", threaded_application.context.getResources().getString(R.string.prefAutoImportExportDefaultValue));

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -4612,7 +4612,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (whichThrottle < threaded_application.SOUND_MAX_SUPPORTED_THROTTLES) { // only dealing with the first two throttle for now
                 if (!mainapp.prefDeviceSounds[whichThrottle].equals("none")) {
                     int mSound = -1;
-                    if (mainapp.consists[whichThrottle].isActive()) {
+                    if ( (mainapp.consists != null) && (mainapp.consists[whichThrottle].isActive()) ) {
                         mSound = getLocoSoundStep(whichThrottle);
 
                         Log.d("Engine_Driver", "doLocoSound               : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
@@ -7190,10 +7190,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     private void autoImportFromURL() {
 //        navigateToHandler(PermissionsHelper.STORE_SERVER_AUTO_PREFERENCES);
-        autoImportFromURLImpl();
-    }
-
-    public void autoImportFromURLImpl() {
+//        autoImportFromURLImpl();
+//    }
+//
+//    public void autoImportFromURLImpl() {
         new autoImportFromURL().execute();
     }
 
@@ -7288,10 +7288,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     private void autoImportUrlAskToImport() {
 //        navigateToHandler(PermissionsHelper.READ_SERVER_AUTO_PREFERENCES);
-        autoImportUrlAskToImportImpl();
-    }
-
-    private void autoImportUrlAskToImportImpl() {
+//        autoImportUrlAskToImportImpl();
+//    }
+//
+//    private void autoImportUrlAskToImportImpl() {
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             //@Override
             @SuppressLint("ApplySharedPref")

--- a/EngineDriver/src/main/res/layout/roster_entry.xml
+++ b/EngineDriver/src/main/res/layout/roster_entry.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rosterEntryView"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical" >
@@ -30,13 +31,14 @@
         android:layout_margin="5dp"
         android:layout_weight="1"
         android:paddingLeft="6dp"
-        android:paddingRight="6dp">
+        android:paddingRight="6dp" >
 
         <TableRow android:gravity="center_horizontal">
             <ImageView
                 android:id="@+id/rosterEntryImage"
-                android:layout_width="300dp"
-                android:layout_height="150dp" />
+                android:layout_width="wrap_content"
+                android:layout_height="150dp"
+                android:background="#00000000" />
         </TableRow>
 
         <TableRow android:gravity="center_horizontal">
@@ -49,14 +51,14 @@
                 <Button
                     android:id="@+id/selectRosterEntryImage"
                     style="?attr/ed_normal_button_style"
-                    android:text="@string/selectRosterEntryImage"
+                    android:text="@string/rosterEntryImageSelectButtonText"
                     android:textSize="16sp"
                     android:layout_weight="5" />
 
                 <Button
                     android:id="@+id/removeRosterEntryImage"
                     style="?attr/ed_normal_button_style"
-                    android:text="@string/removeRosterEntryImage"
+                    android:text="@string/rosterEntryImageRemoveButtonText"
                     android:textSize="16sp"
                     android:layout_weight="5" />
             </LinearLayout>

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -924,4 +924,9 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Addicionals al telèfon Loco sona les preferències</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Els sons de pas de loco jugaran fins al final en canviar de pas. La quantitat d\'impuls (a dalt) només es converteix en un temps mínim.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">No feu clic a Loco Step Sounds</string>
+    <string name="rosterEntryImageHelpText">Imatges emmagatzemades localment. Si el vostre servidor té una imatge per al Loco, sobreescriu aquesta selecció.</string>
+    <string name="rosterEntryImageRemoveButtonText">Treure</string>
+    <string name="rosterEntryImageSaveButtonText">Estalviar</string>
+    <string name="rosterEntryImageSelectButtonText">Nova imatge</string>
+    <string name="rosterEntryImageServerImageHelpText">El vostre servidor té una imatge per al loco. Podeu canviar la imatge local, ja que s\'acabarà automàticament per la que hi ha al servidor.</string>
 </resources>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -1124,5 +1124,10 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Další v telefonu Loco Sounds Preferences</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Zuny Loco Step bude hrát až do jejich konce při změně kroku. Částka hybnosti (výše) se stává minimálním časem.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">Nefulip Clip Locko Step Zvuky</string>
+    <string name="rosterEntryImageHelpText">Lokálně uložené obrázky. Pokud má váš server obraz pro LOCO, přepíše tento výběr.</string>
+    <string name="rosterEntryImageRemoveButtonText">Odstranit</string>
+    <string name="rosterEntryImageSaveButtonText">Uložit</string>
+    <string name="rosterEntryImageSelectButtonText">Nový vzhled</string>
+    <string name="rosterEntryImageServerImageHelpText">Váš server má obraz pro LOCO. Můžete změnit místní snímek, protože bude automaticky převaženo jedním na serveru.</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -936,5 +936,10 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Zusätzlich in Telefon Loco Sounds-Vorlieben</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco-Step-Sounds spielen bis zum Ende, wenn Sie den Schritt ändern. Der Momentummenge (oben) wird nur zu einer Mindestzeit.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">Clip Loco-Step-Sounds nicht</string>
+    <string name="rosterEntryImageHelpText">Nur lokal gespeicherte Bilder. Wenn Ihr Server ein Bild für den LOCO hat, wird diese Auswahl überschrieben.</string>
+    <string name="rosterEntryImageRemoveButtonText">Entfernen</string>
+    <string name="rosterEntryImageSaveButtonText">Speichern</string>
+    <string name="rosterEntryImageSelectButtonText">Neues Bild</string>
+    <string name="rosterEntryImageServerImageHelpText">Ihr Server verfügt über ein Bild für den Lok. Sie können das lokale Bild ändern, da er von der einem auf dem Server automatisch überwunden wird.</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -919,4 +919,9 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Adicional en teléfono loco sonidas preferencias</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Los sonidos del paso de Loco jugarán hasta su final al cambiar el paso. La cantidad de impulso (arriba) se convierte en un tiempo mínimo solamente.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">No clips Loco Paso sonidos</string>
+    <string name="rosterEntryImageHelpText">Solo imágenes almacenadas localmente. Si su servidor tiene una imagen para el LOCO, sobrescribirá esta selección.</string>
+    <string name="rosterEntryImageServerImageHelpText">Su servidor tiene una imagen para el Loco. No puede cambiar la imagen local, ya que se agregará automáticamente por el en el servidor.</string>
+    <string name="rosterEntryImageSelectButtonText">Nueva imagen</string>
+    <string name="rosterEntryImageRemoveButtonText">Remover</string>
+    <string name="rosterEntryImageSaveButtonText">Guardar</string>
 </resources>

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -948,5 +948,10 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Supplémentaire dans le téléphone Loco Sounds Préférences</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Les sons de l\'étape loco joueront jusqu\'à leur fin lors du changement d\'étape. Le montant de l\'élan (ci-dessus) devient un temps minimum seulement.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">Ne clipez pas de sons sur la loco</string>
+    <string name="rosterEntryImageHelpText">Images stockées localement uniquement. Si votre serveur a une image pour le loco, il écrasera cette sélection.</string>
+    <string name="rosterEntryImageRemoveButtonText">Éliminer</string>
+    <string name="rosterEntryImageSaveButtonText">Sauver</string>
+    <string name="rosterEntryImageSelectButtonText">Nouvelle image</string>
+    <string name="rosterEntryImageServerImageHelpText">Votre serveur a une image pour la loco. Vous ne pouvez pas changer l\'image locale car elle sera automatiquement ouverte par celle sur le serveur.</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -868,5 +868,10 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Ulteriori preferenze del telefono dei suoni del telefono</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco Step Sounds giocherà fino alla fine quando cambiano il passaggio. L\'importo dello slancio (sopra) diventa solo un tempo minimo.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">Non clitare i suoni Step Loco</string>
+    <string name="rosterEntryImageHelpText">Solo immagini memorizzate localmente. Se il tuo server ha un\'immagine per la loco, sovrascriverà questa selezione.</string>
+    <string name="rosterEntryImageServerImageHelpText">Il tuo server ha un\'immagine per la loco. Puoi cambiare l\'immagine locale in quanto verrà automaticamente sovrascritta da quella sul server.</string>
+    <string name="rosterEntryImageSelectButtonText">Nuova immagine</string>
+    <string name="rosterEntryImageRemoveButtonText">Rimuovere</string>
+    <string name="rosterEntryImageSaveButtonText">Salva</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -871,5 +871,10 @@
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Preferências adicionais em Telefone Loco Sounds</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Os sons de passo de loco jogarão até o fim ao mudar de passo. A quantidade de momentum (acima) se torna apenas um tempo mínimo.</string>
     <string name="prefDeviceSoundsMomentumOverrideTitle">Não clique sons de passo de loco</string>
+    <string name="rosterEntryImageHelpText">Apenas imagens armazenadas localmente. Se o seu servidor tiver uma imagem para o loco, ele substituirá essa seleção.</string>
+    <string name="rosterEntryImageServerImageHelpText">Seu servidor tem uma imagem para o loco. Você não pode alterar a imagem local, pois será automaticamente superajectiva pelo servidor.</string>
+    <string name="rosterEntryImageSelectButtonText">Nova imagem</string>
+    <string name="rosterEntryImageRemoveButtonText">Remover</string>
+    <string name="rosterEntryImageSaveButtonText">Salve </string>
 
 </resources>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -169,9 +169,12 @@
     <string name="logviewerClose">Close</string>
     <string name="logviewerSave">Start recording to file</string>
 
-    <string name="selectRosterEntryImage">Select new image</string>
-    <string name="removeRosterEntryImage">Remove image</string>
+    <string name="rosterEntryImageSelectButtonText">New image</string>
+    <string name="rosterEntryImageRemoveButtonText">Remove</string>
     <string name="rosterEntryImageHelpText">Locally stored images only.  If your server has an image for the loco, it will overwrite this selection.</string>
+    <string name="rosterEntryImageServerImageHelpText">Your server has an image for the loco. You can\'t change the local image as it will be automatically overwitten by the one on the server.</string>
+    <string name="rosterEntryImageSaveButtonText">Save</string>
+
 
     <string name="prefTitle">Preferences</string>
     <string name="prefSummary">Preferences for Engine Driver</string>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -27,7 +27,7 @@
  * FIX - Switching layouts sometimes not updating correctly for direction changes
  * bump minSdkVersion from 15 to 16
  * Cache roster images for selected locos
- * Option to load local images for roster locos (primarily intended for DCC++EX)
+ * Option to load local images for roster locos (primarily intended for DCC++EX but works for any server that does not support a web server)
 **Version 2.30.128
  * Add confirmation dialog to Clear Consists
  * FIX - Locos selected from roster written to Recents without name


### PR DESCRIPTION
- rewrite of the way the images are opened and compressed to support very large source images
- shift all the saved images to .PNG (from .JPG) to resolve the problem of the transparent backgrounds
- correctly applies rotation of the source image
- option to the remove the local image (roster images only)