### PR TITLE
DCC-EX native command support

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jmri.enginedriver"
     android:versionCode="156"
-    android:versionName="2.34.156" android:installLocation="auto">
+    android:versionName="2.34.156i" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
@@ -223,5 +223,11 @@
             android:launchMode="singleTop"
             android:theme="@style/app_theme_black" >
         </activity>
-    </application>
+        <activity
+            android:name=".dcc_ex"
+            android:alwaysRetainTaskState="true"
+            android:launchMode="singleTop"
+            android:label="@string/app_name_dcc_ex"
+            android:theme="@style/app_theme_black" >
+        </activity>    </application>
 </manifest>

--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jmri.enginedriver"
     android:versionCode="156"
-    android:versionName="2.34.156i" android:installLocation="auto">
+    android:versionName="2.34.156" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
@@ -229,5 +229,6 @@
             android:launchMode="singleTop"
             android:label="@string/app_name_dcc_ex"
             android:theme="@style/app_theme_black" >
-        </activity>    </application>
+        </activity>
+    </application>
 </manifest>

--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -23,6 +23,8 @@
     <li>Support for USB volume dials as a Gamepad type</li>
     <li>Preference for setting what a second press of the Stop button on a gamepad does</li>
     <li>Prevent some crashes reported to Play Store</li>
+    <li>Support for using the native DCC-EX commands instead of wiThrottle on an EX-Command Station</li>
+    <li>Able to read and write CVs, on the programming track only, when using native DCC-EX commands</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/Consist.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/Consist.java
@@ -47,7 +47,7 @@ public final class Consist {
         private int lightOn;                             //state of the headlight
         private int source;                              //how was the loco originally selected
 
-        ConLoco(String address) {
+        public ConLoco(String address) {
             super(address);
             backward = false;
             lightOn = LIGHT_UNKNOWN;

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -64,6 +64,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -125,6 +126,8 @@ public class connection_activity extends AppCompatActivity implements Permission
     int rootViewHeight = 0;
 
     boolean prefAllowMobileData = false;
+    boolean prefDCCEXconnectionOption = false;
+    Spinner DCCEXconnectionOptionSpinner;
 
     private Toolbar toolbar;
 
@@ -563,6 +566,11 @@ public class connection_activity extends AppCompatActivity implements Permission
             }
         });
 
+
+        DCCEXconnectionOptionSpinner = findViewById(R.id.cons_DCCEXconnectionOption);
+        DCCEXconnectionOptionSpinner.setOnItemSelectedListener(new DCCEXconnectionOption_listener());
+        setConnectionProtocolOption();
+
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
@@ -610,6 +618,8 @@ public class connection_activity extends AppCompatActivity implements Permission
         if (prefs.getBoolean("connect_to_first_server_preference", false)) {
             connectA();
         }
+        setConnectionProtocolOption();
+
         if (CMenu != null) {
             mainapp.displayFlashlightMenuButton(CMenu);
             mainapp.setFlashlightButton(CMenu);
@@ -1117,6 +1127,43 @@ public class connection_activity extends AppCompatActivity implements Permission
         } finally {
             is.close();
             os.close();
+        }
+    }
+
+    public class DCCEXconnectionOption_listener implements AdapterView.OnItemSelectedListener {
+
+        @SuppressLint("ApplySharedPref")
+        @Override
+        public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+
+            Spinner spinner = findViewById(R.id.cons_DCCEXconnectionOption);
+            int spinnerPosition = spinner.getSelectedItemPosition();
+            mainapp.prefDCCEX = spinnerPosition == 0;
+            prefs.edit().putBoolean("prefDCCEX", mainapp.prefDCCEX).commit();  //set the preference
+        }
+
+        @Override
+        public void onNothingSelected(AdapterView<?> parent) {
+        }
+    }
+
+    private void setConnectionProtocolOption() {
+        prefDCCEXconnectionOption = prefs.getBoolean("prefDCCEXconnectionOption", getResources().getBoolean(R.bool.prefDCCEXconnectionOptionDefaultValue));
+
+        if (mainapp.prefDCCEX) {
+            DCCEXconnectionOptionSpinner.setSelection(0);
+        } else {
+            DCCEXconnectionOptionSpinner.setSelection(1);
+        }
+
+        TextView DCCEXheading =  findViewById(R.id.cons_DCCEXconnectionOption_heading);
+        LinearLayout DCCEXlayout =  findViewById(R.id.cons_DCCEXconnectionOption_layout);
+        if (prefDCCEXconnectionOption) {
+            DCCEXheading.setVisibility(View.VISIBLE);
+            DCCEXlayout.setVisibility(View.VISIBLE);
+        } else {
+            DCCEXheading.setVisibility(View.GONE);
+            DCCEXlayout.setVisibility(View.GONE);
         }
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
@@ -97,7 +97,7 @@ public class dcc_ex extends AppCompatActivity {
                     @SuppressLint("SimpleDateFormat") SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SS");
                     String currentTime = sdf.format(new Date());
                     DCCEXresponsesStr =  currentTime + " : " + msg.obj.toString() + "\n" + DCCEXresponsesStr;
-                    if (DCCEXresponsesStr.length()>2048) DCCEXresponsesStr.substring(0,2048);
+                    if (DCCEXresponsesStr.length()>2048) DCCEXresponsesStr = DCCEXresponsesStr.substring(0,4086);
                     DCCEXresponsesLabel.setText(DCCEXresponsesStr);
                     break;
                 case message_type.WRITE_DECODER_SUCCESS:
@@ -199,6 +199,7 @@ public class dcc_ex extends AppCompatActivity {
 
     public class send_command_button_listener implements View.OnClickListener {
         public void onClick(View v) {
+            DCCEXinfoStr = "";
             String cmdStr = etDCCEXsendCommandValue.getText().toString();
             if ((cmdStr.length()>0) && (cmdStr.charAt(0)!='<')) {
                 mainapp.buttonVibration();
@@ -308,7 +309,7 @@ public class dcc_ex extends AppCompatActivity {
             Objects.requireNonNull(getSupportActionBar()).setDisplayShowTitleEnabled(false);
             mainapp.setToolbarTitle(toolbar,
                     getApplicationContext().getResources().getString(R.string.app_name),
-                    getApplicationContext().getResources().getString(R.string.app_name_power_control),
+                    getApplicationContext().getResources().getString(R.string.app_name_dcc_ex),
                     "");
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
@@ -1,0 +1,443 @@
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package jmri.enginedriver;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Objects;
+
+public class dcc_ex extends AppCompatActivity {
+
+    private threaded_application mainapp;  // hold pointer to mainapp
+    private Menu menu;
+
+    private String DCCEXcv = "";
+    private String DCCEXcvValue = "";
+    private EditText etDCCEXcv;
+    private EditText etDCCEXcvValue;
+
+    private String DCCEXaddress = "";
+    private EditText etDCCEXwriteAddressValue;
+
+    private String DCCEXsendCommandValue = "";
+    private EditText etDCCEXsendCommandValue;
+
+    private TextView DCCEXwriteInfoLabel;
+    private String DCCEXinfoStr = "";
+
+    private TextView DCCEXresponsesLabel;
+    private String DCCEXresponsesStr = "";
+
+    private Toolbar toolbar;
+
+    //Handle messages from the communication thread back to this thread (responses from withrottle)
+    @SuppressLint("HandlerLeak")
+    class dcc_ex_handler extends Handler {
+
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case message_type.RECEIVED_DECODER_ADDRESS:
+                    String response_str = msg.obj.toString();
+                    if ((response_str.length() > 0) && (!response_str.equals("-1"))) {  //refresh address
+                        DCCEXaddress = response_str;
+                        DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXSucceeded);
+                    } else {
+                        DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXFailed);
+                    }
+                    refresh_dcc_ex_view();
+                    break;
+                case message_type.RECEIVED_CV:
+                    String cvResponseStr = msg.obj.toString();
+                    if (cvResponseStr.length() > 0) {
+                        String[] cvArgs = cvResponseStr.split("(\\|)");
+                        if ((cvArgs[0].equals(DCCEXcv)) && (!cvArgs[1].equals("-1"))) { // response matches what we got back
+                            DCCEXcvValue = cvArgs[1];
+                            DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXSucceeded);
+                        } else {
+                            DCCEXcvValue = "";
+                            DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXFailed);
+                        }
+                        refresh_dcc_ex_view();
+                    }
+                    break;
+                case message_type.DCCEX_RESPONSE:  // informational response
+                    @SuppressLint("SimpleDateFormat") SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SS");
+                    String currentTime = sdf.format(new Date());
+                    DCCEXresponsesStr =  currentTime + " : " + msg.obj.toString() + "\n" + DCCEXresponsesStr;
+                    if (DCCEXresponsesStr.length()>2048) DCCEXresponsesStr.substring(0,2048);
+                    DCCEXresponsesLabel.setText(DCCEXresponsesStr);
+                    break;
+                case message_type.WRITE_DECODER_SUCCESS:
+                    DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXSucceeded);
+                    refresh_dcc_ex_view();
+                    break;
+                case message_type.WRITE_DECODER_FAIL:
+                    DCCEXinfoStr = getApplicationContext().getResources().getString(R.string.DCCEXFailed);
+                    refresh_dcc_ex_view();
+                    break;
+                case message_type.WIT_CON_RETRY:
+                    witRetry(msg.obj.toString());
+                    break;
+                case message_type.WIT_CON_RECONNECT:
+                    refresh_dcc_ex_view();
+                    break;
+                case message_type.RESTART_APP:
+                case message_type.RELAUNCH_APP:
+                case message_type.DISCONNECT:
+                case message_type.SHUTDOWN:
+                    disconnect();
+                    break;
+            }
+        }
+    }
+
+    public class read_address_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            DCCEXinfoStr = "";
+            DCCEXaddress = "";
+            mainapp.buttonVibration();
+            mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_DECODER_ADDRESS, "*", -1);
+            refresh_dcc_ex_view();
+        }
+    }
+
+    public class write_address_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            DCCEXinfoStr = "";
+            String addrStr = etDCCEXwriteAddressValue.getText().toString();
+            try {
+                Integer addr = Integer.decode(addrStr);
+                if ((addr>2) && (addr<=9999)) {
+                    DCCEXaddress = addr.toString();
+                    mainapp.buttonVibration();
+                    mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_DECODER_ADDRESS, "", addr);
+                } else {
+                    DCCEXaddress = "";
+                }
+            } catch (Exception e) {
+                DCCEXaddress = "";
+            }
+            refresh_dcc_ex_view();
+        }
+    }
+
+    public class read_cv_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            DCCEXinfoStr = "";
+            DCCEXcvValue = "";
+            String cvStr = etDCCEXcv.getText().toString();
+            try {
+                int cv = Integer.decode(cvStr);
+                if (cv > 0) {
+                    DCCEXcv = Integer.toString(cv);
+                    mainapp.buttonVibration();
+                    mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_CV, "", cv);
+                    refresh_dcc_ex_view();
+                }
+            } catch (Exception e) {
+                DCCEXcv = "";
+            }
+            refresh_dcc_ex_view();
+        }
+    }
+
+    public class write_cv_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            DCCEXinfoStr = "";
+            String cvStr = etDCCEXcv.getText().toString();
+            String cvValueStr = etDCCEXcvValue.getText().toString();
+            try {
+                Integer cv = Integer.decode(cvStr);
+                int cvValue = Integer.decode(cvValueStr);
+                if ((cv>0) && (cvValue>0)) {
+                    DCCEXcv = cv.toString();
+                    DCCEXcvValue = Integer.toString(cvValue);
+                    mainapp.buttonVibration();
+                    mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_CV, cvValueStr, cv);
+                } else {
+                    DCCEXaddress = "";
+                }
+            } catch (Exception e) {
+                DCCEXaddress = "";
+            }
+            refresh_dcc_ex_view();
+        }
+    }
+
+    public class send_command_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            String cmdStr = etDCCEXsendCommandValue.getText().toString();
+            if ((cmdStr.length()>0) && (cmdStr.charAt(0)!='<')) {
+                mainapp.buttonVibration();
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DCCEX_SEND_COMMAND, "<"+cmdStr+">");
+                DCCEXaddress = "";
+            }
+            refresh_dcc_ex_view();
+        }
+    }
+
+
+
+    private void witRetry(String s) {
+        Intent in = new Intent().setClass(this, reconnect_status.class);
+        in.putExtra("status", s);
+        startActivity(in);
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+    }
+
+    public void refresh_dcc_ex_view() {
+
+        etDCCEXwriteAddressValue.setText(DCCEXaddress);
+        DCCEXwriteInfoLabel.setText(DCCEXinfoStr);
+
+        etDCCEXcv.setText(DCCEXcv);
+        etDCCEXcvValue.setText(DCCEXcvValue);
+
+        etDCCEXcvValue.setText(DCCEXcvValue);
+
+        etDCCEXsendCommandValue.setText(DCCEXsendCommandValue);
+
+        DCCEXresponsesLabel.setText(DCCEXresponsesStr);
+
+        mainapp.hideSoftKeyboard(this.getCurrentFocus());
+
+        if (menu != null) {
+            mainapp.displayEStop(menu);
+        }
+    }
+
+    // *************************************************************************************** //
+
+    /**
+     * Called when the activity is first created.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mainapp = (threaded_application) getApplication();
+        if (mainapp.isForcingFinish()) {     // expedite
+            return;
+        }
+
+        mainapp.applyTheme(this);
+
+        setContentView(R.layout.dcc_ex);
+
+        //put pointer to this activity's handler in main app's shared variable (If needed)
+        mainapp.dcc_ex_msg_handler = new dcc_ex_handler();
+
+        Button button = findViewById(R.id.dexc_DCCEXreadAddressButton);
+        read_address_button_listener read_address_click_listener = new read_address_button_listener();
+        button.setOnClickListener(read_address_click_listener);
+
+        button = findViewById(R.id.dexc_DCCEXwriteAddressButton);
+        write_address_button_listener write_address_click_listener = new write_address_button_listener();
+        button.setOnClickListener(write_address_click_listener);
+
+        etDCCEXwriteAddressValue = findViewById(R.id.dexc_DCCEXwriteAddressValue);
+        etDCCEXwriteAddressValue.setText("");
+
+        button = findViewById(R.id.dexc_DCCEXreadCvButton);
+        read_cv_button_listener readCvClickListener = new read_cv_button_listener();
+        button.setOnClickListener(readCvClickListener);
+
+        button = findViewById(R.id.dexc_DCCEXwriteCvButton);
+        write_cv_button_listener writeCvClickListener = new write_cv_button_listener();
+        button.setOnClickListener(writeCvClickListener);
+
+        etDCCEXcv = findViewById(R.id.dexc_DCCEXcv);
+        etDCCEXcv.setText("");
+
+        etDCCEXcvValue = findViewById(R.id.dexc_DCCEXcvValue);
+        etDCCEXcvValue.setText("");
+
+        button = findViewById(R.id.dexc_DCCEXsendCommandButton);
+        send_command_button_listener sendCommandClickListener = new send_command_button_listener();
+        button.setOnClickListener(sendCommandClickListener);
+
+        etDCCEXsendCommandValue = findViewById(R.id.dexc_DCCEXsendCommandValue);
+        etDCCEXsendCommandValue.setText("");
+
+        DCCEXwriteInfoLabel = findViewById(R.id.dexc_DCCEXwriteInfoLabel);
+        DCCEXwriteInfoLabel.setText("");
+
+        DCCEXresponsesLabel = findViewById(R.id.dexc_DCCEXresponsesLabel);
+        DCCEXresponsesLabel.setText("");
+
+        Button closeButton = findViewById(R.id.dcc_ex_button_close);
+        close_button_listener closeClickListener = new close_button_listener();
+        closeButton.setOnClickListener(closeClickListener);
+
+
+        toolbar = (Toolbar) findViewById(R.id.toolbar);
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+            Objects.requireNonNull(getSupportActionBar()).setDisplayShowTitleEnabled(false);
+            mainapp.setToolbarTitle(toolbar,
+                    getApplicationContext().getResources().getString(R.string.app_name),
+                    getApplicationContext().getResources().getString(R.string.app_name_power_control),
+                    "");
+        }
+
+    } // end onCreate
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mainapp.isForcingFinish()) { //expedite
+            this.finish();
+            return;
+        }
+        mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
+
+        if (menu != null) {
+            mainapp.displayEStop(menu);
+            mainapp.displayFlashlightMenuButton(menu);
+            mainapp.setFlashlightButton(menu);
+        }
+        //update power state
+        mainapp.DCCEXscreenIsOpen = true;
+
+        refresh_dcc_ex_view();
+    }
+
+    /**
+     * Called when the activity is finished.
+     */
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        mainapp.hideSoftKeyboard(this.getCurrentFocus());
+        mainapp.DCCEXscreenIsOpen = false;
+        if (mainapp.dcc_ex_msg_handler !=null) {
+            mainapp.dcc_ex_msg_handler.removeCallbacksAndMessages(null);
+            mainapp.dcc_ex_msg_handler = null;
+        } else {
+            Log.d("Engine_Driver", "onDestroy: mainapp.dcc_ex_msg_handler is null. Unable to removeCallbacksAndMessages");
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu myMenu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.power_menu, myMenu);
+        menu = myMenu;
+        mainapp.displayEStop(myMenu);
+        mainapp.displayFlashlightMenuButton(menu);
+        mainapp.setFlashlightButton(menu);
+
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    //Handle pressing of the back button to end this activity
+    @Override
+    public boolean onKeyDown(int key, KeyEvent event) {
+        if (key == KeyEvent.KEYCODE_BACK) {
+            mainapp.DCCEXscreenIsOpen = false;
+            this.finish();  //end this activity
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        }
+        return (super.onKeyDown(key, event));
+    }
+
+    private void disconnect() {
+        this.finish();
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
+
+    public class close_button_listener implements View.OnClickListener {
+        public void onClick(View v) {
+            mainapp.buttonVibration();
+            finish();
+        }
+    }
+
+    // listener for the joystick events
+    @Override
+    public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
+        boolean rslt = mainapp.implDispatchGenericMotionEvent(event);
+        if (rslt) {
+            return (true);
+        } else {
+            return super.dispatchGenericMotionEvent(event);
+        }
+    }
+
+    // listener for physical keyboard events
+    // used to support the gamepad only   DPAD and key events
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+//        InputDevice idev = getDevice(event.getDeviceId());
+        boolean rslt = mainapp.implDispatchKeyEvent(event);
+        if (rslt) {
+            return (true);
+        } else {
+            return super.dispatchKeyEvent(event);
+        }
+    }
+
+    @SuppressLint("NonConstantResourceId")
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle all of the possible menu actions.
+        switch (item.getItemId()) {
+            case R.id.EmerStop:
+                mainapp.sendEStopMsg();
+                mainapp.buttonVibration();
+                return true;
+            case R.id.flashlight_button:
+                mainapp.toggleFlashlight(this, menu);
+                mainapp.buttonVibration();
+                return true;
+            case R.id.power_layout_button:
+                if (!mainapp.isPowerControlAllowed()) {
+                    mainapp.powerControlNotAllowedDialog(menu);
+                } else {
+                    mainapp.powerStateMenuButton();
+                }
+                mainapp.buttonVibration();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/message_type.java
@@ -51,10 +51,10 @@ public interface message_type {
     int TIME_CHANGED = 28;      // ta -> activities  updates current time
     int CLOCK_DISPLAY_CHANGED = 29;     // pref -> ta  clock display preference changed
     int ESTOP = 30;             // ta(sendeStopMsg) -> ta  estop requested
-    int WITHROTTLE_QUIT = 31;   // ta(disconnect) -> ta send quit command to server
+    int WIFI_QUIT = 31;   // ta(disconnect) -> ta send quit command to server
     int REQ_STEAL = 32;         // ta(message_action) pass addr, throttle -> throttle
     int STEAL = 33;             // ta(checkSteal) pass addr, throttle -> ta send commands to steal
-    int WITHROTTLE_SEND = 34;    // ta, pass complete message, used for delayed sends
+    int WIFI_SEND = 34;         // ta, pass complete message, used for delayed sends
     int SEND_HEARTBEAT_START = 35;    // ta, pass complete message, used for delayed sends
     int FORCE_FUNCTION = 36;     // ed(buttons) -> ta function, on = 0 off =1(sends Tfxy to WiT)
     int TOAST_MESSAGE = 37;      //web_activity -> ta pass message text
@@ -67,12 +67,23 @@ public interface message_type {
     int IMPORT_SERVER_AUTO_AVAILABLE = 44;    //
     int WIT_TURNOUT_NOT_DEFINED = 45;    //
     int RESTART_APP = 46;   //
-    int WIT_QUERY_SPEED_AND_DIRECTION = 47;   //
-    int HTTP_SERVER_NAME_RECEIVED = 49;   //
-    int CONNECTION_COMPLETED_CHECK = 50;   //
-    int RELAUNCH_APP = 51;   //
-    int SOUNDS_FORCE_LOCO_SOUNDS_TO_START = 52;   //
-    int GAMEPAD_ACTION = 53;   //
-    int GAMEPAD_JOYSTICK_ACTION = 54;   //
-    int VOLUME_BUTTON_ACTION = 55;   //
+    int WIT_QUERY_SPEED_AND_DIRECTION = 47;
+    int HTTP_SERVER_NAME_RECEIVED = 49;
+    int CONNECTION_COMPLETED_CHECK = 50;
+    int RELAUNCH_APP = 51;
+    int SOUNDS_FORCE_LOCO_SOUNDS_TO_START = 52;
+    int GAMEPAD_ACTION = 53;
+    int GAMEPAD_JOYSTICK_ACTION = 54;
+    int VOLUME_BUTTON_ACTION = 55;
+    int REFRESH_FUNCTIONS = 56;
+    int REQUEST_DECODER_ADDRESS = 57;
+    int RECEIVED_DECODER_ADDRESS = 58;
+    int WRITE_DECODER_ADDRESS = 59;
+    int WRITE_DECODER_SUCCESS = 60;
+    int WRITE_DECODER_FAIL = 61;
+    int WRITE_CV = 62;
+    int REQUEST_CV = 63;
+    int RECEIVED_CV = 64;
+    int DCCEX_RESPONSE = 65;
+    int DCCEX_SEND_COMMAND = 66;
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -591,6 +591,11 @@ public class routes extends AppCompatActivity implements android.gesture.Gesture
                 startActivityForResult(in, 0);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 return true;
+            case R.id.dcc_ex_mnu:
+                in = new Intent().setClass(this, dcc_ex.class);
+                startActivity(in);
+                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+                return true;
             case R.id.logviewer_menu:
                 Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
                 startActivity(logviewer);

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -545,6 +545,7 @@ public class routes extends AppCompatActivity implements android.gesture.Gesture
         mainapp.displayPowerStateMenuButton(menu);
         mainapp.displayThrottleMenuButton(menu, "swipe_through_routes_preference");
         mainapp.setPowerMenuOption(menu);
+        mainapp.setDCCEXMenuOption(menu);
         mainapp.setPowerStateButton(menu);
         mainapp.setWebMenuOption(menu);
         mainapp.setTurnoutsMenuOption(menu);

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -456,6 +456,7 @@ public class select_loco extends AppCompatActivity {
 
     // request release of specified throttle
     void release_loco(int whichThrottle) {
+        mainapp.storeThrottleLocosForReleaseDCCEX(whichThrottle);
         mainapp.consists[whichThrottle].release();
         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.RELEASE, "", whichThrottle); // pass 0, 1 or 2 in message
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -2230,19 +2230,21 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // if skipLead is true, the direction is not set for the lead engine
     void setEngineDirection(int whichThrottle, int direction, boolean skipLead) {
         Consist con;
-        con = mainapp.consists[whichThrottle];
-        dirs[whichThrottle] = direction;
+        if ( (mainapp.consists!=null) && (dirs!=null) ) {
+            con = mainapp.consists[whichThrottle];
+            dirs[whichThrottle] = direction;
 
-        String leadAddr = con.getLeadAddr();
-        for (String addr : con.getList()) { // loop through each engine in consist
-            if (!skipLead || (addr != null && !addr.equals(leadAddr))) {
-                int locoDir = direction;
-                try {
-                    if (con.isReverseOfLead(addr)) // if engine faces opposite of lead loco
-                        locoDir ^= 1; // then reverse the commanded direction
-                    mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DIRECTION, addr, whichThrottle, locoDir);
-                } catch (Exception e) { // isReverseOfLead returns null if addr is not in con - should never happen since we are walking through consist list
-                    Log.d("Engine_Driver", "throttle " + mainapp.throttleIntToString(whichThrottle) + " direction change for unselected loco " + addr);
+            String leadAddr = con.getLeadAddr();
+            for (String addr : con.getList()) { // loop through each engine in consist
+                if (!skipLead || (addr != null && !addr.equals(leadAddr))) {
+                    int locoDir = direction;
+                    try {
+                        if (con.isReverseOfLead(addr)) // if engine faces opposite of lead loco
+                            locoDir ^= 1; // then reverse the commanded direction
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DIRECTION, addr, whichThrottle, locoDir);
+                    } catch (Exception e) { // isReverseOfLead returns null if addr is not in con - should never happen since we are walking through consist list
+                        Log.d("Engine_Driver", "throttle " + mainapp.throttleIntToString(whichThrottle) + " direction change for unselected loco " + addr);
+                    }
                 }
             }
         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -856,6 +856,7 @@ public class turnouts extends AppCompatActivity implements android.gesture.Gestu
         mainapp.displayPowerStateMenuButton(menu);
         mainapp.displayThrottleMenuButton(menu, "swipe_through_turnouts_preference");
         mainapp.setPowerMenuOption(menu);
+        mainapp.setDCCEXMenuOption(menu);
         mainapp.setPowerStateButton(menu);
         mainapp.setWebMenuOption(menu);
         mainapp.setRoutesMenuOption(menu);

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -905,6 +905,11 @@ public class turnouts extends AppCompatActivity implements android.gesture.Gestu
                 startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
                 return true;
+            case R.id.dcc_ex_mnu:
+                in = new Intent().setClass(this, dcc_ex.class);
+                startActivity(in);
+                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+                return true;
             case R.id.logviewer_menu:
                 Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
                 startActivity(logviewer);

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
@@ -1,0 +1,455 @@
+package jmri.enginedriver.util;
+
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+import android.webkit.WebView;
+import android.widget.Toast;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+
+import jmri.enginedriver.R;
+import jmri.enginedriver.message_type;
+import jmri.enginedriver.threaded_application;
+
+public class comm_handler extends Handler {
+   //All of the work of the communications thread is initiated from this function.
+
+   protected threaded_application mainapp;  // hold pointer to mainapp
+   protected SharedPreferences prefs;
+   protected comm_thread commThread;
+
+   public comm_handler(threaded_application myApp, SharedPreferences myPrefs, comm_thread myCommThread) {
+      mainapp = myApp;
+      prefs = myPrefs;
+      commThread = myCommThread;
+   }
+
+   @SuppressLint({"DefaultLocale", "ApplySharedPref"})
+   public void handleMessage(Message msg) {
+//                Log.d("Engine_Driver", "comm_handler.handleMessage: message: " +msg.what);
+      switch (msg.what) {
+         // note: if the Throttle is sent in arg1, it is always expected to be a int
+         // if it is sent in arg0, it will be a string
+
+         //Start or Stop jmdns stuff, or add "fake" discovered servers
+         case message_type.SET_LISTENER:
+            if (mainapp.client_ssid != null &&
+                    mainapp.client_ssid.matches("DCCEX_[0-9a-f]{6}$")) {
+               //add "fake" discovered server entry for DCCEX: DCCEX_123abc
+               commThread.addFakeDiscoveredServer(mainapp.client_ssid, mainapp.client_address, "2560", "DCC-EX");
+               mainapp.isDCCEX = mainapp.prefDCCEX;
+            } else if (mainapp.client_ssid != null &&
+                    mainapp.client_ssid.matches("^Dtx[0-9]{1,2}-.*_[0-9,A-F]{4}-[0-9]{1,3}$")) {
+               //add "fake" discovered server entry for Digitrax LnWi: Dtx1-LnServer_0009-7
+               commThread.addFakeDiscoveredServer(mainapp.client_ssid, mainapp.client_address, "12090", "LnWi");
+            } else {
+               //arg1= 1 to turn on, arg1=0 to turn off
+               if (msg.arg1 == 0) {
+                  commThread.endJmdns();
+               } else {
+                  //show message if using mobile data
+                  if ((!mainapp.client_type.equals("WIFI")) && (mainapp.prefAllowMobileData)) {
+                     threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppNotWIFI, mainapp.client_type), Toast.LENGTH_LONG);
+                  }
+                  if (commThread.jmdns == null) {   //start jmdns if not started
+                     commThread.startJmdns();
+                     if (commThread.jmdns != null) {  //don't bother if jmdns didn't start
+                        try {
+                           commThread.multicast_lock.acquire();
+                        } catch (Exception e) {
+                           //log message, but keep going if this fails
+                           Log.d("Engine_Driver", "comm_handler.handleMessage: multicast_lock.acquire() failed");
+                        }
+                        commThread.jmdns.addServiceListener("_withrottle._tcp.local.", commThread.listener);
+                        Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns listener added");
+                     } else {
+                        Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns not running, didn't start listener");
+                     }
+                  } else {
+                     Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns already running");
+                  }
+               }
+            }
+            break;
+
+         //Connect to the WiThrottle server.
+         case message_type.CONNECT:
+
+            //The IP address is stored in the obj as a String, the port is stored in arg1.
+            String new_host_ip = msg.obj.toString();
+            new_host_ip = new_host_ip.trim();
+            int new_port = msg.arg1;
+
+            //avoid duplicate connects, seen when user clicks address multiple times quickly
+            if (comm_thread.socketWiT != null && comm_thread.socketWiT.SocketGood()
+                    && new_host_ip.equals(mainapp.host_ip) && new_port == mainapp.port) {
+               Log.d("Engine_Driver", "comm_handler.handleMessage: Duplicate CONNECT message received.");
+               break;
+            }
+
+            //clear app.thread shared variables so they can be reinitialized
+            mainapp.initShared();
+            mainapp.fastClockSeconds = 0L;
+
+            //store ip and port in global variables
+            mainapp.host_ip = new_host_ip;
+            mainapp.port = new_port;
+            // skip url checking on Play Protect
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+               WebView.setSafeBrowsingWhitelist(Collections.singletonList(mainapp.host_ip), null);
+            }
+
+            //attempt connection to WiThrottle server
+            comm_thread.socketWiT = new comm_thread.socketWifi();
+            if (comm_thread.socketWiT.connect()) {
+               if (mainapp.isDCCEX) threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.usingProtocolDCCEX), Toast.LENGTH_LONG);
+
+               commThread.sendThrottleName();
+               mainapp.sendMsgDelay(mainapp.comm_msg_handler, 5000L, message_type.CONNECTION_COMPLETED_CHECK);
+               commThread.phone = new comm_thread.PhoneListener();
+            } else {
+               mainapp.host_ip = null;  //clear vars if failed to connect
+               mainapp.port = 0;
+            }
+            mainapp.soundsReloadSounds = true;
+            break;
+
+         //Release one or all locos on the specified throttle.  addr is in msg (""==all), arg1 holds whichThrottle.
+         case message_type.RELEASE: {
+            int delays = 0;
+            String addr = msg.obj.toString();
+            final int whichThrottle = msg.arg1;
+            final boolean releaseAll = (addr.length() == 0);
+
+            if (releaseAll || mainapp.consists[whichThrottle].isEmpty()) {
+               addr = "";
+               mainapp.function_labels[whichThrottle] = new LinkedHashMap<>();
+               mainapp.function_states[whichThrottle] = new boolean[32];
+            }
+            if (prefs.getBoolean("stop_on_release_preference",                         //send stop command before releasing (if set in prefs)
+                    mainapp.getResources().getBoolean(R.bool.prefStopOnReleaseDefaultValue))) {
+               comm_thread.sendSpeedZero(whichThrottle);
+               delays++;
+            }
+
+//                        sendReleaseLoco(addr, whichThrottle, delays * WiThrottle_Msg_Interval);
+            commThread.sendReleaseLoco(addr, whichThrottle, 0);
+            break;
+         }
+
+            //estop requested.   arg1 holds whichThrottle
+         //  M0A*<;>X  was(0X)
+         case message_type.ESTOP: {
+            final int whichThrottle = msg.arg1;
+//            commThread.wifiSend(String.format("M%sA*<;>X", mainapp.throttleIntToString(whichThrottle)));  //send eStop request
+            commThread.sendEStop(whichThrottle);
+            break;
+         }
+
+         case message_type.RESTART_APP: {
+            SharedPreferences sharedPreferences = mainapp.getSharedPreferences("jmri.enginedriver_preferences", 0);
+            sharedPreferences.edit().putBoolean("prefForcedRestart", true).commit();
+            sharedPreferences.edit().putInt("prefForcedRestartReason", msg.arg1).commit();
+            mainapp.alert_activities(message_type.RESTART_APP, "");
+            break;
+         }
+
+         case message_type.RELAUNCH_APP: {
+            SharedPreferences sharedPreferences = mainapp.getSharedPreferences("jmri.enginedriver_preferences", 0);
+            sharedPreferences.edit().putBoolean("prefForcedRestart", true).commit();
+            sharedPreferences.edit().putInt("prefForcedRestartReason", msg.arg1).commit();
+            mainapp.alert_activities(message_type.RELAUNCH_APP, "");
+
+            Intent intent = mainapp.getBaseContext().getPackageManager().getLaunchIntentForPackage(mainapp.getBaseContext().getPackageName());
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            mainapp.startActivity(intent);
+            Runtime.getRuntime().exit(0); // really force the kill
+            break;
+         }
+
+         //Disconnect from the WiThrottle server and Shutdown
+         case message_type.DISCONNECT: {
+            Log.d("Engine_Driver", "comm_handler.handleMessage: TA Disconnect");
+            mainapp.doFinish = true;
+            Log.d("Engine_Driver", "comm_handler.handleMessage: TA alert all activities to shutdown");
+            mainapp.alert_activities(message_type.SHUTDOWN, "");     //tell all activities to finish()
+            commThread.stoppingConnection();
+
+            // arg1 = 1 means shutdown with no delays
+            if (msg.arg1 == 1) {
+//               commThread.wifiSend("Q");
+//               commThread.shutdown(true);
+               commThread.sendDisconnect();
+            } else {
+               // At this point TA needs to send the quit message to WiT and then shutdown.
+               // However the DISCONNECT message also tells the Throttle activity to release all throttles
+               // and that process can take some time:
+               //  release request messages and possibly zero speed messages need to be sent to WiT
+               //  for each active throttle and WiT will respond with release messages.
+               // So we delay the Quit and shutdown to allow time for all the throttle messages to complete
+               mainapp.sendMsgDelay(mainapp.comm_msg_handler, 1500L, message_type.WIFI_QUIT);
+               if (!mainapp.sendMsgDelay(mainapp.comm_msg_handler, 1600L, message_type.SHUTDOWN)) {
+                  commThread.shutdown(false);
+               }
+            }
+
+            if (mainapp.soundPool != null) {
+               mainapp.soundPool.autoPause();
+            }
+            break;
+         }
+
+         //Set up an engine to control. The address of the engine is given in msg.obj and whichThrottle is in arg1
+         //Optional rostername if present is separated from the address by the proper delimiter
+         case message_type.REQ_LOCO_ADDR: {
+//                        int delays = 0;
+            final String addr = msg.obj.toString();
+            final int whichThrottle = msg.arg1;
+            if (prefs.getBoolean("drop_on_acquire_preference",
+                    mainapp.getResources().getBoolean(R.bool.prefDropOnAcquireDefaultValue))) {
+               commThread.sendReleaseLoco("*", whichThrottle, 0);
+//                            delays++;
+            }
+//                        sendAcquireLoco(addr, whichThrottle, delays * WiThrottle_Msg_Interval);
+            commThread.sendAcquireLoco(addr, whichThrottle, 0);
+            break;
+         }
+
+         case message_type.REQUEST_DECODER_ADDRESS: { // DCC-EX only
+            commThread.sendAcquireLoco("*", -1, 0);
+            break;
+         }
+         case message_type.RECEIVED_DECODER_ADDRESS: {
+            if (!mainapp.doFinish) {
+               mainapp.alert_activities(message_type.RECEIVED_DECODER_ADDRESS, msg.obj.toString());
+            }
+            break;
+         }
+
+         case message_type.DCCEX_SEND_COMMAND: { // DCC-EX only
+            commThread.sendDCCEXcommand(msg.obj.toString());
+            break;
+         }
+
+         case message_type.REQUEST_CV: { // DCC-EX only
+            commThread.sendReadCv(msg.arg1);
+            break;
+         }
+
+         case message_type.WRITE_CV: { // DCC-EX only
+            int cvValue = Integer.decode(msg.obj.toString());
+            commThread.sendWriteCv(cvValue, msg.arg1);
+            break;
+         }
+
+         case message_type.RECEIVED_CV: {
+            if (!mainapp.doFinish) {
+               mainapp.alert_activities(message_type.RECEIVED_CV, msg.obj.toString());
+            }
+            break;
+         }
+
+         case message_type.WRITE_DECODER_ADDRESS: { // DCC-EX only
+            commThread.sendWriteDecoderAddress(msg.arg1);
+            break;
+         }
+
+         case message_type.DCCEX_RESPONSE:
+         case message_type.WRITE_DECODER_SUCCESS:
+         case message_type.WRITE_DECODER_FAIL: {
+            if (!mainapp.doFinish) {
+               mainapp.alert_activities(msg.what, msg.obj.toString());
+            }
+            break;
+         }
+
+         //send commands to steal the last requested address
+         case message_type.STEAL: {
+            String addr = msg.obj.toString();
+            int whichThrottle = msg.arg1;
+            commThread.sendStealLoco(addr, whichThrottle);
+            break;
+         }
+
+         //Adjust the throttle's speed. whichThrottle is in arg 1 and arg2 holds the value of the speed to set.
+         //  message sent is formatted M1A*<;>V13  was(1V13)
+         case message_type.VELOCITY: {
+            final int whichThrottle = msg.arg1;
+            final int speed = msg.arg2;
+            comm_thread.sendSpeed(whichThrottle, speed);
+            break;
+         }
+         //Change direction. address is in msg, whichThrottle is in arg 1 and arg2 holds the direction to change to.
+         //  message sent is formatted M1AS96<;>R0  was(1R0<;>S96)
+         case message_type.DIRECTION: {
+            final String addr = msg.obj.toString();
+            final int whichThrottle = msg.arg1;
+//            commThread.wifiSend(String.format("M%sA%s<;>R%d", mainapp.throttleIntToString(whichThrottle), addr, msg.arg2));
+            commThread.sendDirection(whichThrottle, addr, msg.arg2);
+            break;
+         }
+         //Set or unset a function. whichThrottle+addr is in the msg, arg1 is the function number, arg2 is set or unset.
+         //  M1AS96<;>F01  was(1F01<;>S96)
+         case message_type.FUNCTION: {
+            String addr = msg.obj.toString();
+            final char cWhichThrottle = addr.charAt(0);
+            addr = addr.substring(1);
+            commThread.sendFunction(cWhichThrottle, addr, msg.arg1, msg.arg2);
+            break;
+         }
+         //Set or unset a function. whichThrottle+addr is in the msg, arg1 is the function number, arg2 is set or unset.
+         case message_type.FORCE_FUNCTION: {
+            String addr = msg.obj.toString();
+            final char cWhichThrottle = addr.charAt(0);
+            addr = addr.substring(1);
+            commThread.sendForceFunction(cWhichThrottle, addr, msg.arg2, msg.arg1);
+            break;
+         }
+         //send command to change turnout.  msg = (T)hrow, (C)lose or (2)(toggle) + systemName
+         case message_type.TURNOUT: {
+            final String cmd = msg.obj.toString();
+//            commThread.wifiSend("PTA" + cmd);
+            commThread.sendTurnout(cmd);
+            break;
+         }
+         //send command to route turnout.  msg = 2(toggle) + systemName
+         case message_type.ROUTE: {
+            final String cmd = msg.obj.toString();
+//            commThread.wifiSend("PRA" + cmd);
+            commThread.sendRoute(cmd);
+            break;
+         }
+         //send command to change power setting, new state is passed in arg1
+         case message_type.POWER_CONTROL:
+//            commThread.wifiSend(String.format("PPA%d", msg.arg1));
+            commThread.sendPower(msg.arg1);
+            break;
+         //send whatever command string comes in obj to Withrottle Server
+         case message_type.WIFI_SEND:
+            comm_thread.wifiSend(msg.obj.toString());
+            break;
+         // Request the throttle's speed and direction. whichThrottle is in arg 1
+         case message_type.WIT_QUERY_SPEED_AND_DIRECTION: {
+            final int whichThrottle = msg.arg1;
+            comm_thread.sendRequestSpeedAndDir(whichThrottle);
+            break;
+         }
+         //send Q to withrottle server
+         case message_type.WIFI_QUIT:
+//            if (commThread.socketWiT != null && commThread.socketWiT.SocketGood())
+//               commThread.wifiSend("Q");
+            commThread.sendQuit();
+            break;
+
+         //send heartbeat start command to withrottle server
+         case message_type.SEND_HEARTBEAT_START:
+//            commThread.heart.setHeartbeatSent(true);
+//            commThread.wifiSend("*+");
+            commThread.sendHeartbeatStart();
+            break;
+
+         //Current Time clock display preference change, sets mainapp.fastClockFormat
+         case message_type.CLOCK_DISPLAY_CHANGED:
+            if (!mainapp.doFinish) {
+               try {
+                  mainapp.fastClockFormat = Integer.parseInt(Objects.requireNonNull(prefs.getString("ClockDisplayTypePreference", "0")));
+               } catch (NumberFormatException e) {
+                  mainapp.fastClockFormat = 0;
+               }
+               mainapp.alert_activities(message_type.TIME_CHANGED, "");
+            }
+            break;
+
+         // SHUTDOWN - terminate socketWiT and it's done
+         case message_type.SHUTDOWN:
+            commThread.shutdown(false);
+            break;
+
+         case message_type.CONNECTION_COMPLETED_CHECK:
+            //if not successfully connected to a 2.0+ server by this time, kill connection
+            if (mainapp.withrottle_version < 2.0) {
+               mainapp.sendMsg(mainapp.comm_msg_handler, message_type.TOAST_MESSAGE,
+                       "timeout waiting for VN message for "
+                               + mainapp.host_ip + ":" + mainapp.port + ", disconnecting");
+               if (comm_thread.socketWiT != null) {
+                  comm_thread.socketWiT.disconnect(true, true);     //just close the socket
+               }
+            }
+            break;
+
+         case message_type.REFRESH_FUNCTIONS:
+         case message_type.ROSTER_UPDATE: // update of roster-related data completed in background
+            if (!mainapp.doFinish) {
+               mainapp.alert_activities(msg.what, "");
+            }
+            break;
+
+         // WiT socket is down and reconnect attempt in prog
+         case message_type.WIT_CON_RETRY:
+            if (!mainapp.doFinish) {
+               mainapp.alert_activities(message_type.WIT_CON_RETRY, msg.obj.toString());
+            }
+            break;
+
+         // WiT socket is back up
+         case message_type.WIT_CON_RECONNECT:
+            if (!mainapp.doFinish) {
+               commThread.sendThrottleName();
+               commThread.reacquireAllConsists();
+               mainapp.alert_activities(message_type.WIT_CON_RECONNECT, msg.obj.toString());
+            }
+            break;
+
+         //send whatever message string comes in obj as a long toast message
+         case message_type.TOAST_MESSAGE:
+            threaded_application.safeToast(msg.obj.toString(), Toast.LENGTH_LONG);
+            break;
+
+         case message_type.KIDS_TIMER_ENABLE:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.KIDS_TIMER_ENABLE, "", 0);
+            break;
+         case message_type.KIDS_TIMER_START:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.KIDS_TIMER_START, "", 0);
+            break;
+         case message_type.KIDS_TIMER_END:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.KIDS_TIMER_END, "", 0);
+            break;
+         case message_type.KIDS_TIMER_TICK:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.KIDS_TIMER_TICK, "", msg.arg1);
+            break;
+         case message_type.IMPORT_SERVER_AUTO_AVAILABLE:
+            Log.d("Engine_Driver", "comm_handler.handleMessage: message: AUTO_IMPORT_URL_AVAILABLE " + msg.what);
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.IMPORT_SERVER_AUTO_AVAILABLE, "", 0);
+            break;
+
+         case message_type.HTTP_SERVER_NAME_RECEIVED:
+            String retrievedServerName = msg.obj.toString();
+            if (mainapp.connectedHostName != null &&
+                    !retrievedServerName.equals(mainapp.connectedHostName) &&
+                    !mainapp.connectedHostName.equals(threaded_application.demo_host)) {
+               mainapp.updateConnectionList(retrievedServerName);
+            }
+            break;
+
+         case message_type.GAMEPAD_ACTION:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.GAMEPAD_ACTION, msg.obj.toString());
+            break;
+         case message_type.GAMEPAD_JOYSTICK_ACTION:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.GAMEPAD_JOYSTICK_ACTION, msg.obj.toString());
+            break;
+
+         case message_type.VOLUME_BUTTON_ACTION:
+            mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.VOLUME_BUTTON_ACTION, msg.obj.toString());
+            break;
+      }
+   }
+}
+

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
@@ -1,3 +1,21 @@
+/*Copyright (C) 2018 M. Steve Todd
+  mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 package jmri.enginedriver.util;
 
 import android.annotation.SuppressLint;
@@ -219,12 +237,12 @@ public class comm_handler extends Handler {
 //                            delays++;
             }
 //                        sendAcquireLoco(addr, whichThrottle, delays * WiThrottle_Msg_Interval);
-            commThread.sendAcquireLoco(addr, whichThrottle, 0);
+            comm_thread.sendAcquireLoco(addr, whichThrottle, 0);
             break;
          }
 
          case message_type.REQUEST_DECODER_ADDRESS: { // DCC-EX only
-            commThread.sendAcquireLoco("*", -1, 0);
+            comm_thread.sendAcquireLoco("*", -1, 0);
             break;
          }
          case message_type.RECEIVED_DECODER_ADDRESS: {
@@ -235,18 +253,18 @@ public class comm_handler extends Handler {
          }
 
          case message_type.DCCEX_SEND_COMMAND: { // DCC-EX only
-            commThread.sendDCCEXcommand(msg.obj.toString());
+            comm_thread.sendDCCEXcommand(msg.obj.toString());
             break;
          }
 
          case message_type.REQUEST_CV: { // DCC-EX only
-            commThread.sendReadCv(msg.arg1);
+            comm_thread.sendReadCv(msg.arg1);
             break;
          }
 
          case message_type.WRITE_CV: { // DCC-EX only
             int cvValue = Integer.decode(msg.obj.toString());
-            commThread.sendWriteCv(cvValue, msg.arg1);
+            comm_thread.sendWriteCv(cvValue, msg.arg1);
             break;
          }
 
@@ -258,7 +276,7 @@ public class comm_handler extends Handler {
          }
 
          case message_type.WRITE_DECODER_ADDRESS: { // DCC-EX only
-            commThread.sendWriteDecoderAddress(msg.arg1);
+            comm_thread.sendWriteDecoderAddress(msg.arg1);
             break;
          }
 
@@ -287,6 +305,7 @@ public class comm_handler extends Handler {
             comm_thread.sendSpeed(whichThrottle, speed);
             break;
          }
+
          //Change direction. address is in msg, whichThrottle is in arg 1 and arg2 holds the direction to change to.
          //  message sent is formatted M1AS96<;>R0  was(1R0<;>S96)
          case message_type.DIRECTION: {

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
@@ -1,3 +1,21 @@
+/*Copyright (C) 2018 M. Steve Todd
+  mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 package jmri.enginedriver.util;
 
 import android.annotation.SuppressLint;
@@ -763,7 +781,7 @@ public class comm_thread extends Thread {
     /* ******************************************************************************************** */
     /* ******************************************************************************************** */
 
-    private static void processWifiResponse(String responseStr) {
+    protected static void processWifiResponse(String responseStr) {
             /* see java/arc/jmri/jmrit/withrottle/deviceserver.java for server code and some documentation
           VN<Version#>
           RL<RosterSize>]<RosterList>
@@ -1406,7 +1424,7 @@ public class comm_thread extends Thread {
 
     //parse roster functions list into appropriate app variable array
     //  //RF29}|{4805(L)]\[Light]\[Bell]\[Horn]\[Air]\[Uncpl]\[BrkRls]\[]\[]\[]\[]\[]\[]\[Engine]\[]\[]\[]\[]\[]\[BellSel]\[HornSel]\[]\[]\[]\[]\[]\[]\[]\[]\[
-    private static void processRosterFunctionString(String responseStr, int whichThrottle) {
+    static void processRosterFunctionString(String responseStr, int whichThrottle) {
 
         Log.d("Engine_Driver", "comm_thread.processRosterFunctionString: processing function labels for " + mainapp.throttleIntToString(whichThrottle));
         String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //split into list of labels
@@ -1428,7 +1446,7 @@ public class comm_thread extends Thread {
 
     //parse roster list into appropriate app variable array
     //  RL2]\[NS2591}|{2591}|{L]\[NS4805}|{4805}|{L
-    private static void processRosterList(String responseStr) {
+    static void processRosterList(String responseStr) {
         //clear the global variable
         mainapp.roster_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
         //todo   RDB why don't we just clear the existing map with roster_entries.clear() instead of disposing and creating a new instance?
@@ -1452,7 +1470,7 @@ public class comm_thread extends Thread {
 
     //parse consist list into appropriate mainapp hashmap
     //RCD}|{88(S)}|{Consist Name]\[2591(L)}|{true]\[3(S)}|{true]\[4805(L)}|{true
-    private static void processConsistList(String responseStr) {
+    static void processConsistList(String responseStr) {
         String consist_addr = null;
         StringBuilder consist_desc = new StringBuilder();
         String consist_name = "";
@@ -1483,11 +1501,11 @@ public class comm_thread extends Thread {
     }
 
     //clear out any stored consists
-    private static void clearConsistList() {
+    static void clearConsistList() {
         if (mainapp.consist_entries!=null) mainapp.consist_entries.clear();
     }
 
-    private static int findTurnoutPos(String systemName) {
+    static int findTurnoutPos(String systemName) {
         int pos = -1;
         for (String sn : mainapp.to_system_names) { //TODO: rewrite for better lookup
             pos++;
@@ -1501,7 +1519,7 @@ public class comm_thread extends Thread {
     //parse turnout change to update mainapp array entry
     //  PTA<NewState><SystemName>
     //  PTA2LT12
-    private static void processTurnoutChange(String responseStr) {
+    static void processTurnoutChange(String responseStr) {
         if (mainapp.to_system_names == null) return;  //ignore if turnouts not defined
         String newState = responseStr.substring(3, 4);
         String systemName = responseStr.substring(4);
@@ -1521,7 +1539,7 @@ public class comm_thread extends Thread {
     //parse turnout list into appropriate app variable array
     //  PTL[<SystemName><UserName><State>repeat] where state 1=Unknown. 2=Closed, 4=Thrown
     //  PTL]\[LT12}|{my12}|{1
-    private static void processTurnoutList(String responseStr) {
+    static void processTurnoutList(String responseStr) {
 
         String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
         //initialize app arrays (skipping first)
@@ -1543,7 +1561,7 @@ public class comm_thread extends Thread {
 
     }
 
-    private static void processTurnoutTitles(String responseStr) {
+    static void processTurnoutTitles(String responseStr) {
         //PTT]\[Turnouts}|{Turnout]\[Closed}|{2]\[Thrown}|{4
 
         //clear the global variable
@@ -1565,7 +1583,7 @@ public class comm_thread extends Thread {
     //parse route list into appropriate app variable array
     //  PRA<NewState><SystemName>
     //  PRA2LT12
-    private static void processRouteChange(String responseStr) {
+    static void processRouteChange(String responseStr) {
         String newState = responseStr.substring(3, 4);
         String systemName = responseStr.substring(4);
         int pos = -1;
@@ -1583,7 +1601,7 @@ public class comm_thread extends Thread {
     //parse route list into appropriate app variable array
     //  PRL[<SystemName><UserName><State>]repeat where state 1=Unknown,2=Active,4=Inactive,8=Inconsistent
     //  PRL]\[LT12}|{my12}|{1
-    private static void processRouteList(String responseStr) {
+    static void processRouteList(String responseStr) {
 
         String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
         //initialize app arrays (skipping first)
@@ -1603,7 +1621,7 @@ public class comm_thread extends Thread {
 
     }
 
-    private static void processRouteTitles(String responseStr) {
+    static void processRouteTitles(String responseStr) {
         //PRT
 
         //clear the global variable
@@ -1622,7 +1640,7 @@ public class comm_thread extends Thread {
     }
 
     //parse function state string into appropriate app variable array
-    private static void processFunctionState(int whichThrottle, Integer fn, boolean fState) {
+    static void processFunctionState(int whichThrottle, Integer fn, boolean fState) {
 
         boolean skip = (fn > 2) && (mainapp.prefAlwaysUseDefaultFunctionLabels)
                 && ((mainapp.prefConsistFollowRuleStyle.equals(threaded_application.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
@@ -2028,7 +2046,7 @@ public class comm_thread extends Thread {
 
         private boolean heartbeatSent = false;
 
-        private int getInboundInterval() {
+        int getInboundInterval() {
             return heartbeatInboundInterval;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
@@ -1,0 +1,2188 @@
+package jmri.enginedriver.util;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.net.NetworkRequest;
+import android.net.wifi.WifiManager;
+import android.os.Build;
+import android.os.Looper;
+import android.os.Message;
+import android.os.SystemClock;
+import android.provider.Settings;
+import android.telephony.PhoneStateListener;
+import android.telephony.TelephonyManager;
+import android.util.Log;
+import android.widget.Toast;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceEvent;
+import javax.jmdns.ServiceInfo;
+import javax.jmdns.ServiceListener;
+
+import jmri.enginedriver.Consist;
+import jmri.enginedriver.R;
+import jmri.enginedriver.message_type;
+import jmri.enginedriver.threaded_application;
+
+public class comm_thread extends Thread {
+    JmDNS jmdns = null;
+    volatile boolean endingJmdns = false;
+    withrottle_listener listener;
+    android.net.wifi.WifiManager.MulticastLock multicast_lock;
+    static socketWifi socketWiT;
+    PhoneListener phone;
+    static heartbeat heart = new heartbeat();
+    private static long lastSentMs = System.currentTimeMillis();
+    private static long lastQueuedMs = System.currentTimeMillis();
+
+    protected static threaded_application mainapp;  // hold pointer to mainapp
+    protected static SharedPreferences prefs;
+
+    protected String LATCHING_DEFAULT;
+
+    private static int requestLocoIdForWhichThrottleDCCEX;
+
+    public comm_thread(threaded_application myApp, SharedPreferences myPrefs) {
+        super("comm_thread");
+
+        mainapp = myApp;
+        prefs = myPrefs;
+
+        mainapp.prefDCCEX = prefs.getBoolean("prefDCCEX", mainapp.getResources().getBoolean(R.bool.prefDCCEXDefaultValue));
+        LATCHING_DEFAULT = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValue); // can change with language
+
+        this.start();
+    }
+
+    /* ******************************************************************************************** */
+
+    //Listen for a WiThrottle service advertisement on the LAN.
+    public class withrottle_listener implements ServiceListener {
+
+        public void serviceAdded(ServiceEvent event) {
+            //          Log.d("Engine_Driver", String.format("comm_thread.serviceAdded fired"));
+            //A service has been added. If no details, ask for them
+            Log.d("Engine_Driver", String.format("comm_thread.serviceAdded for '%s', Type='%s'", event.getName(), event.getType()));
+            ServiceInfo si = jmdns.getServiceInfo(event.getType(), event.getName(), 0);
+            if (si == null || si.getPort() == 0) {
+                Log.d("Engine_Driver", String.format("comm_thread.serviceAdded, requesting details: '%s', Type='%s'", event.getName(), event.getType()));
+                jmdns.requestServiceInfo(event.getType(), event.getName(), true, 1000);
+            }
+        }
+
+        public void serviceRemoved(ServiceEvent event) {
+            //Tell the UI thread to remove from the list of services available.
+            mainapp.sendMsg(mainapp.connection_msg_handler, message_type.SERVICE_REMOVED, event.getName()); //send the service name to be removed
+            Log.d("Engine_Driver", String.format("comm_thread.serviceRemoved: '%s'", event.getName()));
+        }
+
+        public void serviceResolved(ServiceEvent event) {
+            //          Log.d("Engine_Driver", String.format("comm_thread.serviceResolved fired"));
+            //A service's information has been resolved. Send the port and service name to connect to that service.
+            int port = event.getInfo().getPort();
+
+            String serverType = event.getInfo().getPropertyString("jmri") == null ? "" : "JMRI";
+
+            String host_name = event.getInfo().getName(); //
+            Inet4Address[] ip_addresses = event.getInfo().getInet4Addresses();  //only get ipV4 address
+            String ip_address = ip_addresses[0].toString().substring(1);  //use first one, since WiThrottle is only putting one in (for now), and remove leading slash
+
+            //Tell the UI thread to update the list of services available.
+            HashMap<String, String> hm = new HashMap<>();
+            hm.put("ip_address", ip_address);
+            hm.put("port", ((Integer) port).toString());
+            hm.put("host_name", host_name);
+
+            mainapp.knownDCCEXserverIps.put(ip_address, serverType);
+
+            Message service_message = Message.obtain();
+            service_message.what = message_type.SERVICE_RESOLVED;
+            service_message.arg1 = port;
+            service_message.obj = hm;  //send the hashmap as the payload
+            boolean sent = false;
+            try {
+                sent = mainapp.connection_msg_handler.sendMessage(service_message);
+            } catch (Exception ignored) {
+            }
+            if (!sent)
+                service_message.recycle();
+
+            Log.d("Engine_Driver", String.format("comm_thread.serviceResolved - %s(%s):%d -- %s",
+                    host_name, ip_address, port, event.toString().replace(System.getProperty("line.separator"), " ")));
+
+        }
+    }
+
+    void startJmdns() {
+        //Set up to find a WiThrottle service via ZeroConf
+        try {
+            if (mainapp.client_address != null) {
+                WifiManager wifi = (WifiManager) mainapp.getSystemService(Context.WIFI_SERVICE);
+
+                if (multicast_lock == null) {  //do this only as needed
+                    multicast_lock = wifi.createMulticastLock("engine_driver");
+                    multicast_lock.setReferenceCounted(true);
+                }
+
+                Log.d("Engine_Driver", "comm_thread.startJmdns: local IP addr " + mainapp.client_address);
+
+                jmdns = JmDNS.create(mainapp.client_address_inet4, mainapp.client_address);  //pass ip as name to avoid hostname lookup attempt
+
+                listener = new withrottle_listener();
+                Log.d("Engine_Driver", "comm_thread.startJmdns: listener created");
+
+            } else {
+                threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppNoLocalIp), Toast.LENGTH_SHORT);
+            }
+        } catch (Exception except) {
+            Log.e("Engine_Driver", "comm_thread.startJmdns - Error creating withrottle listener: " + except.getMessage());
+            threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppErrorCreatingWiThrottle, except.getMessage()), Toast.LENGTH_SHORT);
+        }
+    }
+
+    //endJmdns() takes a long time, so put it in its own thread
+    void endJmdns() {
+        Thread jmdnsThread = new Thread("EndJmdns") {
+            @Override
+            public void run() {
+                try {
+                    Log.d("Engine_Driver", "comm_thread.endJmdns: removing jmdns listener");
+                    jmdns.removeServiceListener("_withrottle._tcp.local.", listener);
+
+                    multicast_lock.release();
+                } catch (Exception e) {
+                    Log.d("Engine_Driver", "comm_thread.endJmdns: exception in jmdns.removeServiceListener()");
+                }
+                try {
+                    Log.d("Engine_Driver", "comm_thread.endJmdns: calling jmdns.close()");
+                    jmdns.close();
+                    Log.d("Engine_Driver", "comm_thread.endJmdns: after jmdns.close()");
+                } catch (Exception e) {
+                    Log.d("Engine_Driver", "comm_thread.endJmdns: exception in jmdns.close()");
+                }
+                jmdns = null;
+                endingJmdns = false;
+                Log.d("Engine_Driver", "comm_thread.endJmdns run exit");
+            }
+        };
+        if (jmdnsIsActive()) {      //only need to run one instance of this thread to terminate jmdns
+            endingJmdns = true;
+            jmdnsThread.start();
+            Log.d("Engine_Driver", "comm_thread.endJmdns active so ending it and starting thread to remove listener");
+        } else {
+            jmdnsThread = null;
+            Log.d("Engine_Driver", "comm_thread.endJmdns not active");
+        }
+    }
+
+    boolean jmdnsIsActive() {
+        return jmdns != null && !endingJmdns;
+    }
+
+    /*
+      add configuration of digitrax LnWi or DCCEX to discovered list, since they do not provide mDNS
+     */
+    void addFakeDiscoveredServer(String entryName, String clientAddr, String entryPort, String serverType) {
+
+        if (clientAddr == null || clientAddr.lastIndexOf(".") < 0)
+            return; //bail on unexpected value
+
+        //assume that the server is at x.y.z.1
+        String server_addr = clientAddr.substring(0, clientAddr.lastIndexOf("."));
+        server_addr += ".1";
+        HashMap<String, String> hm = new HashMap<>();
+        hm.put("ip_address", server_addr);
+        hm.put("port", entryPort);
+        hm.put("host_name", entryName);
+
+        mainapp.knownDCCEXserverIps.put(server_addr, serverType);
+
+        Message service_message = Message.obtain();
+        service_message.what = message_type.SERVICE_RESOLVED;
+        service_message.arg1 = mainapp.port;
+        service_message.obj = hm;  //send the hashmap as the payload
+        boolean sent = false;
+        try {
+            sent = mainapp.connection_msg_handler.sendMessage(service_message);
+        } catch (Exception ignored) {
+        }
+        if (!sent)
+            service_message.recycle();
+
+        Log.d("Engine_Driver", String.format("comm_thread.addFakeDiscoveredServer: added '%s' at %s to Discovered List", entryName, server_addr));
+
+    }
+
+//        class comm_handler extends Handler {}
+
+    protected void stoppingConnection() {
+        heart.stopHeartbeat();
+        if (phone != null) {
+            phone.disable();
+            phone = null;
+        }
+        endJmdns();
+//            dlMetadataTask.stop();
+        threaded_application.dlRosterTask.stop();
+    }
+
+    protected void shutdown(boolean fast) {
+        Log.d("Engine_Driver", "comm_thread.Shutdown");
+        if (socketWiT != null) {
+            socketWiT.disconnect(true, fast);     //stop reading from the socket
+        }
+        Log.d("Engine_Driver", "comm_thread.Shutdown: socketWit down");
+        mainapp.saveSharedPreferencesToFileIfAllowed();
+        mainapp.host_ip = null;
+        mainapp.port = 0;
+        threaded_application.reinitStatics();                    // ensure activities are ready for relaunch
+        mainapp.doFinish = false;                   //ok for activities to run if restarted after this
+
+        threaded_application.dlRosterTask.stop();
+//            dlMetadataTask.stop();
+
+        // make sure flashlight is switched off at shutdown
+        if (threaded_application.flashlight != null) {
+            threaded_application.flashlight.setFlashlightOff();
+            threaded_application.flashlight.teardown();
+        }
+        mainapp.flashState = false;
+        Log.d("Engine_Driver", "comm_thread.Shutdown finished");
+    }
+
+    /* ******************************************************************************************** */
+    /* ******************************************************************************************** */
+
+    protected void sendThrottleName() {
+        sendThrottleName(true);
+    }
+
+    private static void sendThrottleName(Boolean sendHWID) {
+//        String serverType = mainapp.knownDCCEXserverIps.get(mainapp.host_ip);
+//        if ( (!mainapp.isDCCEX) && (serverType != null) && (!serverType.equals("JMRI")) && (mainapp.prefDCCEX) ) { //assume it is DCC-EX
+//            mainapp.isDCCEX = true;
+//            Log.d("Engine_Driver", "comm_thread.sendThrottleName DCC-EX: Believe this is DCC-EX system ");
+//        }
+        mainapp.isDCCEX = mainapp.prefDCCEX;
+
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            String s = prefs.getString("throttle_name_preference", threaded_application.context.getResources().getString(R.string.prefThrottleNameDefaultValue));
+            wifiSend("N" + s);  //send throttle name
+            if (sendHWID) {
+                if (mainapp.deviceId.equals("")) {
+                    mainapp.deviceId = Settings.System.getString(mainapp.getContentResolver(), Settings.System.ANDROID_ID);
+                }
+                if (mainapp.deviceId.equals("")) {
+                    wifiSend("HU" + s);  //also send throttle name as the UDID
+                } else {
+                    wifiSend("HU" + mainapp.deviceId);
+                }
+            }
+
+        } else { //DCC-EX // name is not relevant, so send a Command Station Status Request
+//            Log.d("Engine_Driver", "comm_thread.sendThrottleName DCC-EX: <s>");
+            if (mainapp.DCCEXlistsRequested < 0) { // if we haven't received all the lists go ask for them
+                wifiSend("<s>");
+                sendRequestRoster();
+                sendRequestTurnouts();
+                sendRequestRoutes();
+                mainapp.DCCEXlistsRequested = 0;  // don't ask again
+            } else {
+                wifiSend("<D CABS>");
+            }
+
+        }
+    }
+
+    /* ask for specific loco to be added to a throttle
+         input addr is formatted "L37<;>CSX37" or "S96" (if no roster name)
+         msgTxt will be formatted M0+L1012<;>EACL1012 or M1+S96<;>S96 */
+    static void sendAcquireLoco(String addr, int whichThrottle, int interval) {
+        String rosterName;
+        String address;
+        String[] as = threaded_application.splitByString(addr, "<;>");
+        if (as.length > 1) {
+            address = as[0];
+            rosterName = "E" + as[1];
+        } else { //if no rostername, just use address for both
+            address = addr;
+            rosterName = addr;
+        }
+
+        String msgTxt;
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            //format multithrottle request for loco M1+L37<;>ECSX37
+            msgTxt = String.format("M%s+%s<;>%s", mainapp.throttleIntToString(whichThrottle), address, rosterName);  //add requested loco to this throttle
+//            Log.d("Engine_Driver", "comm_thread.sendAquireLoco: acquireLoco: addr:'" + addr + "' msgTxt: '" + msgTxt + "'");
+//            sendMsgDelay(comm_msg_handler, interval, message_type.WIFI_SEND, msgTxt);
+            mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WIFI_SEND, msgTxt);
+
+            if (heart.getInboundInterval() > 0 && mainapp.withrottle_version > 0.0 && !heart.isHeartbeatSent()) {
+//                sendMsgDelay(comm_msg_handler, interval + WITHROTTLE_SPACING_INTERVAL, message_type.SEND_HEARTBEAT_START);
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.SEND_HEARTBEAT_START);
+            }
+
+        } else { //DCC-EX
+            if (!address.equals("*")) {
+                msgTxt = String.format("<t 0 %s 0 1>", address.substring(1, address.length()));  //add requested loco to this throttle
+
+                Consist con = mainapp.consists[whichThrottle];
+                con.setConfirmed(address); // don't wait for confirmation
+                con.setWhichSource(address, 1); //entered by address, not roster
+                mainapp.addLocoToRecents(con.getLoco(address));
+                wifiSend(msgTxt);
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WIFI_SEND, msgTxt);
+
+                String lead = mainapp.consists[whichThrottle].getLeadAddr();
+                if (lead.equals(address)) {
+                    sendRequestRosterLocoDetails(address); // get the CS to resend the Loco details so we can get the functions
+                }
+
+                if (heart.getInboundInterval() > 0 && mainapp.withrottle_version > 0.0 && !heart.isHeartbeatSent()) {
+                    mainapp.sendMsg(mainapp.comm_msg_handler, message_type.SEND_HEARTBEAT_START);
+                }
+                mainapp.sendMsgDelay(mainapp.comm_msg_handler, 1000L, message_type.REFRESH_FUNCTIONS);
+            } else { // requesting the loco id on the programming track.  Using the DCC-EX driveway feature
+                requestLocoIdForWhichThrottleDCCEX = whichThrottle;
+                wifiSend("<R>");
+            }
+
+//            Log.d("Engine_Driver", "comm_thread.sendAcquireLoco DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected static void sendRequestRosterLocoDetails(String addr) {
+        if (mainapp.isDCCEX) { // only relevant to DCC-EX
+            wifiSend("<JR " + addr.substring(1) + ">");
+        }
+    }
+
+
+    /* "steal" will send the MTS command */
+    protected void sendStealLoco(String addr, int whichThrottle) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            if (addr != null) {
+                String msgtxt = String.format("M%sS%s<;>%s", mainapp.throttleIntToString(whichThrottle), addr, addr);
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WIFI_SEND, msgtxt);
+            }
+        } // not relevant to DCC-EX
+    }
+
+    //release all locos for throttle using '*', or a single loco using address
+    protected void sendReleaseLoco(String addr, int whichThrottle, long interval) {
+        String msgTxt = "";
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            msgTxt = String.format("M%s-%s<;>r", mainapp.throttleIntToString(whichThrottle), (!addr.equals("") ? addr : "*"));
+            mainapp.sendMsgDelay(mainapp.comm_msg_handler, interval, message_type.WIFI_SEND, msgTxt);
+
+        } else { // DCC-EX
+            if ((addr.length() == 0) || (addr.equals("*"))) { // release all on the throttle
+                if (mainapp.throttleLocoReleaseListDCCEX[whichThrottle] != null) {
+                    for (String addrStr : mainapp.throttleLocoReleaseListDCCEX[whichThrottle]) {
+                        msgTxt = String.format("<- %s>", addrStr.substring(1));
+                        wifiSend(msgTxt);
+                        //                    Log.d("Engine_Driver", "comm_thread.sendSpeed DCC-EX: " + msgTxt);
+                    }
+                }
+            } else {
+                msgTxt = String.format("<- %s>", mainapp.throttleIntToString(whichThrottle));
+                wifiSend(msgTxt);
+            }
+
+//            Log.d("Engine_Driver", "comm_thread.sendReleaseLoco DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected void reacquireAllConsists() {
+        for (int i = 0; i < mainapp.maxThrottlesCurrentScreen; i++)
+            reacquireConsist(mainapp.consists[i], i);
+    }
+
+    private void reacquireConsist(Consist c, int whichThrottle) {
+        int delays = 0;
+        for (Consist.ConLoco l : c.getLocos()) { // reacquire each confirmed loco in the consist
+            if (l.isConfirmed()) {
+                String addr = l.getAddress();
+                String roster_name = l.getRosterName();
+                if (roster_name != null)  // add roster selection info if present
+                    addr += "<;>" + roster_name;
+//                    sendAcquireLoco(addr, whichThrottle, delays * WITHROTTLE_SPACING_INTERVAL); //ask for next loco, with 0 or more delays
+                sendAcquireLoco(addr, whichThrottle, 0); //ask for next loco, with 0 or more delays
+                delays++;
+            }
+        }
+    }
+
+    protected void sendEStop(int whichThrottle) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend(String.format("M%sA*<;>X", mainapp.throttleIntToString(whichThrottle)));  //send eStop request
+
+        } else { //DCC-EX
+            wifiSend("<!>");
+//            Log.d("Engine_Driver", "comm_thread.sendEStop DCC-EX: ");
+        }
+    }
+
+    protected void sendDisconnect() {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend("Q");
+            shutdown(true);
+
+        } else { //  DCC-EX   no equivalent to a "Q" so just drop all the locos to be tidy
+            Consist con = null;
+            if (mainapp.consists.length > 0) {
+                for (int i = 0; i < mainapp.consists.length; i++) {
+                    con = mainapp.consists[i];
+                    for (Consist.ConLoco l : con.getLocos()) {
+                        sendReleaseLoco(l.getAddress(), i, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    protected void sendFunction(char cWhichThrottle, String addr, int fn, int fState) {
+        sendFunction(mainapp.throttleCharToInt(cWhichThrottle), addr, fn, fState);
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected void sendFunction(int whichThrottle, String addr, int fn, int fState) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            if (addr.length() == 0) addr = "*";
+            wifiSend(String.format("M%dA%s<;>F%d%d", whichThrottle, addr, fState, fn));
+
+        } else { //DCC-EX
+            String msgTxt = "";
+
+            String isLatching = mainapp.function_consist_latching.get(fn);
+            int newfState = -1;
+
+            if (mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle] != null) {  //  we have a roster specific latching for this
+                if (fn < mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle].length) {
+                    isLatching = mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle][fn] ? LATCHING_DEFAULT : "none";
+                }
+            }
+
+            if ((isLatching != null) && (isLatching.equals(LATCHING_DEFAULT))) {
+                if (mainapp.function_states[whichThrottle][fn]) { // currently pressed
+                    if (fState == 1) newfState = 0;
+                } else { // not currently pressed
+                    if (fState == 1) newfState = 1;
+                }
+            } else {
+                newfState = fState;
+            }
+
+            if (newfState >= 0) {
+                if ((addr.length() == 0) || (addr.equals("*"))) { // all on the throttle
+                    Consist con = mainapp.consists[whichThrottle];
+                    for (Consist.ConLoco l : con.getLocos()) {
+                        msgTxt = String.format("<F %s %d %d>", l.getAddress().substring(1, l.getAddress().length()), fn, newfState);
+                        wifiSend(msgTxt);
+//                        Log.d("Engine_Driver", "comm_thread.sendSpeed DCC-EX: " + msgTxt);
+                    }
+                } else { // just one address
+                    msgTxt = String.format("<F %s %d %d>", addr.substring(1, addr.length()), fn, newfState);
+                    wifiSend(msgTxt);
+//                    Log.d("Engine_Driver", "comm_thread.sendFunction DCC-EX: " + msgTxt);
+                }
+            }
+        }
+    }
+
+    protected void sendForceFunction(char cWhichThrottle, String addr, int fn, int fState) {
+        sendForceFunction(mainapp.throttleCharToInt(cWhichThrottle), addr, fn, fState);
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected void sendForceFunction(int whichThrottle, String addr, int fn, int fState) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            if (addr.length() == 0) addr = "*";
+            wifiSend(String.format("M%dA%s<;>F%d%d", whichThrottle, addr, fn, fState));
+
+        } else { //DCC-EX
+            sendFunction(whichThrottle, addr, fn, fState);
+        }
+    }
+
+    protected static void sendRequestRoster() {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = "<JR>";
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendRequestRoster DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected static void sendRequestTurnouts() {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = "<JT>";
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendRequestTurnouts DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected static void sendRequestRoutes() {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = "<JA>";
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendRequestRoutes DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected void sendTurnout(String cmd) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend("PTA" + cmd);
+
+        } else { //DCC-EX
+            String systemName = cmd.substring(1);
+            String translatedState = "T";
+            switch (cmd.charAt(0)) {
+                case 'C':
+                    translatedState = "C";
+                case '2': { // toggle
+                    int pos = findTurnoutPos(systemName);
+                    if (pos >= 0) {
+                        if (mainapp.to_states[pos].equals("4")) {
+                            translatedState = "C";
+                        }
+                    }
+                }
+            }
+            String msgTxt = "<T " + cmd.substring(1) + " " + translatedState + ">";              // format <T id 0|1|T|C>
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendTurnout DCC-EX: " + msgTxt);
+        }
+    }
+
+    protected void sendRoute(String cmd) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend("PRA" + cmd);
+
+        } else { //DCC-EX    Route: </START id>      Automation: </START id addr>
+            String systemName = cmd.substring(1);
+            String msgTxt = "</START " + systemName + ">";
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendRoute DCC-EX: " + msgTxt);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected void sendPower(int pState) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend(String.format("PPA%d", pState));
+
+        } else { //DCC-EX
+            String msgTxt = String.format("<%d>", pState);
+            wifiSend(msgTxt);
+//            Log.d("Engine_Driver", "comm_thread.sendPower DCC-EX: " + msgTxt);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected static void sendJoinDCCEX() {
+        if (mainapp.isDCCEX) { // DCC-EX
+            wifiSend("<1 JOIN>");
+        }
+    }
+
+    protected void sendQuit() {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            if (socketWiT != null && socketWiT.SocketGood())
+                wifiSend("Q");
+        } /// N/A for DCC-EX
+    }
+
+    protected void sendHeartbeatStart() {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            if (socketWiT != null && socketWiT.SocketGood())
+                heart.setHeartbeatSent(true);
+            wifiSend("*+");
+
+        } else { //DCC-EX
+            heart.setHeartbeatSent(true);
+            wifiSend("<D CABS>"); // DCC-EX doesn't have heartbeat, so sending a command with a simple response
+//            Log.d("Engine_Driver", "comm_thread.sendHeartbeatStart DCC-EX: <D CABS>)");
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected void sendDirection(int whichThrottle, String addr, int dir) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend(String.format("M%sA%s<;>R%d", mainapp.throttleIntToString(whichThrottle), addr, dir));
+
+        } else { //DCC-EX
+            String msgTxt = "";
+            if ((addr.length() == 0) || (addr.equals("*"))) { // all on the throttle
+                Consist con = mainapp.consists[whichThrottle];
+                msgTxt = "";
+                for (Consist.ConLoco l : con.getLocos()) {
+                    int newDir = dir;
+                    if (l.isBackward()) newDir = (dir == 0) ? 1 : 0;
+                    msgTxt = String.format("<t 0 %s %d %d>", l.getAddress().substring(1, l.getAddress().length()), mainapp.lastKnownSpeedDCCEX[whichThrottle], newDir);
+                    wifiSend(msgTxt);
+                    mainapp.lastKnownDirDCCEX[whichThrottle] = newDir;
+//                    Log.d("Engine_Driver", "comm_thread.sendSpeed DCC-EX: " + msgTxt);
+                }
+            } else {
+                msgTxt = String.format("<t 0 %s %d %d>", addr.substring(1, addr.length()), mainapp.lastKnownSpeedDCCEX[whichThrottle], dir);
+                wifiSend(msgTxt);
+                mainapp.lastKnownDirDCCEX[whichThrottle] = dir;
+//                Log.d("Engine_Driver", "comm_thread.sendDirection DCC-EX: " + msgTxt);
+            }
+        }
+    }
+
+    protected static void sendSpeedZero(int whichThrottle) {
+        sendSpeed(whichThrottle, 0);
+    }
+
+    @SuppressLint("DefaultLocale")
+    protected static void sendSpeed(int whichThrottle, int speed) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend(String.format("M%sA*<;>V%d", mainapp.throttleIntToString(whichThrottle), speed));
+
+        } else { //DCC-EX
+            Consist con = mainapp.consists[whichThrottle];
+            String msgTxt = "";
+            for (Consist.ConLoco l : con.getLocos()) {
+                int dir = mainapp.lastKnownDirDCCEX[whichThrottle];
+                int newDir = dir;
+                if (l.isBackward()) newDir = (dir == 0) ? 1 : 0;
+                msgTxt = String.format("<t 0 %s %d %d>", l.getAddress().substring(1, l.getAddress().length()), speed, newDir);
+                wifiSend(msgTxt);
+//                Log.d("Engine_Driver", "comm_thread.sendSpeed DCC-EX: " + msgTxt);
+            }
+        }
+    }
+
+//    @SuppressLint("DefaultLocale")
+//    private void sendRequestSpeed(int whichThrottle) {
+//        if (!mainapp.isDCCEX) { // not DCC-EX
+//            wifiSend(String.format("M%sA*<;>qV",
+//                mainapp.throttleIntToString(whichThrottle)));
+//
+//        } else { //DCC-EX
+//            Consist con = mainapp.consists[whichThrottle];
+//            String msgTxt = "";
+//            for (Consist.ConLoco l : con.getLocos()) {
+//                msgTxt = String.format("<t %s>", l.getAddress().substring(1,l.getAddress().length()));
+//                wifiSend(msgTxt);
+////                Log.d("Engine_Driver", "comm_thread.sendRequestSpeed DCC-EX: " + msgTxt);
+//            }
+//        }
+//    }
+//
+//    @SuppressLint("DefaultLocale")
+//    private void sendRequestDir(int whichThrottle) {
+//        if (!mainapp.isDCCEX) { // not DCC-EX
+//            wifiSend(String.format("M%sA*<;>qR",
+//                    mainapp.throttleIntToString(whichThrottle)));
+//
+//        } else { //DCC-EX
+//            Consist con = mainapp.consists[whichThrottle];
+//            String msgTxt = "";
+//            for (Consist.ConLoco l : con.getLocos()) {
+//                msgTxt = String.format("<t %s>", l.getAddress().substring(1,l.getAddress().length()));
+//                wifiSend(msgTxt);
+////                Log.d("Engine_Driver", "comm_thread.sendRequestDir DCC-EX: " + msgTxt);
+//            }
+//        }
+//    }
+
+    @SuppressLint("DefaultLocale")
+    protected static void sendRequestSpeedAndDir(int whichThrottle) {
+        if (!mainapp.isDCCEX) { // not DCC-EX
+            wifiSend(String.format("M%sA*<;>qV\nM%sA*<;>qR",
+                    mainapp.throttleIntToString(whichThrottle), mainapp.throttleIntToString(whichThrottle)));
+
+        } else { //DCC-EX
+            Consist con = mainapp.consists[whichThrottle];
+            String msgTxt = "";
+            for (Consist.ConLoco l : con.getLocos()) {
+                msgTxt = String.format("<t %s>", l.getAddress().substring(1, l.getAddress().length()));
+                wifiSend(msgTxt);
+//                Log.d("Engine_Driver", "comm_thread.sendRequestSpeedAndDir DCC-EX: " + msgTxt);
+            }
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    public static void sendWriteDecoderAddress(int addr) {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = String.format("<W %s>", addr);
+            wifiSend(msgTxt);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    public static void sendReadCv(int cv) {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = String.format("<R %d>", cv);
+            wifiSend(msgTxt);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    public static void sendWriteCv(int cvValue, int cv) {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            String msgTxt = String.format("<W %d %d>", cv, cvValue);
+            wifiSend(msgTxt);
+        }
+    }
+
+    @SuppressLint("DefaultLocale")
+    public static void sendDCCEXcommand(String cmdStr) {
+        if (mainapp.isDCCEX) { // DCC-EX only
+            wifiSend(cmdStr);
+        }
+    }
+
+
+    /* ******************************************************************************************** */
+    /* ******************************************************************************************** */
+
+    private static void processWifiResponse(String responseStr) {
+            /* see java/arc/jmri/jmrit/withrottle/deviceserver.java for server code and some documentation
+          VN<Version#>
+          RL<RosterSize>]<RosterList>
+          RF<RosterFunctionList>
+          RS<2ndRosterFunctionList>
+          *<HeartbeatIntervalInSeconds>
+          PTL[<SystemTurnoutName><UserName><State>repeat] where state 1=Unknown. 2=Closed, 4=Thrown
+          PTA<NewTurnoutState><SystemName>
+          PPA<NewPowerState> where state 0=off, 1=on, 2=unknown
+          M<throttleid> multi-throttle command
+          TODO: add remaining items, or move examples into code below
+             */
+
+        //send response to debug log for review
+        Log.d("Engine_Driver", "comm_thread.processWifiResponse: " + (mainapp.isDCCEX ? "DCC-EX" : "") + "<--:" + responseStr);
+
+        boolean skipAlert = false;          //set to true if the Activities do not need to be Alerted
+
+        if (!mainapp.isDCCEX) { // not DCC-EX
+
+            switch (responseStr.charAt(0)) {
+
+                case 'M': { //handle responses from MultiThrottle function
+                    if (responseStr.length() < 5) { //must be at least Mtxs9
+                        Log.d("Engine_Driver", "comm_thread.processWifiResponse: invalid response string: '" + responseStr + "'");
+                        break;
+                    }
+                    String sWhichThrottle = responseStr.substring(1, 2);
+                    int whichThrottle = mainapp.throttleCharToInt(sWhichThrottle.charAt(0));
+                    String[] ls = threaded_application.splitByString(responseStr, "<;>");    //drop off separator
+                    String addr = ls[0].substring(3);
+                    char com2 = responseStr.charAt(2);
+                    //loco was successfully added to a throttle
+                    if (com2 == '+') {  //"MT+L2591<;>"  loco was added
+                        Consist con = mainapp.consists[whichThrottle];
+                        if (con.getLoco(addr) != null) { //loco was added to consist in select_loco
+                            con.setConfirmed(addr);
+                            mainapp.addLocoToRecents(con.getLoco(addr));
+                        } else if (con.isWaitingOnID()) { //we were waiting for this response to get address
+                            Consist.ConLoco conLoco = new Consist.ConLoco(addr);
+                            conLoco.setFunctionLabelDefaults(mainapp, whichThrottle);
+                            //look for RosterEntry which matches address returned
+                            String rn = mainapp.getRosterNameFromAddress(conLoco.getFormatAddress(), true);
+                            if (!rn.equals("")) {
+                                conLoco.setIsFromRoster(true);
+                                conLoco.setRosterName(rn);
+                            }
+                            con.add(conLoco);
+                            con.setWhichSource(addr, 1); //entered by address, not roster
+                            con.setConfirmed(addr);
+//                            addLocoToRecents(con.getLoco(addr));
+                            mainapp.addLocoToRecents(conLoco);
+                            Log.d("Engine_Driver", "comm_thread.processWifiResponse: loco '" + addr + "' ID'ed on programming track and added to " + whichThrottle);
+                        } else {
+                            Log.d("Engine_Driver", "comm_thread.processWifiResponse: loco '" + addr + "' not selected but assigned by server to " + whichThrottle);
+                        }
+
+                        String consistname = mainapp.getConsistNameFromAddress(addr); //check for a JMRI consist for this address,
+                        if (consistname != null) { //if found, request function keys for lead, format MTAS13<;>CL1234
+                            String[] cna = threaded_application.splitByString(consistname, "+");
+                            String cmd = String.format("M%sA%s<;>C%s", mainapp.throttleIntToString(whichThrottle), addr, mainapp.cvtToLAddr(cna[0]));
+                            Log.d("Engine_Driver", "comm_thread.processWifiResponse: rqsting fkeys for lead loco " + mainapp.cvtToLAddr(cna[0]));
+                            wifiSend(cmd);
+                        }
+
+                    } else if (com2 == '-') { //"MS-L6318<;>"  loco removed from throttle
+                        mainapp.consists[whichThrottle].remove(addr);
+                        Log.d("Engine_Driver", "comm_thread.processWifiResponse: loco " + addr + " dropped from " + mainapp.throttleIntToString(whichThrottle));
+
+                    } else if (com2 == 'L') { //list of function buttons
+                        if (mainapp.consists[whichThrottle].isLeadFromRoster()) { // if not from the roster ignore the function labels that WiT has sent back
+                            String lead;
+                            lead = mainapp.consists[whichThrottle].getLeadAddr();
+                            if (lead.equals(addr))                        //*** temp - only process if for lead engine in consist
+                                processRosterFunctionString("RF29}|{1234(L)" + ls[1], whichThrottle);  //prepend some stuff to match old-style
+                            mainapp.consists[whichThrottle].setFunctionLabels(addr, "RF29}|{1234(L)" + ls[1], mainapp);
+                        }
+
+                    } else if (com2 == 'A') { //process change in function value  MTAL4805<;>F028
+                        if (ls.length == 2 && "F".equals(ls[1].substring(0, 1))) {
+                            try {
+                                processFunctionState(whichThrottle, Integer.valueOf(ls[1].substring(2)), "1".equals(ls[1].substring(1, 2)));
+                            } catch (NumberFormatException | StringIndexOutOfBoundsException ignore) {
+                                Log.d("Engine_Driver", "comm_thread.processWifiResponse: bad incoming message data, unable to parse '" + responseStr + "'");
+                            }
+                        }
+
+                    } else if (com2 == 'S') { //"MTSL4425<;>L4425" loco is in use, prompt for Steal
+                        Log.d("Engine_Driver", "comm_thread.processWifiResponse: rcvd MTS, request prompt for " + addr + " on " + mainapp.throttleIntToString(whichThrottle));
+                        mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.REQ_STEAL, addr, whichThrottle);
+                    }
+
+                    break;
+                }
+                case 'V': // WiThrottle Protocol Version
+                    if (responseStr.startsWith("VN")) {
+                        Double old_vn = mainapp.withrottle_version;
+                        try {
+                            mainapp.withrottle_version = Double.parseDouble(responseStr.substring(2));
+                        } catch (Exception e) {
+                            Log.e("Engine_Driver", "comm_thread.processWifiResponse: invalid WiT version string");
+                            mainapp.withrottle_version = 0.0;
+                            break;
+                        }
+                        //only move on to Throttle screen if version received is 2.0+
+                        if (mainapp.withrottle_version >= 2.0) {
+                            if (!mainapp.withrottle_version.equals(old_vn)) { //only if changed
+                                mainapp.sendMsg(mainapp.connection_msg_handler, message_type.CONNECTED);
+                            } else {
+                                Log.d("Engine_Driver", "comm_thread.processWifiResponse: version already set to " + mainapp.withrottle_version + ", ignoring");
+                            }
+                        } else {
+                            threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppWiThrottleNotSupported, responseStr.substring(2)), Toast.LENGTH_SHORT);
+                            socketWiT.disconnect(false);
+                        }
+                    } else {
+                        Log.e("Engine_Driver", "comm_thread.processWifiResponse: invalid WiT version string");
+                    }
+                    break;
+
+                case 'H': // Alert and Info Message
+                    if (responseStr.charAt(1) == 'T') { //set hardware server type, HTMRC for example
+                        mainapp.setServerType(responseStr.substring(2)); //store the type
+                    } else if (responseStr.charAt(1) == 't') { //server description string "HtMy Server Details go here"
+                        mainapp.setServerDescription(responseStr.substring(2)); //store the description
+                    } else if (responseStr.charAt(1) == 'M') { //alert message sent from server to throttle
+                        threaded_application.safeToast(responseStr.substring(2), Toast.LENGTH_LONG); // copy to UI as toast message
+                        //see if it is a turnout fail
+                        if ((responseStr.contains("Turnout")) || (responseStr.contains("create not allowed"))) {
+                            Pattern pattern = Pattern.compile(".*'(.*)'.*");
+                            Matcher matcher = pattern.matcher(responseStr);
+                            if (matcher.find()) {
+                                mainapp.sendMsg(mainapp.turnouts_msg_handler, message_type.WIT_TURNOUT_NOT_DEFINED, matcher.group(1));
+                            }
+                        }
+
+                    } else if (responseStr.charAt(1) == 'm') { //info message sent from server to throttle
+                        threaded_application.safeToast(responseStr.substring(2), Toast.LENGTH_SHORT); // copy to UI as toast message
+                    }
+                    break;
+
+                case '*': // heartbeat
+                    try {
+                        mainapp.heartbeatInterval = Integer.parseInt(responseStr.substring(1)) * 1000;  //convert to milliseconds
+                    } catch (Exception e) {
+                        Log.d("Engine_Driver", "comm_thread.processWifiResponse: invalid WiT hearbeat string");
+                        mainapp.heartbeatInterval = 0;
+                    }
+                    heart.startHeartbeat(mainapp.heartbeatInterval);
+                    break;
+
+                case 'R': // Roster
+                    switch (responseStr.charAt(1)) {
+
+                        case 'C':
+                            if (responseStr.charAt(2) == 'C' || responseStr.charAt(2) == 'L') {  //RCC1 or RCL1 (treated the same in ED)
+                                clearConsistList();
+                            } else if (responseStr.charAt(2) == 'D') {  //RCD}|{88(S)}|{Consist Name]\[2591(L)}|{true]\[3(S)}|{true]\[4805(L)}|{true
+                                processConsistList(responseStr);
+                            }
+                            break;
+
+                        case 'L':
+                            //                  roster_list_string = responseStr.substring(2);  //set app variable
+                            processRosterList(responseStr);  //process roster list
+                            break;
+
+                        case 'F':   //RF29}|{2591(L)]\[Light]\[Bell]\[Horn]\[Air]\[Uncpl]\[BrkRls]\[]\[]\[]\[]\[]\[]\[Engine]\[]\[]\[]\[]\[]\[BellSel]\[HornSel]\[]\[]\[]\[]\[]\[]\[]\[]\[
+                            processRosterFunctionString(responseStr.substring(2), 0);
+                            break;
+
+                        case 'S': //RS29}|{4805(L)]\[Light]\[Bell]\[Horn]\[Air]\[Uncpl]\[BrkRls]\[]\[]\[]\[]\[]\[]\[Engine]\[]\[]\[]\[]\[]\[BellSel]\[HornSel]\[]\[]\[]\[]\[]\[]\[]\[]\[
+                            processRosterFunctionString(responseStr.substring(2), 1);
+                            break;
+
+                    }  //end switch inside R
+                    break;
+                case 'P': //Panel
+                    switch (responseStr.charAt(1)) {
+                        case 'T': //turnouts
+                            if (responseStr.charAt(2) == 'T') {  //turnout control allowed
+                                processTurnoutTitles(responseStr);
+                            }
+                            if (responseStr.charAt(2) == 'L') {  //list of turnouts
+                                processTurnoutList(responseStr);  //process turnout list
+                            }
+                            if (responseStr.charAt(2) == 'A') {  //action?  changes to turnouts
+                                processTurnoutChange(responseStr);  //process turnout changes
+                            }
+                            break;
+
+                        case 'R':  //routes
+                            if (responseStr.charAt(2) == 'T') {  //route  control allowed
+                                processRouteTitles(responseStr);
+                            }
+                            if (responseStr.charAt(2) == 'L') {  //list of routes
+                                processRouteList(responseStr);  //process route list
+                            }
+                            if (responseStr.charAt(2) == 'A') {  //action?  changes to routes
+                                processRouteChange(responseStr);  //process route changes
+                            }
+                            break;
+
+                        case 'P':  //power
+                            if (responseStr.charAt(2) == 'A') {  //change power state
+                                String oldState = mainapp.power_state;
+                                mainapp.power_state = responseStr.substring(3);
+                                if (mainapp.power_state.equals(oldState)) {
+                                    skipAlert = true;
+                                }
+                            }
+                            break;
+
+                        case 'F':  //FastClock message: PFT1581530521<;>2.0
+                            //extracts and sets shared fastClockSeconds
+                            if (responseStr.startsWith("PFT")) {
+                                mainapp.fastClockSeconds = 0L;
+                                String[] ta = threaded_application.splitByString(responseStr.substring(3), "<;>"); //get the number between "PFT" and the "<;>"
+                                try {
+                                    mainapp.fastClockSeconds = Long.parseLong(ta[0]);
+                                } catch (NumberFormatException e) {
+                                    Log.w("Engine_Driver", "unable to extract fastClockSeconds from '" + responseStr + "'");
+                                }
+                                mainapp.alert_activities(message_type.TIME_CHANGED, "");     //tell activities the time has changed
+                            }
+                            break;
+
+                        case 'W':  //Web Server port
+                            int oldPort = mainapp.web_server_port;
+                            try {
+                                mainapp.web_server_port = Integer.parseInt(responseStr.substring(2));  //set app variable
+                            } catch (Exception e) {
+                                Log.d("Engine_Driver", "comm_thread.processWifiResponse: invalid web server port string");
+                            }
+                            if (oldPort == mainapp.web_server_port) {
+                                skipAlert = true;
+                            } else {
+//                                dlMetadataTask.get();           // start background metadata update
+                                threaded_application.dlRosterTask.get();             // start background roster update
+
+                            }
+                            mainapp.webServerNameHasBeenChecked = false;
+                            break;
+                    }  //end switch inside P
+                    break;
+            }  //end switch
+
+            /* ***********************************  *********************************** */
+
+        } else { // DCC-EX
+            if (responseStr.length() >= 3) {
+                if (responseStr.charAt(0) == '<') {
+                    if (mainapp.DCCEXscreenIsOpen) {
+                        mainapp.alert_activities(message_type.DCCEX_RESPONSE, responseStr);
+                    }
+
+
+                    String[] args = responseStr.substring(1, responseStr.length() - 1).split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", 999);
+
+                    switch (responseStr.charAt(1)) {
+                        case 'i': // Command Station Information
+                            String old_vn = mainapp.DCCEXversion;
+                            mainapp.DCCEXversion = responseStr;
+                            if (!mainapp.DCCEXversion.equals(old_vn)) { //only if changed
+                                mainapp.sendMsg(mainapp.connection_msg_handler, message_type.CONNECTED);
+                            } else {
+                                Log.d("Engine_Driver", "comm_thread.processWifiResponse: version already set to " + mainapp.DCCEXversion + ", ignoring");
+                            }
+
+                            mainapp.withrottle_version = 4.0;  // fudge it
+                            mainapp.setServerType("DCC-EX");
+                            mainapp.setServerDescription(responseStr.substring(3, responseStr.length() - 1)); //store the description
+
+                            skipAlert = true;
+                            mainapp.heartbeatInterval = 20000; // force a heartbeat period
+                            heart.startHeartbeat(mainapp.heartbeatInterval);
+                            mainapp.power_state = "2"; // unknown
+                            break;
+
+                        case 'l':
+                            processDCCEXlocos(args);
+                            skipAlert = true;
+                            break;
+
+                        case 'r':
+                            if (args.length<=2) { // response from a request for a loco id (the Drive away feature, and also the Address read)
+                                processDCCEXRequestLocoIdResponse(args);
+                            } else { // response from a CV write
+                                processDCCEXRequestCvResponse(args);
+                            }
+                            skipAlert = true;
+                            break;
+
+                        case 'p': // power response
+                            mainapp.power_state = responseStr.substring(2, 3);
+                            responseStr = "PPA" + responseStr.charAt(2);
+                            break;
+
+                        case 'j': //roster, turnouts / routes lists
+                            skipAlert = true;
+                            switch (responseStr.charAt(2)) {
+                                case 'T': // turnouts
+                                    processDCCEXturnouts(args);
+                                    break;
+                                case 'A': // automations/routes
+                                    processDCCEXroutes(args);
+                                    break;
+                                case 'R': // roster
+                                    skipAlert = processDCCEXroster(args);
+                                    break;
+                            }
+                            break;
+
+                        case 'H': //Turnout change
+                            responseStr = "PTA" + (((args[2].equals("T")) || (args[2].equals("1"))) ? 4 : 2) + args[1];
+                            processTurnoutChange(responseStr);
+                            break;
+
+                        case 'v': // response from a request a CV value
+                            processDCCEXRequestCvResponse(args);
+                            skipAlert = true;
+                            break;
+
+                        case 'w': // response from an address write or other CV write
+                            responseStr = args[1];
+                            if (!args[1].equals("-1")) {
+                                mainapp.alert_activities(message_type.WRITE_DECODER_SUCCESS, responseStr);
+                            } else {
+                                mainapp.alert_activities(message_type.WRITE_DECODER_FAIL, responseStr);
+                            }
+
+                    }
+
+                } else { // ignore responses that don't start with "<"
+                    skipAlert = true;
+                }
+            } else {
+                skipAlert = true;
+            }
+        }
+        if (!skipAlert) {
+            mainapp.alert_activities(message_type.RESPONSE, responseStr);  //send response to running activities
+        }
+    }  //end of processWifiResponse
+
+    /* ***********************************  *********************************** */
+
+    private static void processDCCEXRequestCvResponse(String [] args) {
+        String cv = "";
+        String cvValue = "-1";
+
+        if (args.length==3) {
+            cv = args[1];
+            cvValue = args[2];
+        }
+
+        mainapp.alert_activities(message_type.RECEIVED_CV, cv + "|" + cvValue);  //send response to running activities
+    }
+
+    private static void processDCCEXRequestLocoIdResponse(String [] args) {
+        String responseStr = "";
+
+        if (requestLocoIdForWhichThrottleDCCEX!=-1) { // if -1, request came from the CV read/write screen
+            if (!args[1].equals("-1")) {
+                String addrStr = args[1];
+                if (Integer.parseInt(args[1]) <= 127) {
+                    addrStr = "S" + addrStr;
+                } else {
+                    addrStr = "L" + addrStr;
+                }
+                Consist con = mainapp.consists[requestLocoIdForWhichThrottleDCCEX];
+                if (con.isWaitingOnID()) { //we were waiting for this response to get address
+                    Consist.ConLoco conLoco = new Consist.ConLoco(addrStr);
+                    conLoco.setFunctionLabelDefaults(mainapp, requestLocoIdForWhichThrottleDCCEX);
+                    //look for RosterEntry which matches address returned
+                    String rn = mainapp.getRosterNameFromAddress(conLoco.getFormatAddress(), true);
+                    if (!rn.equals("")) {
+                        conLoco.setIsFromRoster(true);
+                        conLoco.setRosterName(rn);
+                    }
+                    con.add(conLoco);
+                    con.setWhichSource(addrStr, 1); //entered by address, not roster
+                    con.setConfirmed(addrStr);
+    //                            addLocoToRecents(con.getLoco(addr));
+                    mainapp.addLocoToRecents(conLoco);
+
+                    sendAcquireLoco(addrStr, requestLocoIdForWhichThrottleDCCEX, 0);
+                    sendJoinDCCEX();
+                } else {
+                    mainapp.alert_activities(message_type.RECEIVED_DECODER_ADDRESS, args[1]);  //send response to running activities
+                }
+            } // else {} did not succeed
+
+        } else {
+            mainapp.alert_activities(message_type.RECEIVED_DECODER_ADDRESS, args[1]);  //send response to running activities
+        }
+
+    }
+
+    private static void processDCCEXlocos(String [] args) {
+        String responseStr="";
+        
+        int dir = 0;
+        int speed = Integer.parseInt(args[3]);
+        if (speed >= 128) {
+            speed = speed - 128;
+            dir = 1;
+        }
+
+        String addr_str = args[1];
+        if (Integer.parseInt(args[1]) <= 127) {
+            addr_str = "S" + addr_str;
+        } else {
+            addr_str = "L" + addr_str;
+        }
+        int whichThrottle = mainapp.getWhichThrottleFromAddress(addr_str);
+        if (whichThrottle >= 0) {
+            responseStr = "M" + mainapp.throttleIntToString(whichThrottle) + "A" + addr_str + "<;>V" + speed;
+            mainapp.alert_activities(message_type.RESPONSE, responseStr);  //send response to running activities
+            responseStr = "M" + mainapp.throttleIntToString(whichThrottle) + "A" + addr_str + "<;>R" + dir;
+            mainapp.alert_activities(message_type.RESPONSE, responseStr);  //send response to running activities
+
+            // Process the functions
+            int fnState;
+            for (int i = 0; i < 27; i++) {
+                fnState = mainapp.bitExtracted(Integer.parseInt(args[4]), 1, i + 1);
+                processFunctionState(whichThrottle, i, (fnState != 0));
+                responseStr = "M" + mainapp.throttleIntToString(whichThrottle) + "A" + addr_str + "<;>F" + fnState + "" + (i);
+                mainapp.alert_activities(message_type.RESPONSE, responseStr);  //send response to running activities
+            }
+        }
+    } // end processDCCEXlocos()
+
+    private static boolean processDCCEXroster(String [] args) {
+        boolean skipAlert = true;
+
+        if ( (args!=null) && (args.length>1)) {
+            if ( (args.length<3) || (args[2].charAt(0) != '"') ) {  // loco list
+                if (mainapp.rosterStringDCCEX.equals("")) {
+                    mainapp.rosterStringDCCEX = "";
+                    mainapp.rosterIDsDCCEX = new int[args.length - 1];
+                    mainapp.rosterLocoNamesDCCEX = new String[args.length - 1];
+                    mainapp.rosterLocoFunctionsDCCEX = new String[args.length - 1];
+                    mainapp.rosterDetailsReceivedDCCEX = new boolean[args.length - 1];
+                    for (int i = 0; i < args.length - 1; i++) { // first will be blank
+                        mainapp.rosterIDsDCCEX[i] = Integer.parseInt(args[i + 1]);
+                        mainapp.rosterDetailsReceivedDCCEX[i] = false;
+                        wifiSend("<JR " + args[i + 1] + ">");
+                    }
+                }
+            } else {  // individual loco
+                if (mainapp.DCCEXlistsRequested < 3) {
+                    if (mainapp.rosterIDsDCCEX != null) {
+                        for (int i = 0; i < mainapp.rosterIDsDCCEX.length; i++) {
+                            if (mainapp.rosterIDsDCCEX[i] == Integer.parseInt(args[1])) {
+                                mainapp.rosterLocoNamesDCCEX[i] = args[2].substring(1, args[2].length() - 1);
+                                mainapp.rosterLocoFunctionsDCCEX[i] = args[3]; // ignore this
+                                mainapp.rosterDetailsReceivedDCCEX[i] = true;
+                                break;
+                            }
+                        }
+
+                        // check if we have all of them
+                        boolean ready = true;
+                        for (int i = 0; i < mainapp.rosterIDsDCCEX.length; i++) {
+                            if (!mainapp.rosterDetailsReceivedDCCEX[i]) {
+                                ready = false;
+                                break;
+                            }
+                        }
+                        if (ready) {
+                            mainapp.rosterStringDCCEX = "RL" + mainapp.rosterIDsDCCEX.length;
+                            for (int i = 0; i < mainapp.rosterIDsDCCEX.length; i++) {
+                                mainapp.rosterStringDCCEX = mainapp.rosterStringDCCEX
+                                        + "]\\[" + mainapp.rosterLocoNamesDCCEX[i]
+                                        + "}|{" + mainapp.rosterIDsDCCEX[i]
+                                        + "}|{" + (mainapp.rosterIDsDCCEX[i] <= 127 ? "S" : "L");
+                            }
+                            processRosterList(mainapp.rosterStringDCCEX);
+                            mainapp.rosterStringDCCEX = "";
+                            mainapp.DCCEXlistsRequested++;
+                            Log.d("Engine_Driver", "comm_thread.processDCCEXroster: Roster complete. Count: " + mainapp.DCCEXlistsRequested);
+                        }
+                    }
+
+                } else { // this a request for details on a specific loco - not part of the main roster request
+
+                    String addr_str = args[1];
+                    addr_str = ((Integer.parseInt(args[1]) <= 127) ? "S" : "L") + addr_str;
+
+                    int whichThrottle = mainapp.getWhichThrottleFromAddress(addr_str);
+                    if (whichThrottle >= 0) {
+                        String lead = mainapp.consists[whichThrottle].getLeadAddr();
+                        if (lead.equals(addr_str)) {                       // only process the functions for lead engine in consist
+                            if (args[3].length() > 2) {                       // only process the functions for lead engine in consist
+                                String[] fnArgs = args[3].substring(1, args[3].length() - 1).split("/", 999);
+                                mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle] = new boolean[args[3].length()];
+                                StringBuilder responseStrBuilder = new StringBuilder("RF29}|{1234(L)]\\[");  //prepend some stuff to match old-style
+                                for (int i = 0; i < fnArgs.length; i++) {
+                                    if (fnArgs[i].length() == 0) {
+                                        responseStrBuilder.append("]\\[");
+                                        mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle][i] = false;
+                                    } else {
+                                        if (fnArgs[i].charAt(0) == '*') { // is NOT latching
+                                            responseStrBuilder.append(fnArgs[i].substring(1)).append("]\\[");
+                                            mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle][i] = false;
+                                        } else {
+                                            responseStrBuilder.append(fnArgs[i]).append("]\\[");
+                                            mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle][i] = true;
+                                        }
+                                    }
+                                }
+                                processRosterFunctionString(responseStrBuilder.toString(), whichThrottle);
+
+                                mainapp.consists[whichThrottle].setFunctionLabels(addr_str, responseStrBuilder.toString(), mainapp);
+                                skipAlert = false;
+                            } else {
+                                mainapp.throttleFunctionIsLatchingDCCEX[whichThrottle] = null;
+                            }
+                        }
+
+                        Consist con = mainapp.consists[whichThrottle];
+                        if (con.getLoco(addr_str) != null) { //loco was added to consist in select_loco
+                            con.setConfirmed(addr_str);
+                            con.setWhichSource(addr_str, 1); //entered by address, not roster
+                            mainapp.addLocoToRecents(con.getLoco(addr_str));
+                        }
+                    }
+                }
+            }
+        }
+        return skipAlert;
+    } // end processDCCEXroster()
+
+    private static void processDCCEXturnouts(String [] args) {
+
+        if ( (args!=null) && (args.length>1)) {
+            if ( ((args.length < 4) || (args[3].charAt(0) != '"')) // turnouts list  <jT id1 id2 id3 ...>
+               &&  !((args.length == 3) || (args[2].charAt(0) == 'X')) ) {   // not... <jT id X>
+                if (mainapp.turnoutStringDCCEX.equals("")) {
+                    mainapp.turnoutStringDCCEX = "";
+                    mainapp.turnoutIDsDCCEX = new int[args.length - 1];
+                    mainapp.turnoutNamesDCCEX = new String[args.length - 1];
+                    mainapp.turnoutStatesDCCEX = new String[args.length - 1];
+                    mainapp.turnoutDetailsReceivedDCCEX = new boolean[args.length - 1];
+                    for (int i = 0; i < args.length - 1; i++) { // first will be blank
+                        mainapp.turnoutIDsDCCEX[i] = Integer.parseInt(args[i + 1]);
+                        mainapp.turnoutDetailsReceivedDCCEX[i] = false;
+                        wifiSend("<JT " + args[i + 1] + ">");
+                    }
+                }
+            } else {  // individual turnout  <jT id state "[desc]">
+                for (int i = 0; i < mainapp.turnoutIDsDCCEX.length; i++) {
+                    if (mainapp.turnoutIDsDCCEX[i] == Integer.parseInt(args[1])) {
+                        mainapp.turnoutStatesDCCEX[i] = args[2];
+                        mainapp.turnoutNamesDCCEX[i] = args[3].substring(1, args[3].length() - 1);
+                        mainapp.turnoutDetailsReceivedDCCEX[i] = true;
+                        break;
+                    }
+                }
+                // check if we have all of them
+                boolean ready = true;
+                for (int i = 0; i < mainapp.turnoutIDsDCCEX.length; i++) {
+                    if (!mainapp.turnoutDetailsReceivedDCCEX[i]) {
+                        ready = false;
+                        break;
+                    }
+                }
+                if (ready) {
+                    mainapp.turnoutStringDCCEX = "PTT";
+                    for (int i = 0; i < mainapp.turnoutIDsDCCEX.length; i++) {
+                        mainapp.turnoutStringDCCEX = mainapp.turnoutStringDCCEX
+                                + "]\\[" + mainapp.turnoutIDsDCCEX[i]
+                                + "}|{" + mainapp.turnoutNamesDCCEX[i]
+                                + "}|{" + (mainapp.turnoutStatesDCCEX[i].equals("T") ? 4 : 2);
+                    }
+                    processTurnoutTitles("PTT]\\[Turnouts}|{Turnout]\\[Closed}|{2]\\[Thrown}|{4]\\[Unknown}|{1]\\[Inconsistent}|{8");
+                    processTurnoutList(mainapp.turnoutStringDCCEX);
+                    mainapp.turnoutStringDCCEX = "";
+                    mainapp.DCCEXlistsRequested++;
+                    Log.d("Engine_Driver", "comm_thread.processDCCEXturnouts: Turnouts complete. Count: " + mainapp.DCCEXlistsRequested);
+                }
+            }
+        }
+    } // end processDCCEXturnouts()
+
+    private static void processDCCEXroutes(String [] args) {
+
+        if ( (args!=null) && (args.length>1)) {
+            if ( ((args.length < 4) || (args[3].charAt(0) != '"'))  // routes list   <jA id1 id2 id3 ...>
+               && !((args.length == 3) || (args[2].charAt(0) == 'X')) ) {  // not... <jA id X>
+                if (mainapp.routeStringDCCEX.equals("")) {
+                    mainapp.routeStringDCCEX = "";
+                    mainapp.routeIDsDCCEX = new int[args.length - 1];
+                    mainapp.routeNamesDCCEX = new String[args.length - 1];
+                    mainapp.routeStatesDCCEX = new String[args.length - 1];
+                    mainapp.routeDetailsReceivedDCCEX = new boolean[args.length - 1];
+                    for (int i = 0; i < args.length - 1; i++) { // first will be blank
+                        mainapp.routeIDsDCCEX[i] = Integer.parseInt(args[i + 1]);
+                        mainapp.routeDetailsReceivedDCCEX[i] = false;
+                        wifiSend("<JA " + args[i + 1] + ">");
+                    }
+                }
+            } else {  // individual route   <jA id type "[description]">
+                for (int i = 0; i < mainapp.routeIDsDCCEX.length; i++) {
+                    if (mainapp.routeIDsDCCEX[i] == Integer.parseInt(args[1])) {
+//                    mainapp.routeStatesDCCEX[i] = args[2];
+                        mainapp.routeNamesDCCEX[i] = args[3].substring(1, args[3].length() - 1);
+                        mainapp.routeDetailsReceivedDCCEX[i] = true;
+                        break;
+                    }
+                }
+                // check if we have all of them
+                boolean ready = true;
+                for (int i = 0; i < mainapp.routeIDsDCCEX.length; i++) {
+                    if (!mainapp.routeDetailsReceivedDCCEX[i]) {
+                        ready = false;
+                        break;
+                    }
+                }
+                if (ready) {
+                    mainapp.routeStringDCCEX = "PRL";
+                    for (int i = 0; i < mainapp.routeIDsDCCEX.length; i++) {
+                        mainapp.routeStringDCCEX = mainapp.routeStringDCCEX
+                                + "]\\[" + mainapp.routeIDsDCCEX[i]
+                                + "}|{" + mainapp.routeNamesDCCEX[i]
+                                + "}|{" + "1";  //unknown
+                    }
+                    processRouteTitles("PRT]\\[Routes}|{Route]\\[Active}|{2]\\[Inactive}|{4");
+                    processRouteList(mainapp.routeStringDCCEX);
+                    mainapp.routeStringDCCEX = "";
+                    mainapp.DCCEXlistsRequested++;
+                    Log.d("Engine_Driver", "comm_thread.processDCCEXroutes: Routes complete. Count: " + mainapp.DCCEXlistsRequested);
+                }
+            }
+        }
+    } // end processDCCEXroutes()
+
+    /* ***********************************  *********************************** */
+
+    //parse roster functions list into appropriate app variable array
+    //  //RF29}|{4805(L)]\[Light]\[Bell]\[Horn]\[Air]\[Uncpl]\[BrkRls]\[]\[]\[]\[]\[]\[]\[Engine]\[]\[]\[]\[]\[]\[BellSel]\[HornSel]\[]\[]\[]\[]\[]\[]\[]\[]\[
+    private static void processRosterFunctionString(String responseStr, int whichThrottle) {
+
+        Log.d("Engine_Driver", "comm_thread.processRosterFunctionString: processing function labels for " + mainapp.throttleIntToString(whichThrottle));
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //split into list of labels
+
+        //populate a temp label array from RF command string
+        LinkedHashMap<Integer, String> function_labels_temp = new LinkedHashMap<>();
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 0 && !"".equals(ts)) { //skip first chunk, which is length, and skip any blank entries
+                function_labels_temp.put(i - 1, ts); //index is hashmap key, value is label string
+            }  //end if i>0
+            i++;
+        }  //end for
+
+        //set the appropriate global variable from the temp
+        mainapp.function_labels[whichThrottle] = function_labels_temp;
+
+    }
+
+    //parse roster list into appropriate app variable array
+    //  RL2]\[NS2591}|{2591}|{L]\[NS4805}|{4805}|{L
+    private static void processRosterList(String responseStr) {
+        //clear the global variable
+        mainapp.roster_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
+        //todo   RDB why don't we just clear the existing map with roster_entries.clear() instead of disposing and creating a new instance?
+
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        //initialize app arrays (skipping first)
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 0) { //skip first chunk
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into name, address and length
+                try {
+                    mainapp.roster_entries.put(tv[0], tv[1] + "(" + tv[2] + ")"); //roster name is hashmap key, value is address(L or S), e.g.  2591(L)
+                } catch (Exception e) {
+                    Log.d("Engine_Driver", "comm_thread.processRosterList caught Exception");  //ignore any bad stuff in roster entries
+                }
+            }  //end if i>0
+            i++;
+        }  //end for
+
+    }
+
+    //parse consist list into appropriate mainapp hashmap
+    //RCD}|{88(S)}|{Consist Name]\[2591(L)}|{true]\[3(S)}|{true]\[4805(L)}|{true
+    private static void processConsistList(String responseStr) {
+        String consist_addr = null;
+        StringBuilder consist_desc = new StringBuilder();
+        String consist_name = "";
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        String plus = ""; //plus sign for a separator
+        //initialize app arrays (skipping first)
+        int i = 0;
+        for (String ts : ta) {
+            if (i == 0) { //first chunk is a "header"
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split header chunk into header, address and name
+                consist_addr = tv[1];
+                consist_name = tv[2];
+            } else {  //list of locos in consist
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into loco address and direction
+                consist_desc.append(plus).append(tv[0]);
+                plus = "+";
+            }  //end if i==0
+            i++;
+        }  //end for
+        Log.d("Engine_Driver", "comm_thread.processConsistList: consist header, addr='" + consist_addr
+                + "', name='" + consist_name + "', desc='" + consist_desc + "'");
+        //don't add empty consists to list
+        if (mainapp.consist_entries != null && consist_desc.length() > 0) {
+            mainapp.consist_entries.put(consist_addr, consist_desc.toString());
+        } else {
+            Log.d("Engine_Driver", "comm_thread.processConsistList: skipping empty consist '" + consist_name + "'");
+        }
+    }
+
+    //clear out any stored consists
+    private static void clearConsistList() {
+        if (mainapp.consist_entries!=null) mainapp.consist_entries.clear();
+    }
+
+    private static int findTurnoutPos(String systemName) {
+        int pos = -1;
+        for (String sn : mainapp.to_system_names) { //TODO: rewrite for better lookup
+            pos++;
+            if (sn != null && sn.equals(systemName)) {
+                break;
+            }
+        }
+        return pos;
+    }
+
+    //parse turnout change to update mainapp array entry
+    //  PTA<NewState><SystemName>
+    //  PTA2LT12
+    private static void processTurnoutChange(String responseStr) {
+        if (mainapp.to_system_names == null) return;  //ignore if turnouts not defined
+        String newState = responseStr.substring(3, 4);
+        String systemName = responseStr.substring(4);
+//        int pos = -1;
+//        for (String sn : mainapp.to_system_names) {
+//            pos++;
+//            if (sn != null && sn.equals(systemName)) {
+//                break;
+//            }
+//        }
+        int pos = findTurnoutPos(systemName);
+        if (pos >= 0 && pos <= mainapp.to_system_names.length) {  //if found, update to new value
+            mainapp.to_states[pos] = newState;
+        }
+    }  //end of processTurnoutChange
+
+    //parse turnout list into appropriate app variable array
+    //  PTL[<SystemName><UserName><State>repeat] where state 1=Unknown. 2=Closed, 4=Thrown
+    //  PTL]\[LT12}|{my12}|{1
+    private static void processTurnoutList(String responseStr) {
+
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        //initialize app arrays (skipping first)
+        mainapp.to_system_names = new String[ta.length - 1];
+        mainapp.to_user_names = new String[ta.length - 1];
+        mainapp.to_states = new String[ta.length - 1];
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 0) { //skip first chunk, just message id
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into 3 parts, key and value
+                if (tv.length == 3) { //make sure split worked
+                    mainapp.to_system_names[i - 1] = tv[0];
+                    mainapp.to_user_names[i - 1] = tv[1];
+                    mainapp.to_states[i - 1] = tv[2];
+                }
+            }  //end if i>0
+            i++;
+        }  //end for
+
+    }
+
+    private static void processTurnoutTitles(String responseStr) {
+        //PTT]\[Turnouts}|{Turnout]\[Closed}|{2]\[Thrown}|{4
+
+        //clear the global variable
+        mainapp.to_state_names = new HashMap<>();
+
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        //initialize app arrays (skipping first)
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 1) { //skip first 2 chunks
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into value and key
+                mainapp.to_state_names.put(tv[1], tv[0]);
+            }  //end if i>0
+            i++;
+        }  //end for
+
+    }
+
+    //parse route list into appropriate app variable array
+    //  PRA<NewState><SystemName>
+    //  PRA2LT12
+    private static void processRouteChange(String responseStr) {
+        String newState = responseStr.substring(3, 4);
+        String systemName = responseStr.substring(4);
+        int pos = -1;
+        for (String sn : mainapp.rt_system_names) {
+            pos++;
+            if (sn != null && sn.equals(systemName)) {
+                break;
+            }
+        }
+        if (pos >= 0 && pos <= mainapp.rt_system_names.length) {  //if found, update to new value
+            mainapp.rt_states[pos] = newState;
+        }
+    }  //end of processRouteChange
+
+    //parse route list into appropriate app variable array
+    //  PRL[<SystemName><UserName><State>]repeat where state 1=Unknown,2=Active,4=Inactive,8=Inconsistent
+    //  PRL]\[LT12}|{my12}|{1
+    private static void processRouteList(String responseStr) {
+
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        //initialize app arrays (skipping first)
+        mainapp.rt_system_names = new String[ta.length - 1];
+        mainapp.rt_user_names = new String[ta.length - 1];
+        mainapp.rt_states = new String[ta.length - 1];
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 0) { //skip first chunk, just message id
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into 3 parts, key and value
+                mainapp.rt_system_names[i - 1] = tv[0];
+                mainapp.rt_user_names[i - 1] = tv[1];
+                mainapp.rt_states[i - 1] = tv[2];
+            }  //end if i>0
+            i++;
+        }  //end for
+
+    }
+
+    private static void processRouteTitles(String responseStr) {
+        //PRT
+
+        //clear the global variable
+        mainapp.rt_state_names = new HashMap<>();
+
+        String[] ta = threaded_application.splitByString(responseStr, "]\\[");  //initial separation
+        //initialize app arrays (skipping first)
+        int i = 0;
+        for (String ts : ta) {
+            if (i > 1) { //skip first 2 chunks
+                String[] tv = threaded_application.splitByString(ts, "}|{");  //split these into value and key
+                mainapp.rt_state_names.put(tv[1], tv[0]);
+            }  //end if i>0
+            i++;
+        }  //end for
+    }
+
+    //parse function state string into appropriate app variable array
+    private static void processFunctionState(int whichThrottle, Integer fn, boolean fState) {
+
+        boolean skip = (fn > 2) && (mainapp.prefAlwaysUseDefaultFunctionLabels)
+                && ((mainapp.prefConsistFollowRuleStyle.equals(threaded_application.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                || (mainapp.prefConsistFollowRuleStyle.equals(threaded_application.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)));
+
+        if (!skip) {
+            try {
+                mainapp.function_states[whichThrottle][fn] = fState;
+            } catch (ArrayIndexOutOfBoundsException ignored) {
+            }
+        }
+    }
+
+    //
+    // wifiSend(String msg)
+    //
+    //send formatted msg to the socket using multithrottle format
+    //  intermessage gap enforced by requeueing messages as needed
+    protected static void wifiSend(String msg) {
+//            Log.d("Engine_Driver", "comm_thread.wifiSend: WiT send '" + msg + "'");
+        if (msg == null) { //exit if no message
+            Log.d("Engine_Driver", "comm_thread.wifiSend: --> null msg");
+            return;
+        } else if (socketWiT == null) {
+            Log.e("Engine_Driver", "comm_thread.wifiSend: socketWiT is null, message '" + msg + "' not sent!");
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        long lastGap = now - lastSentMs;
+
+        //send if sufficient gap between messages or msg is timingSensitive, requeue if not
+        if (lastGap >= threaded_application.WiThrottle_Msg_Interval || timingSensitive(msg)) {
+            //perform the send
+            Log.d("Engine_Driver", "comm_thread.wifiSend: " + (mainapp.isDCCEX ? "DCC-EX" : "") + "           -->:" + msg.replaceAll("\n", "\u21B5") + " (" + lastGap + ")"); //replace newline with cr arrow
+            lastSentMs = now;
+            socketWiT.Send(msg);
+        } else {
+            //requeue this message
+            int nextGap = Math.max((int) (lastQueuedMs - now), 0) + (threaded_application.WiThrottle_Msg_Interval + 5); //extra 5 for processing
+            Log.d("Engine_Driver", "comm_thread.wifiSend: requeue:" + msg.replaceAll("\n", "\u21B5") +
+                    ", lastGap=" + lastGap + ", nextGap=" + nextGap); //replace newline with cr arrow
+            mainapp.sendMsgDelay(mainapp.comm_msg_handler, nextGap, message_type.WIFI_SEND, msg);
+            lastQueuedMs = now + nextGap;
+        }
+    }  //end wifiSend()
+
+    /* true indicates that message should NOT be requeued as the timing of this message
+         is critical.
+     */
+    private static boolean timingSensitive(String msg) {
+        boolean ret = false;
+        if (msg.matches("^M[0-5]A.{1,5}<;>F[0-1][\\d]{1,2}$")) {
+            ret = true;
+        } //any function key message
+        if (ret) Log.d("Engine_Driver", "comm_thread.timingSensitive: timeSensitive msg, not requeuing:");
+        return ret;
+    }
+
+    public void run() {
+        Looper.prepare();
+        mainapp.comm_msg_handler = new comm_handler(mainapp, prefs, this);
+        Looper.loop();
+        Log.d("Engine_Driver", "comm_thread.run() exit");
+    }
+
+    /* ******************************************************************************************** */
+    /* ******************************************************************************************** */
+
+    static class socketWifi extends Thread {
+        InetAddress host_address;
+        Socket clientSocket = null;
+        BufferedReader inputBR = null;
+        PrintWriter outputPW = null;
+        private volatile boolean endRead = false;           //signals rcvr to terminate
+        private volatile boolean socketGood = false;        //indicates socket condition
+        private volatile boolean inboundTimeout = false;    //indicates inbound messages are not arriving from WiT
+        private boolean firstConnect = false;               //indicates initial socket connection was achieved
+        private int connectTimeoutMs = 3000; //connection timeout in milliseconds
+        private int socketTimeoutMs = 500; //socket timeout in milliseconds
+
+        private final int MAX_INBOUND_TIMEOUT_RETRIES = 2;
+        private int inboundTimeoutRetryCount = 0;           // number of consecutive inbound timeouts
+        private boolean inboundTimeoutRecovery = false;     // attempting to force WiT to respond
+
+
+        socketWifi() {
+            super("socketWifi");
+        }
+
+        public boolean connect() {
+
+            //use local socketOk instead of setting socketGood so that the rcvr doesn't resume until connect() is done
+            boolean socketOk = HaveNetworkConnection();
+
+            connectTimeoutMs = Integer.parseInt(prefs.getString("prefConnectTimeoutMs", mainapp.getResources().getString(R.string.prefConnectTimeoutMsDefaultValue)));
+            socketTimeoutMs = Integer.parseInt(prefs.getString("prefSocketTimeoutMs", mainapp.getResources().getString(R.string.prefSocketTimeoutMsDefaultValue)));
+
+            //validate address
+            if (socketOk) {
+                try {
+                    host_address = InetAddress.getByName(mainapp.host_ip);
+                } catch (UnknownHostException except) {
+//                        show_toast_message("Can't determine IP address of " + host_ip, Toast.LENGTH_LONG);
+                    threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppCantDetermineIp, mainapp.host_ip), Toast.LENGTH_SHORT);
+                    socketOk = false;
+                }
+            }
+
+            //socket
+            if (socketOk) {
+                try {
+                    //look for someone to answer on specified socket, and set timeout
+                    Log.d("Engine_Driver", "comm_thread.socketWifi: Opening socket, connectTimeout=" + connectTimeoutMs + " and socketTimeout=" + socketTimeoutMs);
+                    clientSocket = new Socket();
+                    InetSocketAddress sa = new InetSocketAddress(mainapp.host_ip, mainapp.port);
+                    clientSocket.connect(sa, connectTimeoutMs);
+                    Log.d("Engine_Driver", "comm_thread.socketWifi: Opening socket: Connect successful.");
+                    clientSocket.setSoTimeout(socketTimeoutMs);
+                    Log.d("Engine_Driver", "comm_thread.socketWifi: Opening socket: set timeout successful.");
+                } catch (Exception except) {
+                    if (!firstConnect) {
+                        threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppCantConnect,
+                                mainapp.host_ip, Integer.toString(mainapp.port), mainapp.client_address, except.getMessage()), Toast.LENGTH_LONG);
+                    }
+                    if ((!mainapp.client_type.equals("WIFI")) && (mainapp.prefAllowMobileData)) { //show additional message if using mobile data
+                        Log.d("Engine_Driver", "comm_thread.socketWifi: Opening socket: Using mobile network, not WIFI. Check your WiFi settings and Preferences.");
+                        threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppNotWIFI, mainapp.client_type), Toast.LENGTH_LONG);
+                    }
+                    socketOk = false;
+                }
+            }
+
+            //rcvr
+            if (socketOk) {
+                try {
+                    inputBR = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+                } catch (IOException except) {
+                    threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppErrorInputStream, except.getMessage()), Toast.LENGTH_SHORT);
+                    socketOk = false;
+                }
+            }
+
+            //start the socketWifi thread.
+            if (socketOk) {
+                if (!this.isAlive()) {
+                    endRead = false;
+                    try {
+                        this.start();
+                    } catch (IllegalThreadStateException except) {
+                        //ignore "already started" errors
+                        threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppErrorStartingSocket, except.getMessage()), Toast.LENGTH_SHORT);
+                    }
+                }
+            }
+
+            //xmtr
+            if (socketOk) {
+                try {
+                    outputPW = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream()), true);
+                    if (outputPW.checkError()) {
+                        socketOk = false;
+                    }
+                } catch (IOException e) {
+                    threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppErrorCreatingOutputStream, e.getMessage()), Toast.LENGTH_SHORT);
+                    socketOk = false;
+                }
+            }
+            socketGood = socketOk;
+            if (socketOk)
+                firstConnect = true;
+            return socketOk;
+        }
+
+        public void disconnect(boolean shutdown) {
+            disconnect(shutdown, false);
+        }
+
+        public void disconnect(boolean shutdown, boolean fastShutdown) {
+            if (shutdown) {
+                endRead = true;
+                if (!fastShutdown) {
+                    for (int i = 0; i < 5 && this.isAlive(); i++) {
+                        try {
+                            Thread.sleep(connectTimeoutMs);     //  give run() a chance to see endRead and exit
+                        } catch (InterruptedException e) {
+                            threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.toastThreadedAppErrorSleepingThread, e.getMessage()), Toast.LENGTH_SHORT);
+                        }
+                    }
+                }
+            }
+
+            socketGood = false;
+
+            //close socket
+            if (clientSocket != null) {
+                try {
+                    clientSocket.close();
+                } catch (Exception e) {
+                    Log.d("Engine_Driver", "comm_thread.socketWifi: Error closing the Socket: " + e.getMessage());
+                }
+            }
+        }
+
+        //read the input buffer
+        public void run() {
+            String str;
+            //continue reading until signaled to exit by endRead
+            while (!endRead) {
+                if (socketGood) {        //skip read when the socket is down
+                    try {
+                        if ((str = inputBR.readLine()) != null) {
+                            if (str.length() > 0) {
+                                heart.restartInboundInterval();
+                                clearInboundTimeout();
+                                processWifiResponse(str);
+                            }
+                        }
+                    } catch (SocketTimeoutException e) {
+                        socketGood = this.SocketCheck();
+                    } catch (IOException e) {
+                        if (socketGood) {
+                            Log.d("Engine_Driver", "comm_thread.run(): WiT rcvr error.");
+                            socketGood = false;     //input buffer error so force reconnection on next send
+                        }
+                    }
+                }
+                if (!socketGood) {
+                    SystemClock.sleep(500L);        //don't become compute bound here when the socket is down
+                }
+            }
+            heart.stopHeartbeat();
+            Log.d("Engine_Driver", "comm_thread.run(): socketWifi exit.");
+        }
+
+        @SuppressLint("StringFormatMatches")
+        void Send(String msg) {
+            boolean reconInProg = false;
+            //reconnect socket if needed
+            if (!socketGood || inboundTimeout) {
+                String status;
+                if (mainapp.client_address == null) {
+                    status = threaded_application.context.getResources().getString(R.string.statusThreadedAppNotConnected);
+                    Log.d("Engine_Driver", "comm_thread.send(): WiT send reconnection attempt.");
+                } else if (inboundTimeout) {
+                    status = threaded_application.context.getResources().getString(R.string.statusThreadedAppNoResponse, mainapp.host_ip, Integer.toString(mainapp.port), heart.getInboundInterval());
+                    Log.d("Engine_Driver", "comm_thread.send(): WiT receive reconnection attempt.");
+                } else {
+                    status = threaded_application.context.getResources().getString(R.string.statusThreadedAppUnableToConnect, mainapp.host_ip, Integer.toString(mainapp.port), mainapp.client_address);
+                    Log.d("Engine_Driver", "comm_thread.send(): WiT send reconnection attempt.");
+                }
+                socketGood = false;
+
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WIT_CON_RETRY, status);
+
+                //perform the reconnection sequence
+                this.disconnect(false);             //clean up socket but do not shut down the receiver
+                this.connect();                     //attempt to reestablish connection
+                reconInProg = true;
+            }
+
+            //try to send the message
+            if (socketGood) {
+                try {
+                    outputPW.println(msg);
+                    outputPW.flush();
+                    heart.restartOutboundInterval();
+
+                    // if we get here without an exception then the socket is ok
+                    if (reconInProg) {
+                        String status = "Connected to WiThrottle Server at " + mainapp.host_ip + ":" + mainapp.port;
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WIT_CON_RECONNECT, status);
+                        Log.d("Engine_Driver", "comm_thread.send(): WiT reconnection successful.");
+                        clearInboundTimeout();
+                        heart.restartInboundInterval();     //socket is good so restart inbound heartbeat timer
+                    }
+                } catch (Exception e) {
+                    Log.d("Engine_Driver", "comm_thread.send(): WiT xmtr error.");
+                    socketGood = false;             //output buffer error so force reconnection on next send
+                }
+            }
+
+            if (!socketGood) {
+                mainapp.comm_msg_handler.postDelayed(heart.outboundHeartbeatTimer, 500L);   //try connection again in 0.5 second
+            }
+        }
+
+        // Attempt to determine if the socket connection is still good.
+        // unfortunatley isConnected returns true if the Socket was disconnected other than by calling close()
+        // so on signal loss it still returns true.
+        // Eventually we just try to send and handle the IOException if the socket was disconnected.
+        boolean SocketCheck() {
+            boolean status = clientSocket.isConnected() && !clientSocket.isInputShutdown() && !clientSocket.isOutputShutdown();
+            if (status)
+                status = HaveNetworkConnection();   // can't trust the socket flags so try something else...
+            return status;
+        }
+
+        // temporary - SocketCheck should determine whether socket connection is good however socket flags sometimes do not get updated
+        // so it doesn't work.  This is better than nothing though?
+        private boolean HaveNetworkConnection() {
+            boolean haveConnectedWifi = false;
+            boolean haveConnectedMobile = false;
+            mainapp.prefAllowMobileData = prefs.getBoolean("prefAllowMobileData", false);
+
+            final ConnectivityManager cm = (ConnectivityManager) mainapp.getSystemService(Context.CONNECTIVITY_SERVICE);
+            NetworkInfo[] netInfo = cm.getAllNetworkInfo();
+            for (NetworkInfo ni : netInfo) {
+                if ("WIFI".equalsIgnoreCase(ni.getTypeName()))
+
+                    if (!mainapp.prefAllowMobileData) {
+                        // attempt to resolve the problem where some devices won't connect over wifi unless mobile data is turned off
+                        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+                                && (!mainapp.haveForcedWiFiConnection)) {
+
+                            Log.d("Engine_Driver", "comm_thread.HaveNetworkConnection: NetworkRequest.Builder");
+                            NetworkRequest.Builder request = new NetworkRequest.Builder();
+                            request.addTransportType(NetworkCapabilities.TRANSPORT_WIFI);
+
+                            cm.registerNetworkCallback(request.build(), new ConnectivityManager.NetworkCallback() {
+                                @Override
+                                public void onAvailable(Network network) {
+                                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                                        ConnectivityManager.setProcessDefaultNetwork(network);
+                                    } else {
+                                        cm.bindProcessToNetwork(network);  //API23+
+                                    }
+                                }
+                            });
+                            mainapp.haveForcedWiFiConnection = true;
+                        }
+                    }
+
+                if (ni.isConnected()) {
+                    haveConnectedWifi = true;
+                } else {
+                    // attempt to resolve the problem where some devices won't connect over wifi unless mobile data is turned off
+                    if (mainapp.prefAllowMobileData) {
+                        haveConnectedWifi = true;
+                    }
+                }
+                if ("MOBILE".equalsIgnoreCase(ni.getTypeName()))
+                    if ((ni.isConnected()) && (mainapp.prefAllowMobileData)) {
+                        haveConnectedMobile = true;
+                    }
+            }
+            return haveConnectedWifi || haveConnectedMobile;
+        }
+
+        boolean SocketGood() {
+            return this.socketGood;
+        }
+
+        void InboundTimeout() {
+            if (++inboundTimeoutRetryCount >= MAX_INBOUND_TIMEOUT_RETRIES) {
+                Log.d("Engine_Driver", "comm_thread.InboundTimeout: WiT max inbound timeouts");
+                inboundTimeout = true;
+                inboundTimeoutRetryCount = 0;
+                inboundTimeoutRecovery = false;
+                // force a send to start the reconnection process
+                mainapp.comm_msg_handler.postDelayed(heart.outboundHeartbeatTimer, 200L);
+            } else {
+                Log.d("Engine_Driver", "comm_thread.InboundTimeout: WiT inbound timeout " +
+                        Integer.toString(inboundTimeoutRetryCount) + " of " + MAX_INBOUND_TIMEOUT_RETRIES);
+                // heartbeat should trigger a WiT reply so force that now
+                inboundTimeoutRecovery = true;
+                mainapp.comm_msg_handler.post(heart.outboundHeartbeatTimer);
+            }
+        }
+
+        void clearInboundTimeout() {
+            inboundTimeout = false;
+            inboundTimeoutRecovery = false;
+            inboundTimeoutRetryCount = 0;
+        }
+    }
+
+    /* ******************************************************************************************** */
+
+    static class heartbeat {
+        //  outboundHeartbeat - send a periodic heartbeat to WiT to show that ED is alive.
+        //  inboundHeartbeat - WiT doesn't send a heartbeat to ED, so send a periodic message to WiT that requires a response.
+        //
+        //  If the HeartbeatValueFromServer is 0 then set heartbeatOutboundInterval = DEFAULT_OUTBOUND_HEARTBEAT_INTERVAL,
+        //    and set heartbeatInboundInterval = 0, to disable the inbound heartbeat checks
+        //
+        //  Otherwise, set heartbeatOutboundInterval to HeartbeatValueFromServer * HEARTBEAT_RESPONSE_ALLOWANCE,
+        //    and set heartbeatInboundInterval to HeartbeatValueFromServer / HEARTBEAT_RESPONSE_ALLOWANCE
+        //
+        //  Insure both values are between MIN_OUTBOUND_HEARTBEAT_INTERVAL and MAX_OUTBOUND_HEARTBEAT_INTERVAL
+
+        private int heartbeatIntervalSetpoint = 0;      //WiT heartbeat interval in msec
+        private int heartbeatOutboundInterval = 0;      //sends outbound heartbeat message at this rate (msec)
+        private int heartbeatInboundInterval = 0;       //alerts user if there was no inbound traffic for this long (msec)
+
+        public boolean isHeartbeatSent() {
+            return heartbeatSent;
+        }
+
+        public void setHeartbeatSent(boolean heartbeatSent) {
+            this.heartbeatSent = heartbeatSent;
+        }
+
+        private boolean heartbeatSent = false;
+
+        private int getInboundInterval() {
+            return heartbeatInboundInterval;
+        }
+
+        /***
+         * startHeartbeat(timeoutInterval in milliseconds)
+         * calcs the inbound and outbound intervals and starts the beating
+         *
+         * @param timeoutInterval the WiT timeoutInterval in milliseconds
+         */
+        void startHeartbeat(int timeoutInterval) {
+            //update interval timers only when the heartbeat timeout interval changed
+            mainapp.prefHeartbeatResponseFactor = threaded_application.getIntPrefValue(prefs, "prefHeartbeatResponseFactor", mainapp.getApplicationContext().getResources().getString(R.string.prefHeartbeatResponseFactorDefaultValue));
+
+            if (timeoutInterval != heartbeatIntervalSetpoint) {
+                heartbeatIntervalSetpoint = timeoutInterval;
+
+                // outbound interval (in ms)
+                int outInterval;
+                if (heartbeatIntervalSetpoint == 0) {   //wit heartbeat is disabled so use default outbound heartbeat
+                    outInterval = threaded_application.DEFAULT_OUTBOUND_HEARTBEAT_INTERVAL;
+                } else {
+//                        outInterval = (int) (heartbeatIntervalSetpoint * HEARTBEAT_RESPONSE_FACTOR);
+                    outInterval = (int) (heartbeatIntervalSetpoint * ( (double) mainapp.prefHeartbeatResponseFactor) / 100);
+                    //keep values in a reasonable range
+                    if (outInterval < threaded_application.MIN_OUTBOUND_HEARTBEAT_INTERVAL)
+                        outInterval = threaded_application.MIN_OUTBOUND_HEARTBEAT_INTERVAL;
+                    if (outInterval > threaded_application.MAX_OUTBOUND_HEARTBEAT_INTERVAL)
+                        outInterval = threaded_application.MAX_OUTBOUND_HEARTBEAT_INTERVAL;
+                }
+                heartbeatOutboundInterval = outInterval;
+
+                // inbound interval
+                int inInterval = mainapp.heartbeatInterval;
+                if (heartbeatIntervalSetpoint == 0) {    // wit heartbeat is disabled so disable inbound heartbeat
+                    inInterval = 0;
+                } else {
+                    if (inInterval < threaded_application.MIN_INBOUND_HEARTBEAT_INTERVAL)
+                        inInterval = threaded_application.MIN_INBOUND_HEARTBEAT_INTERVAL;
+                    if (inInterval < outInterval)
+//                            inInterval = (int) (outInterval / HEARTBEAT_RESPONSE_FACTOR);
+                        inInterval = (int) (outInterval / ( ((double) mainapp.prefHeartbeatResponseFactor) / 100) );
+                    if (inInterval > threaded_application.MAX_INBOUND_HEARTBEAT_INTERVAL)
+                        inInterval = threaded_application.MAX_INBOUND_HEARTBEAT_INTERVAL;
+                }
+                heartbeatInboundInterval = inInterval;
+                //sInboundInterval = Integer.toString(inInterval);    // seconds
+
+                restartOutboundInterval();
+                restartInboundInterval();
+            }
+        }
+
+        //restartOutboundInterval()
+        //restarts the outbound interval timing - call this after sending anything to WiT that requires a response
+        void restartOutboundInterval() {
+            mainapp.comm_msg_handler.removeCallbacks(outboundHeartbeatTimer);                   //remove any pending requests
+            if (heartbeatOutboundInterval > 0) {
+                mainapp.comm_msg_handler.postDelayed(outboundHeartbeatTimer, heartbeatOutboundInterval);    //restart interval
+            }
+        }
+
+        //restartInboundInterval()
+        //restarts the inbound interval timing - call this after receiving anything from WiT
+        void restartInboundInterval() {
+            mainapp.comm_msg_handler.removeCallbacks(inboundHeartbeatTimer);
+            if (heartbeatInboundInterval > 0) {
+                mainapp.comm_msg_handler.postDelayed(inboundHeartbeatTimer, heartbeatInboundInterval);
+            }
+        }
+
+        void stopHeartbeat() {
+            mainapp.comm_msg_handler.removeCallbacks(outboundHeartbeatTimer);           //remove any pending requests
+            mainapp.comm_msg_handler.removeCallbacks(inboundHeartbeatTimer);
+            heartbeatIntervalSetpoint = 0;
+            Log.d("Engine_Driver", "comm_thread.stopHeartbeat: heartbeat stopped.");
+        }
+
+        //outboundHeartbeatTimer()
+        //sends a periodic message to WiT
+        private final Runnable outboundHeartbeatTimer = new Runnable() {
+            @Override
+            public void run() {
+                mainapp.comm_msg_handler.removeCallbacks(this);             //remove pending requests
+                if (heartbeatIntervalSetpoint != 0) {
+                    boolean anySent = false;
+                    for (int i = 0; i < mainapp.numThrottles; i++) {
+                        if (mainapp.consists[i].isActive()) {
+                            sendRequestSpeedAndDir(i);
+                            anySent = true;
+                        }
+                    }
+                    // prior to JMRI 4.20 there were cases where WiT might not respond to
+                    // speed and direction request.  If inboundTimeout handling is in progress
+                    // then we always send the Throttle Name to ensure a response
+                    if (!anySent || (mainapp.getServerType().equals("") && socketWiT.inboundTimeoutRecovery)) {
+                        sendThrottleName(false);    //send message that will get a response
+                    }
+                    mainapp.comm_msg_handler.postDelayed(this, heartbeatOutboundInterval);   //set next beat
+                }
+            }
+        };
+
+        //inboundHeartbeatTimer()
+        //display an alert message when there is no inbound traffic from WiT within required interval
+        private final Runnable inboundHeartbeatTimer = new Runnable() {
+            @Override
+            public void run() {
+                mainapp.comm_msg_handler.removeCallbacks(this); //remove pending requests
+                if (heartbeatIntervalSetpoint != 0) {
+                    if (socketWiT != null && socketWiT.SocketGood()) {
+                        socketWiT.InboundTimeout();
+                    }
+                    mainapp.comm_msg_handler.postDelayed(this, heartbeatInboundInterval);    //set next inbound timeout
+                }
+            }
+        };
+    }
+
+    /* ******************************************************************************************** */
+
+    static class PhoneListener extends PhoneStateListener {
+        private final TelephonyManager telMgr;
+
+        PhoneListener() {
+            telMgr = (TelephonyManager) mainapp.getSystemService(Context.TELEPHONY_SERVICE);
+            this.enable();
+        }
+
+        public void disable() {
+            telMgr.listen(this, PhoneStateListener.LISTEN_NONE);
+        }
+
+        public void enable() {
+            telMgr.listen(this, PhoneStateListener.LISTEN_CALL_STATE);
+        }
+
+        @Override
+        public void onCallStateChanged(int state, String incomingNumber) {
+            if (state == TelephonyManager.CALL_STATE_OFFHOOK) {
+                if (prefs.getBoolean("stop_on_phonecall_preference",
+                        mainapp.getResources().getBoolean(R.bool.prefStopOnPhonecallDefaultValue))) {
+                    Log.d("Engine_Driver", "comm_thread.onCallStateChanged: Phone is OffHook, Stopping Trains");
+                    for (int i = 0; i < mainapp.numThrottles; i++) {
+                        if (mainapp.consists[i].isActive()) {
+                            sendSpeedZero(i);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* ******************************************************************************************** */
+    /* ******************************************************************************************** */
+
+}
+

--- a/EngineDriver/src/main/res/layout/connection.xml
+++ b/EngineDriver/src/main/res/layout/connection.xml
@@ -109,6 +109,46 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/cons_DCCEXconnectionOption_heading"
+        style="?android:attr/listSeparatorTextViewStyle"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/DCCEXconnectionOptionTitle"
+        android:visibility="gone"  />
+
+    <LinearLayout
+        android:id="@+id/cons_DCCEXconnectionOption_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".15"
+        android:background="#00000000"
+        android:orientation="horizontal"
+        android:visibility="gone" >
+
+        <TextView
+            android:id="@+id/cons_DCCEXconnectionOption_Label"
+            style="?attr/floating_text_style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".7"
+            android:padding="8sp"
+            android:text="@string/prefDCCEXSummary" />
+
+        <Spinner
+            android:id="@+id/cons_DCCEXconnectionOption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".3"
+            android:ellipsize="none"
+            android:entries="@array/prefYesNoEntryValues"
+            android:entryValues="@array/prefYesNoEntryValues"
+            android:padding="0dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp" />
+
+    </LinearLayout>
+
+    <TextView
         android:id="@+id/ca_footer"
         style="?attr/floating_text_style"
         android:layout_width="wrap_content"

--- a/EngineDriver/src/main/res/layout/dcc_ex.xml
+++ b/EngineDriver/src/main/res/layout/dcc_ex.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical" >
+
+    <include layout="@layout/toolbar" />
+
+    <TextView
+        style="?android:attr/listSeparatorTextViewStyle"
+        android:text="@string/app_name_dcc_ex" />
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="10dp"
+        android:weightSum="1">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_weight=".9"
+            android:orientation="vertical">
+
+            <TextView
+                style="?attr/floating_text_style"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="1sp"
+                android:text="@string/DCCEXInstructions"
+                android:textSize="12sp" />
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8sp"
+                android:layout_marginBottom="8sp"
+                android:background="#00000000"
+                android:orientation="horizontal"
+                android:weightSum="1">
+
+                <TextView
+                    style="?attr/floating_text_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".5"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXwriteAddressLabel" />
+
+                <EditText
+                    android:id="@+id/dexc_DCCEXwriteAddressValue"
+                    style="?attr/edit_label_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8sp"
+                    android:layout_marginRight="8sp"
+                    android:layout_weight=".2"
+                    android:inputType="number"
+                    android:maxLength="4"
+                    android:paddingRight="8sp"
+                    android:shadowColor="#FFFFFFFF"
+                    android:shadowDx="1"
+                    android:shadowDy="1"
+                    android:shadowRadius="0.3"
+                    android:singleLine="true"
+                    android:text="" />
+
+                <Button
+                    android:id="@+id/dexc_DCCEXreadAddressButton"
+                    style="?attr/ed_small_button_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".15"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXreadAddressButtonLabel" />
+
+                <Button
+                    android:id="@+id/dexc_DCCEXwriteAddressButton"
+                    style="?attr/ed_small_button_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".15"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXwriteAddressButtonLabel" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8sp"
+                android:background="#00000000"
+                android:orientation="horizontal"
+                android:weightSum="1">
+
+                <TextView
+                    style="?attr/floating_text_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".2"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXwriteCvLabel" />
+
+                <EditText
+                    android:id="@+id/dexc_DCCEXcv"
+                    style="?attr/edit_label_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8sp"
+                    android:layout_marginRight="8sp"
+                    android:layout_weight=".15"
+                    android:inputType="number"
+                    android:maxLength="4"
+                    android:shadowColor="#FFFFFFFF"
+                    android:shadowDx="1"
+                    android:shadowDy="1"
+                    android:shadowRadius="0.3"
+                    android:singleLine="true"
+                    android:text="" />
+
+                <TextView
+                    style="?attr/floating_text_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".2"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXwriteCvValueLabel" />
+
+                <EditText
+                    android:id="@+id/dexc_DCCEXcvValue"
+                    style="?attr/edit_label_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8sp"
+                    android:layout_marginRight="8sp"
+                    android:layout_weight=".15"
+                    android:inputType="number"
+                    android:maxLength="4"
+                    android:paddingRight="8sp"
+                    android:shadowColor="#FFFFFFFF"
+                    android:shadowDx="1"
+                    android:shadowDy="1"
+                    android:shadowRadius="0.3"
+                    android:singleLine="true"
+                    android:text="" />
+
+                <Button
+                    android:id="@+id/dexc_DCCEXreadCvButton"
+                    style="?attr/ed_small_button_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".15"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXreadAddressButtonLabel" />
+
+                <Button
+                    android:id="@+id/dexc_DCCEXwriteCvButton"
+                    style="?attr/ed_small_button_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".15"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXwriteAddressButtonLabel" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8sp"
+                android:background="#00000000"
+                android:orientation="horizontal"
+                android:weightSum="1">
+
+                <TextView
+                    style="?attr/floating_text_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".4"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXsendCommandLabel" />
+
+                <EditText
+                    android:id="@+id/dexc_DCCEXsendCommandValue"
+                    style="?attr/edit_label_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8sp"
+                    android:layout_marginRight="8sp"
+                    android:layout_weight=".45"
+                    android:paddingRight="8sp"
+                    android:shadowColor="#FFFFFFFF"
+                    android:shadowDx="1"
+                    android:shadowDy="1"
+                    android:shadowRadius="0.3"
+                    android:singleLine="true"
+                    android:text="" />
+
+                <Button
+                    android:id="@+id/dexc_DCCEXsendCommandButton"
+                    style="?attr/ed_small_button_style"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight=".15"
+                    android:padding="4sp"
+                    android:text="@string/DCCEXsendCommandButtonLabel" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/dexc_DCCEXwriteInfoLabel"
+                style="?attr/floating_text_style"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4sp"
+                android:layout_marginBottom="4sp"
+                android:padding="4sp"
+                android:text="" />
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight=".4">
+
+                <TextView
+                    android:id="@+id/dexc_DCCEXresponsesLabel"
+                    style="?attr/floating_text_style"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8sp"
+                    android:text=""
+                    android:textSize="12sp" />
+
+            </ScrollView>
+
+        </LinearLayout>
+
+        <TableLayout
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_margin="3dp"
+            android:layout_weight=".1"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp">
+
+            <Button
+                android:id="@+id/dcc_ex_button_close"
+                style="?attr/ed_normal_button_style"
+                android:layout_gravity="left"
+                android:text="@string/logviewerClose" />
+
+        </TableLayout>
+
+    </LinearLayout>
+</LinearLayout>

--- a/EngineDriver/src/main/res/layout/dcc_ex.xml
+++ b/EngineDriver/src/main/res/layout/dcc_ex.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical" >
@@ -34,7 +35,6 @@
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8sp"
-                android:layout_marginBottom="8sp"
                 android:background="#00000000"
                 android:orientation="horizontal"
                 android:weightSum="1">
@@ -45,6 +45,8 @@
                     android:layout_height="wrap_content"
                     android:layout_weight=".5"
                     android:padding="4sp"
+                    android:textAlignment="viewEnd"
+                    android:gravity="end"
                     android:text="@string/DCCEXwriteAddressLabel" />
 
                 <EditText
@@ -63,7 +65,8 @@
                     android:shadowDy="1"
                     android:shadowRadius="0.3"
                     android:singleLine="true"
-                    android:text="" />
+                    android:text=""
+                    tools:ignore="RtlHardcoded" />
 
                 <Button
                     android:id="@+id/dexc_DCCEXreadAddressButton"
@@ -97,8 +100,10 @@
                     style="?attr/floating_text_style"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight=".2"
+                    android:layout_weight=".15"
                     android:padding="4sp"
+                    android:textAlignment="viewEnd"
+                    android:gravity="end"
                     android:text="@string/DCCEXwriteCvLabel" />
 
                 <EditText
@@ -108,7 +113,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="8sp"
                     android:layout_marginRight="8sp"
-                    android:layout_weight=".15"
+                    android:layout_weight=".2"
                     android:inputType="number"
                     android:maxLength="4"
                     android:shadowColor="#FFFFFFFF"
@@ -122,8 +127,10 @@
                     style="?attr/floating_text_style"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight=".2"
+                    android:layout_weight=".15"
                     android:padding="4sp"
+                    android:textAlignment="viewEnd"
+                    android:gravity="end"
                     android:text="@string/DCCEXwriteCvValueLabel" />
 
                 <EditText
@@ -133,7 +140,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="8sp"
                     android:layout_marginRight="8sp"
-                    android:layout_weight=".15"
+                    android:layout_weight=".2"
                     android:inputType="number"
                     android:maxLength="4"
                     android:paddingRight="8sp"
@@ -142,7 +149,8 @@
                     android:shadowDy="1"
                     android:shadowRadius="0.3"
                     android:singleLine="true"
-                    android:text="" />
+                    android:text=""
+                    tools:ignore="RtlHardcoded" />
 
                 <Button
                     android:id="@+id/dexc_DCCEXreadCvButton"
@@ -194,7 +202,10 @@
                     android:shadowDy="1"
                     android:shadowRadius="0.3"
                     android:singleLine="true"
-                    android:text="" />
+                    android:text=""
+                    android:inputType="text"
+                    android:maxLength="30"
+                    tools:ignore="RtlHardcoded" />
 
                 <Button
                     android:id="@+id/dexc_DCCEXsendCommandButton"
@@ -214,8 +225,16 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4sp"
                 android:layout_marginBottom="4sp"
+                android:layout_gravity="end"
                 android:padding="4sp"
                 android:text="" />
+
+            <LinearLayout
+                android:id="@+id/separator"
+                android:layout_width="fill_parent"
+                android:layout_height="2dp"
+                android:background="#888888"
+                android:orientation="vertical" />
 
             <ScrollView
                 android:layout_width="match_parent"
@@ -248,7 +267,8 @@
                 android:id="@+id/dcc_ex_button_close"
                 style="?attr/ed_normal_button_style"
                 android:layout_gravity="left"
-                android:text="@string/logviewerClose" />
+                android:text="@string/logviewerClose"
+                tools:ignore="RtlHardcoded" />
 
         </TableLayout>
 

--- a/EngineDriver/src/main/res/layout/device_sounds_settings.xml
+++ b/EngineDriver/src/main/res/layout/device_sounds_settings.xml
@@ -238,8 +238,8 @@
                         android:id="@+id/dss_DeviceSoundsBellIsMomentary_label"
                         style="?attr/floating_text_style"
                         android:layout_width="0dp"
-                        android:layout_weight=".7"
                         android:layout_height="wrap_content"
+                        android:layout_weight=".7"
                         android:padding="8sp"
                         android:text="@string/prefDeviceSoundsBellIsMomentarySummary" />
 

--- a/EngineDriver/src/main/res/layout/select_loco.xml
+++ b/EngineDriver/src/main/res/layout/select_loco.xml
@@ -310,8 +310,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/idngo_help"
             android:layout_centerInParent="true"
-            android:state_enabled="true"
             android:padding="8sp"
+            android:state_enabled="true"
             android:text="@string/idngo_button"
             tools:ignore="RtlHardcoded" />
 

--- a/EngineDriver/src/main/res/menu/routes_menu.xml
+++ b/EngineDriver/src/main/res/menu/routes_menu.xml
@@ -35,6 +35,7 @@
     <item android:id="@+id/turnouts_mnu" android:title="@string/turnouts" />
     <item android:id="@+id/web_mnu" android:title="@string/web" />
     <item android:id="@+id/power_control_mnu" android:title="@string/power" />
+    <item android:id="@+id/dcc_ex_mnu" android:title="@string/app_name_dcc_ex" />
     <item android:id="@+id/settings_mnu" android:title="@string/preferences" />
     <item android:id="@+id/logviewer_menu" android:title="@string/logViewer" />
     <item android:id="@+id/exit_mnu" android:title="@string/exit" />

--- a/EngineDriver/src/main/res/menu/throttle_menu.xml
+++ b/EngineDriver/src/main/res/menu/throttle_menu.xml
@@ -70,6 +70,7 @@
         android:title="@string/web" />
     <item android:id="@+id/power_control_mnu"
         android:title="@string/power" />
+    <item android:id="@+id/dcc_ex_mnu" android:title="@string/app_name_dcc_ex" />
     <item android:id="@+id/settings_mnu"
         android:title="@string/preferences" />
     <item android:id="@+id/timer_mnu"

--- a/EngineDriver/src/main/res/menu/turnouts_menu.xml
+++ b/EngineDriver/src/main/res/menu/turnouts_menu.xml
@@ -39,6 +39,7 @@
     <item android:id="@+id/routes_mnu" android:title="@string/routes" />
     <item android:id="@+id/web_mnu" android:title="@string/web" />
     <item android:id="@+id/power_control_mnu" android:title="@string/power" />
+    <item android:id="@+id/dcc_ex_mnu" android:title="@string/app_name_dcc_ex" />
     <item android:id="@+id/settings_mnu" android:title="@string/preferences" />
     <item android:id="@+id/logviewer_menu" android:title="@string/logViewer" />
     <item android:id="@+id/exit_mnu" android:title="@string/exit" />

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -92,6 +92,8 @@
     <bool name="prefShowTimeOnLogEntryDefaultValue">false</bool>
     <bool name="prefFeedbackOnDisconnectDefaultValue">true</bool>
     <bool name="prefFeedbackWhenGoingToBackgroundDefaultValue">true</bool>
+    <bool name="prefDCCEXDefaultValue">false</bool>
+    <bool name="prefDCCEXconnectionOptionDefaultValue">false</bool>
     <bool name="prefFullScreenSwipeAreaDefaultValue">false</bool>
 
     <bool name="prefKidsTimerEnableReverseDefaultValue">false</bool>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="app_name_throttle_long">Engine Driver - Throttle</string>
     <string name="app_name_throttle_short">Throttle</string>
     <string name="app_name_power_control">Power Control</string>
+    <string name="app_name_dcc_ex">DCC-EX</string>
     <string name="app_name_reconnect_status">Reconnect Status</string>
     <string name="app_name_reconnect_status_long">Engine Driver - Reconnect Status</string>
     <string name="app_name_routes">Routes</string>
@@ -1230,6 +1231,14 @@
     <string name="prefFeedbackWhenGoingToBackgroundTitle">Background Alert</string>
     <string name="prefFeedbackWhenGoingToBackgroundSummary">Audible alert when the app is sent to the background</string>
 
+    <string name="prefDCCEXTitle">Use native DCC-EX commands</string>
+    <string name="prefDCCEXSummary">Use the native DCC-EX &lt;&gt; commands instead of wiThrottle for all connections</string>
+    <string name="usingProtocolDCCEX">Using the DCC-EX protocol.\nUncheck \"Use native DCC-EX commands\" preference to use the wiThrottle protocol.</string>
+
+    <string name="prefDCCEXconnectionOptionTitle">Show protocol option</string>
+    <string name="prefDCCEXconnectionOptionSummary">Show option to switch between wiThrottle and DCC-EX protocols in the Connection Screen</string>
+    <string name="DCCEXconnectionOptionTitle">Connection Protocol</string>
+
     <string name="prefHapticFeedbackTitle">Haptic Feedback (Vibration)</string>
     <string name="prefHapticFeedbackSummary">Haptic feedback (vibrate) on speed changes</string>
     <string name="prefHapticFeedbackDefaultValue" translatable="false">"None"</string>  <!-- DO NOT TRANSLATE -->
@@ -1256,5 +1265,17 @@
 
     <string name="directionIndicatorForward" translatable="false">"▲ "</string>  <!-- DO NOT TRANSLATE -->
     <string name="directionIndicatorReverse" translatable="false">"▼ "</string>  <!-- DO NOT TRANSLATE -->
+
+    <string name="DCCEXInstructions" >"This works on the programming track only!"</string>
+    <string name="DCCEXwriteAddressLabel" >"DCC Address"</string>
+    <string name="DCCEXwriteCvLabel" >"CV"</string>
+    <string name="DCCEXwriteCvValueLabel" >"Value"</string>
+    <string name="DCCEXwriteAddressButtonLabel" >"Write"</string>
+    <string name="DCCEXreadAddressButtonLabel" >"Read"</string>
+    <string name="DCCEXsendCommandButtonLabel" >"Send"</string>
+    <string name="DCCEXsendCommandLabel" >"DCC-EX Command\n(exclude \'&lt;\' &amp; \'&gt;\')"</string>
+
+    <string name="DCCEXSucceeded" >"Succeeded"</string>
+    <string name="DCCEXFailed" >"Failed"</string>
 
 </resources>

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -1768,6 +1768,19 @@
             android:summary="@string/prefFeedbackWhenGoingToBackgroundSummary"
             android:title="@string/prefFeedbackWhenGoingToBackgroundTitle"
             android:layout="@layout/checkbox_no_icon" />
+
+        <CheckBoxPreference
+            android:defaultValue="@bool/prefDCCEXDefaultValue"
+            android:key="prefDCCEX"
+            android:summary="@string/prefDCCEXSummary"
+            android:title="@string/prefDCCEXTitle"
+            android:layout="@layout/checkbox_no_icon" />
+        <CheckBoxPreference
+            android:defaultValue="@bool/prefDCCEXconnectionOptionDefaultValue"
+            android:key="prefDCCEXconnectionOption"
+            android:summary="@string/prefDCCEXconnectionOptionSummary"
+            android:title="@string/prefDCCEXconnectionOptionTitle"
+            android:layout="@layout/checkbox_no_icon" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Optional use the DCC-EX commands rather then wiThrottle.  
And also allo CV programming on the programming track (in DCC-EX only).

comm_handler and comm_thread have been split out of T_A.
95% of the changes are in comm_thread.  The changes effectively act as a translator from DCC-EX to wiThrottle.

Instructions for use
- Enable the new preference in the "Connect Preference" group - "Use native DCC-EX commands"
- If you use other manufaturer's DCC systems, also enable the preference below it - "Show protocol option".  Enabling this will show a yes/no question at the bottom of the connection screen to allow you to switch between the wiThrottle and DCC-EX protocols easily

Only if you connect via the DCC-EX protocol... A new menu option will appear ("DCC-EX") after you connect, which allows CV programming on the programming track

