### PR TITLE
prefAlwaysUseFunctionsFromServer - Fixes

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
@@ -141,7 +141,7 @@ public class Loco {
         return this.isServerSuppliedFunctionLabels;
     }
     public void setIsServerSuppliedFunctionlabels(boolean isFromRoster) {
-        this.isServerSuppliedFunctionLabels = isServerSuppliedFunctionLabels;
+        this.isServerSuppliedFunctionLabels = isFromRoster;
     }
 
     //provide description if present, otherwise provide formatted address

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -6466,14 +6466,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 // while we are using it (causing issues during button update below)
                 function_labels_temp = mainapp.function_labels_default;
                 if (!mainapp.prefAlwaysUseDefaultFunctionLabels) { //avoid npe
-                    if (mainapp.function_labels != null
-                            && mainapp.function_labels[whichThrottle] != null
-                            && mainapp.function_labels[whichThrottle].size() > 0) {
-                        function_labels_temp = new LinkedHashMap<>(mainapp.function_labels[whichThrottle]);
+                    if (mainapp.function_labels != null ) {
+                        if ( mainapp.function_labels[whichThrottle] != null
+                        && mainapp.function_labels[whichThrottle].size() > 0) {
+                            function_labels_temp = new LinkedHashMap<>(mainapp.function_labels[whichThrottle]);
+                        } else { // roster function list is deliberately empty
+                            if (mainapp.consists[whichThrottle].isLeadFromRoster()
+                             && mainapp.consists[whichThrottle].isLeadServerSuppliedFunctionLabels()) {
+                                function_labels_temp = new LinkedHashMap<>(mainapp.function_labels[whichThrottle]);
+                            }
+                        }
                     } else {
                         if (mainapp.consists != null) {  //avoid npe maybe
-                            if (mainapp.consists[whichThrottle] != null && !mainapp.consists[whichThrottle].isLeadFromRoster()
-                                    && !mainapp.consists[whichThrottle].isLeadServerSuppliedFunctionLabels() ) {
+                            if (mainapp.consists[whichThrottle] != null
+                            && !mainapp.consists[whichThrottle].isLeadFromRoster()) {
                                 function_labels_temp = mainapp.function_labels_default;
                             } else {
                                 function_labels_temp = mainapp.function_labels_default_for_roster;

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
@@ -955,9 +955,7 @@ public class comm_thread extends Thread {
                             lead = mainapp.consists[whichThrottle].getLeadAddr();
                             if (lead.equals(addr)) {                        //*** temp - only process if for lead engine in consist
                                 processRosterFunctionString("RF29}|{1234(L)" + ls[1], whichThrottle);  //prepend some stuff to match old-style
-                                if (!mainapp.consists[whichThrottle].isLeadFromRoster()) {
-                                    mainapp.consists[whichThrottle].getLoco(lead).setIsServerSuppliedFunctionlabels(true);
-                                }
+                                mainapp.consists[whichThrottle].getLoco(lead).setIsServerSuppliedFunctionlabels(true);
                             }
                             mainapp.consists[whichThrottle].setFunctionLabels(addr, "RF29}|{1234(L)" + ls[1], mainapp);
                         }


### PR DESCRIPTION
prefAlwaysUseFunctionsFromServer did not work correctly in some circumstances, particularly (but not only) when the roster entry had all blank function labels.