### PR TITLE
Option to allow the server to return the function labels of non-roster locos

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -1354,6 +1354,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                         mainapp.prefHapticFeedbackButtons = prefs.getBoolean("prefHapticFeedbackButtons", getResources().getBoolean(R.bool.prefHapticFeedbackButtonsDefaultValue));
                         break;
 
+                    case "prefAlwaysUseFunctionsFromServer":
+                        parentActivity.mainapp.prefAlwaysUseFunctionsFromServer = sharedPreferences.getBoolean("prefAlwaysUseFunctionsFromServer",
+                                getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
+                        break;
+
                 }
             }
         }
@@ -1912,11 +1917,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     case "prefSwitchingThrottleSliderDeadZone":
                         parentActivity.forceRestartAppOnPreferencesCloseReason = parentActivity.mainapp.FORCED_RESTART_REASON_DEAD_ZONE;
                         parentActivity.forceRestartAppOnPreferencesClose = true;
-                        break;
-
-                    case "prefDCCEXUseFunctionsOfLocosFoundInRoster":
-                        parentActivity.mainapp.prefDCCEXUseFunctionsOfLocosFoundInRoster = sharedPreferences.getBoolean("prefDCCEXUseFunctionsOfLocosFoundInRoster",
-                                getResources().getBoolean(R.bool.prefDCCEXUseFunctionsOfLocosFoundInRosterDefaultValue));
                         break;
 
                 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -127,7 +127,7 @@ public class connection_activity extends AppCompatActivity implements Permission
 
     boolean prefAllowMobileData = false;
     boolean prefDCCEXconnectionOption = false;
-    boolean prefDCCEXUseFunctionsOfLocosFoundInRoster = false;
+    boolean prefAlwaysUseFunctionsFromServer = false;
     Spinner DCCEXconnectionOptionSpinner;
 
     private Toolbar toolbar;

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -195,7 +195,7 @@ public class threaded_application extends Application {
     public HashMap<String, String> knownDCCEXserverIps = new HashMap<>();
     public boolean isDCCEX = false;  // is a DCC-EX EX-CommandStation
     public boolean prefDCCEX = false;
-    public boolean prefDCCEXUseFunctionsOfLocosFoundInRoster = false;
+    public boolean prefAlwaysUseFunctionsFromServer = false;
     public String DCCEXversion = "";
     public int DCCEXlistsRequested = -1;  // -1=not requested  0=requested  1,2,3= no. of lists received
 
@@ -1004,7 +1004,7 @@ public class threaded_application extends Application {
         rt_state_names = null;
 
         prefDCCEX = prefs.getBoolean("prefDCCEX", mainapp.getResources().getBoolean(R.bool.prefDCCEXDefaultValue));
-        prefDCCEXUseFunctionsOfLocosFoundInRoster = prefs.getBoolean("prefDCCEXUseFunctionsOfLocosFoundInRoster", mainapp.getResources().getBoolean(R.bool.prefDCCEXUseFunctionsOfLocosFoundInRosterDefaultValue));
+        prefAlwaysUseFunctionsFromServer = prefs.getBoolean("prefAlwaysUseFunctionsFromServer", mainapp.getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
         mainapp.isDCCEX = prefDCCEX;
 
         DCCEXversion = "";

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
@@ -99,7 +99,7 @@ public class comm_thread extends Thread {
         prefs = myPrefs;
 
         mainapp.prefDCCEX = prefs.getBoolean("prefDCCEX", mainapp.getResources().getBoolean(R.bool.prefDCCEXDefaultValue));
-        mainapp.prefDCCEXUseFunctionsOfLocosFoundInRoster = prefs.getBoolean("prefDCCEXUseFunctionsOfLocosFoundInRoster", mainapp.getResources().getBoolean(R.bool.prefDCCEXUseFunctionsOfLocosFoundInRosterDefaultValue));
+        mainapp.prefAlwaysUseFunctionsFromServer = prefs.getBoolean("prefAlwaysUseFunctionsFromServer", mainapp.getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
         LATCHING_DEFAULT = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValue); // can change with language
 
         this.start();
@@ -950,7 +950,7 @@ public class comm_thread extends Thread {
 
                     } else if (com2 == 'L') { //list of function buttons
                         if ( (mainapp.consists[whichThrottle].isLeadFromRoster())  // if not from the roster ignore the function labels that WiT has sent back
-                        || (mainapp.prefDCCEXUseFunctionsOfLocosFoundInRoster) ) { // unless overidden by the preference
+                        || (mainapp.prefAlwaysUseFunctionsFromServer) ) { // unless overidden by the preference
                             String lead;
                             lead = mainapp.consists[whichThrottle].getLeadAddr();
                             if (lead.equals(addr)) {                        //*** temp - only process if for lead engine in consist

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -108,6 +108,6 @@
 
     <bool name="prefActionBarShowServerDescriptionDefaultValue">false</bool>
     <bool name="prefActionBarShowDccExButtonDefaultValue">false</bool>
-    <bool name="prefDCCEXUseFunctionsOfLocosFoundInRosterDefaultValue">false</bool>
+    <bool name="prefAlwaysUseFunctionsFromServerDefaultValue">false</bool>
 
 </resources>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1244,8 +1244,8 @@
     <string name="prefDCCEXTitle">Use native DCC-EX commands</string>
     <string name="prefDCCEXSummary">Use the native DCC-EX &lt;&gt; commands instead of WiThrottle for all connections.\nNote: Will not take effect until you restart Engine Driver and connect to a server.</string>
 
-    <string name="prefDCCEXUseFunctionsOfLocosFoundInRosterTitle">Allow Roster address matching</string>
-    <string name="prefDCCEXUseFunctionsOfLocosFoundInRosterSummary">If enabled, functions of the first found matching roster entry for an \'entered\' loco address will be used. Only if no loco matches will it use the default funtions. MANDATORY if you have a \'default\' roster entry in the EX-CS</string>
+    <string name="prefAlwaysUseFunctionsFromServerTitle">Always use function labels from server</string>
+    <string name="prefAlwaysUseFunctionsFromServerSummary">If enabled, functions of the first found matching roster entry for an \'entered\' loco address will be used. Only if no loco matches will it use the default funtions. REQUIRED if you have a \'default\' roster entry in the EX-CS</string>
 
     <string name="useProtocolDCCEX">Use native DCC-EX commands (not WiThrottle)</string>
     <string name="usingProtocolDCCEX">Using the DCC-EX protocol.\nUncheck \"Use native DCC-EX commands\" preference to use the WiThrottle protocol.</string>

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -1593,6 +1593,14 @@
             android:summary="@string/prefRosterFilterSummary"
             android:title="@string/prefRosterFilterTitle"
             android:layout="@layout/checkbox_no_icon" />
+
+        <CheckBoxPreference
+            android:defaultValue="@bool/prefAlwaysUseFunctionsFromServerDefaultValue"
+            android:key="prefAlwaysUseFunctionsFromServer"
+            android:summary="@string/prefAlwaysUseFunctionsFromServerSummary"
+            android:title="@string/prefAlwaysUseFunctionsFromServerTitle"
+            android:layout="@layout/checkbox_no_icon" />
+
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -1807,12 +1815,6 @@
                     android:key="prefDCCEXconnectionOption"
                     android:summary="@string/prefDCCEXconnectionOptionSummary"
                     android:title="@string/prefDCCEXconnectionOptionTitle"
-                    android:layout="@layout/checkbox_no_icon" />
-                <CheckBoxPreference
-                    android:defaultValue="@bool/prefDCCEXUseFunctionsOfLocosFoundInRosterDefaultValue"
-                    android:key="prefDCCEXUseFunctionsOfLocosFoundInRoster"
-                    android:summary="@string/prefDCCEXUseFunctionsOfLocosFoundInRosterSummary"
-                    android:title="@string/prefDCCEXUseFunctionsOfLocosFoundInRosterTitle"
                     android:layout="@layout/checkbox_no_icon" />
 
             </PreferenceCategory>


### PR DESCRIPTION
* option to allow the server to return the function labels of non-roster locos
 * For DCC-EX, allow overriding of the default latching behaviour of all/any functions