### PR TITLE
Additional option for the Consist Follow Function feature

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jmri.enginedriver"
     android:versionCode="172"
-    android:versionName="2.35.172" android:installLocation="auto">
+    android:versionName="2.35.172a" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />

--- a/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/Loco.java
@@ -52,9 +52,10 @@ public class Loco {
     private static final String CONSIST_FUNCTION_ACTION_SAME_F_NUMBER_TRAIL = "f trail";
 
 //    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY = "specialPartialContainsOnly";
 
     public Loco(String address) {
         if (address != null)
@@ -218,7 +219,7 @@ public class Loco {
         List<Integer> functionList = new ArrayList<>();
         Integer matchingRule = -1;
 
-        if (prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) {
+        if (prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) {
             // work out if/which rule the activated function matches
             for (int i = 0; i < prefConsistFollowStrings.size(); i++) {
 //            if (searchLabel.toLowerCase().contains(prefConsistFollowStrings.get(i).toLowerCase())) {
@@ -287,7 +288,7 @@ public class Loco {
 
         } else {   // Special - Partial or Exact
 
-            String sl = searchLabel.toLowerCase();
+            String sl = searchLabel.toLowerCase().trim();
             if (functionLabels != null) {
                 // cycle through this locos function labels to find the exactly matching string
                 for (int i = 0; i <= functionLabelsMaxKey; i++) {
@@ -318,14 +319,20 @@ public class Loco {
                         }
 
                         if (processThis) {
-                            String fl = functionLabels.get(i).toLowerCase();
-                            if (prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT)) {
+                            String fl = functionLabels.get(i).toLowerCase().trim();
+                            if (prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT)) {
                                 if (fl.equals(sl)) {
                                     functionList.add(i);
                                 }
                             } else {
-                                if ((fl.contains(sl)) || (sl.contains(fl))) {
-                                    functionList.add(i);
+                                if (prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)) {
+                                    if ((fl.contains(sl)) || (sl.contains(fl))) {
+                                        functionList.add(i);
+                                    }
+                                } else {
+                                    if ((fl.contains(sl))) {
+                                        functionList.add(i);
+                                    }
                                 }
                             }
                         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -138,10 +138,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     protected boolean prefHideSlider = false;
 
     private String prefConsistFollowRuleStyle = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY = "specialPartialContainsOnly";
 
     private boolean ignoreThisThrottleNumChange = false;
 
@@ -1035,7 +1036,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     private void showHideConsistRuleStylePreferences(PreferenceScreen prefScreen) {
         boolean enable = false;
-        if (prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
+        if (prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
             enable = true;
         }
 
@@ -1044,7 +1045,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         enableDisablePreference(prefScreen, "SelectiveLeadSoundF2", enable);
 
         enable = false;
-        if (prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) {
+        if (prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) {
             enable = true;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
@@ -71,10 +71,11 @@ public class function_consist_settings extends AppCompatActivity implements Perm
     private static String[] LATCHING = {"latching", "none"};
 
     boolean isSpecial = false;
-    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY = "specialPartialContainsOnly";
 
     SharedPreferences prefs;
 
@@ -122,8 +123,9 @@ public class function_consist_settings extends AppCompatActivity implements Perm
         mainapp.function_consist_settings_msg_handler = new function_consist_settings_handler();
 
         if ( (mainapp.prefAlwaysUseDefaultFunctionLabels)
-                && ( (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
-                || (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)) ) ) {
+                && ( (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                    || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                    || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY)) ) ) {
             isSpecial = true;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -338,10 +338,11 @@ public class threaded_application extends Application {
 
     public boolean prefAlwaysUseDefaultFunctionLabels = false;
     public String prefConsistFollowRuleStyle = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
+    public static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
+    public static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
     public static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
     public static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+    public static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY = "specialPartialContainsOnly";
 
     public boolean prefShowTimeOnLogEntry = false;
     public boolean prefFeedbackOnDisconnect = true;

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -290,10 +290,11 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private static final int BUTTON_PRESS_MESSAGE_UP = 0;
     private static final int BUTTON_PRESS_MESSAGE_DOWN = 1;
 
-    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
-    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_ORIGINAL = "original";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_COMPLEX = "complex";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT = "specialExact";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL = "specialPartial";
+//    private static final String CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY = "specialPartialContainsOnly";
 
     private static final String CONSIST_FUNCTION_ACTION_LEAD = "lead";
     private static final String CONSIST_FUNCTION_ACTION_LEAD_AND_TRAIL = "lead and trail";
@@ -1053,7 +1054,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
                                             String loco = ls[0].substring(3);
                                             Consist con = mainapp.consists[whichThrottle];
-                                            if ( (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_ORIGINAL))
+                                            if ( (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_ORIGINAL))
                                                     || (loco.equals(con.getLeadAddr())) ) { //if using the 'complex' follow function rules, only send it to the lead loco
                                                 set_function_state(whichThrottle, function);
                                             }
@@ -2390,8 +2391,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         Consist con = mainapp.consists[whichThrottle];
 
         if ( ( (mainapp.prefAlwaysUseDefaultFunctionLabels)
-                && ( (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
-                    || (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)) ) )
+                && ( (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                    || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                    || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY))  ) )
                 || (mainapp.isDCCEX)
         ) {
             int doPress = -1;
@@ -2405,9 +2407,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     doPress = 2; //up
                 }
             } else { //latching
+                isLatching = FUNCTION_CONSIST_LATCHING_YES;
                 if (!downPress) { //only process the release
                     doPress = 0;
-                    isLatching = FUNCTION_CONSIST_LATCHING_YES;
                 }
             }
 
@@ -4645,7 +4647,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         boolean trail = false;
         boolean followLeadFunction = false;
 
-        if (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
+        if (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
             if (!lab.equals("")) {
                 lead = (prefSelectiveLeadSound &&
                         (lab.contains(FUNCTION_BUTTON_LOOK_FOR_WHISTLE) || lab.contains(FUNCTION_BUTTON_LOOK_FOR_HORN) || lab.contains(FUNCTION_BUTTON_LOOK_FOR_BELL))
@@ -4676,16 +4678,17 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         con = mainapp.consists[whichThrottle];
 
         String tempPrefConsistFollowRuleStyle = mainapp.prefConsistFollowRuleStyle;
-        if ( ( (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_COMPLEX))
-            || (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
-            || (!mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)) )
+        if ( ( (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_COMPLEX))
+                || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY))  )
             && (con.size()==1)
             && (!mainapp.prefAlwaysUseDefaultFunctionLabels)
         ) {
-                tempPrefConsistFollowRuleStyle = CONSIST_FUNCTION_RULE_STYLE_ORIGINAL;
+                tempPrefConsistFollowRuleStyle = mainapp.CONSIST_FUNCTION_RULE_STYLE_ORIGINAL;
         }
 
-        if (tempPrefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
+        if (tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_ORIGINAL)) {
 
             String addr = "";
             if (leadOnly)
@@ -4713,7 +4716,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         } else {  //Complex or SpecialExact or SpecialPartial
 
-            if (tempPrefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) { // if Complex, always activate the lead loco
+            if (tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_COMPLEX)) { // if Complex, always activate the lead loco
                 if (buttonPressMessageType == BUTTON_PRESS_MESSAGE_TOGGLE) {
                     mainapp.toggleFunction(mainapp.throttleIntToString(whichThrottle) + con.getLeadAddr(), function);
                 } else {
@@ -4727,8 +4730,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             for (Consist.ConLoco l : con.getLocos()) {
                 boolean processThisLoco = true;
                 if ((l.getAddress().equals(con.getLeadAddr()))
-                        && (!tempPrefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
-                        && (!tempPrefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                        && (!tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                        && (!tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                        && (!tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY))
                         && (!mainapp.prefAlwaysUseDefaultFunctionLabels)
                 ) {  // for complex ignore the lead as we have already set it
                     processThisLoco = false;
@@ -4742,7 +4746,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                             mainapp);
                     if (functionList.size()>0) {
                         for (int i = 0; i < functionList.size(); i++) {
-                            if ( (tempPrefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_COMPLEX))
+                            if ( (tempPrefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_COMPLEX))
                                 || (isLatching == FUNCTION_CONSIST_LATCHING_NA) ) {
                                 if (buttonPressMessageType == BUTTON_PRESS_MESSAGE_TOGGLE) {
                                     mainapp.toggleFunction(mainapp.throttleIntToString(whichThrottle) + l.getAddress(), functionList.get(i));
@@ -6259,8 +6263,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
             boolean isSpecial = false;
             if ( (mainapp.prefAlwaysUseDefaultFunctionLabels)
-                    && ( (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
-                    || (mainapp.prefConsistFollowRuleStyle.equals(CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL)) ) ) {
+                    && ( (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_EXACT))
+                        || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL))
+                        || (mainapp.prefConsistFollowRuleStyle.equals(mainapp.CONSIST_FUNCTION_RULE_STYLE_SPECIAL_PARTIAL_CONTAINS_ONLY))   ) ) {
                 isSpecial = true;
             }
             TMenu.findItem(R.id.function_consist_settings_mnu).setVisible(isSpecial || mainapp.isDCCEX);

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
@@ -59,7 +59,7 @@ public class comm_handler extends Handler {
          //Start or Stop jmdns stuff, or add "fake" discovered servers
          case message_type.SET_LISTENER:
             if (mainapp.client_ssid != null &&
-                    mainapp.client_ssid.matches("DCCEX_[0-9a-f]{6}$")) {
+                    mainapp.client_ssid.matches("DCCEX_[0-9a-fA-F]{6}$")) {
                //add "fake" discovered server entry for DCCEX: DCCEX_123abc
                commThread.addFakeDiscoveredServer(mainapp.client_ssid, mainapp.client_address, "2560", "DCC-EX");
                mainapp.isDCCEX = mainapp.prefDCCEX;

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_thread.java
@@ -1139,8 +1139,10 @@ public class comm_thread extends Thread {
                         mainapp.alert_activities(message_type.DCCEX_RESPONSE, responseStr);
                     }
 
+                    // remove any escaped double quotes
+                    String s = responseStr.replace("\\\"", "'");
                     //split on spaces, with stuff between doublequotes treated as one item
-                    String[] args = responseStr.substring(1, responseStr.length() - 1).split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", 999);
+                    String[] args = s.substring(1, responseStr.length() - 1).split(" (?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", 999);
 
                     switch (responseStr.charAt(1)) {
                         case 'i': // Command Station Information
@@ -1403,15 +1405,11 @@ public class comm_thread extends Thread {
         }
     } // end processDCCEXlocos()
 
-    //handle the two different <jR> replies:
-    //   <jR [id1 id2 id3 …]>
-    //   <jR id ˮˮ|ˮdescˮ ˮˮ|ˮfunct1/funct2/funct3/…ˮ>
     private static boolean processDCCEXroster(String [] args) {
         boolean skipAlert = true;
 
         if ( (args!=null) && (args.length>1)) {
             if ( (args.length<3) || (args[2].charAt(0) != '"') ) {  // loco list
-                //   <jR [id1 id2 id3 …]>
                 if (mainapp.rosterStringDCCEX.equals("")) {
                     mainapp.rosterStringDCCEX = "";
                     mainapp.rosterIDsDCCEX = new int[args.length - 1];
@@ -1419,17 +1417,12 @@ public class comm_thread extends Thread {
                     mainapp.rosterLocoFunctionsDCCEX = new String[args.length - 1];
                     mainapp.rosterDetailsReceivedDCCEX = new boolean[args.length - 1];
                     for (int i = 0; i < args.length - 1; i++) { // first will be blank
-                        try {
-                            mainapp.rosterIDsDCCEX[i] = Integer.parseInt(args[i + 1]);
-                            wifiSend("<JR " + args[i + 1] + ">");  //request the details for this entry
-                        } catch (NumberFormatException e) {
-                            Log.e("Engine_Driver","processDCCEXroster parse error: " + e.getMessage());
-                        }
+                        mainapp.rosterIDsDCCEX[i] = Integer.parseInt(args[i + 1]);
                         mainapp.rosterDetailsReceivedDCCEX[i] = false;
+                        wifiSend("<JR " + args[i + 1] + ">");
                     }
                 }
             } else {  // individual loco
-                //   <jR id ˮˮ|ˮdescˮ ˮˮ|ˮfunct1/funct2/funct3/…ˮ>
                 if (mainapp.DCCEXlistsRequested < 3) {
                     if (mainapp.rosterIDsDCCEX != null) {
                         for (int i = 0; i < mainapp.rosterIDsDCCEX.length; i++) {

--- a/EngineDriver/src/main/res/values-ca/arrays.xml
+++ b/EngineDriver/src/main/res/values-ca/arrays.xml
@@ -188,6 +188,7 @@
         <item>Text complex coincident - Locomotora capdavantera sempre acticada, Trail segueix les regles següents</item>
         <item>Especial exacta - Capdavantera i tota la resta activat si coincideixen exactament les etiquetes de funció</item>
         <item>Especial Parcial - Capdavantera i tota la resta activat si coincideixen parcialment les etiquetes de funció</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Locomotora capdavantera - Coincidència parcial</item>

--- a/EngineDriver/src/main/res/values-cs/arrays.xml
+++ b/EngineDriver/src/main/res/values-cs/arrays.xml
@@ -404,6 +404,7 @@
         <item>Komplex textu shoda - Lead loco aktivován vždy, Trail řídí pravidly níže</item>
         <item>Speciální Exact - Olovo a All Trail aktivován v případě, že přesně shodovat s popisky funkčních</item>
         <item>Zvláštní Částečné - Olovo a All Trail aktivován v případě, že částečně odpovídat štítkům funkce</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-de/arrays.xml
+++ b/EngineDriver/src/main/res/values-de/arrays.xml
@@ -188,6 +188,7 @@
         <item>Komplexe Textabgleich - Lead Lok immer dann aktiviert, folgt Trail Regeln unten</item>
         <item>Besondere Exact - Lead and All Trail aktiviert, wenn sie genau die Funktion Etiketten entsprechen</item>
         <item>Spezielles Teil - Blei und alle Trail aktiviert, wenn sie teilweise die Funktion Etiketten entsprechen</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-es/arrays.xml
+++ b/EngineDriver/src/main/res/values-es/arrays.xml
@@ -188,6 +188,7 @@
         <item>Complejo texto coincidente - loco plomo siempre activado, Trail sigue las reglas siguientes</item>
         <item>Especial exacta - El plomo y el Camino para activarse si coinciden exactamente las etiquetas de función</item>
         <item>Especial Parcial - Plomo y Camino para activarse si coinciden parcialmente las etiquetas de función</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Locomotora delantera - Coincidencia parcial</item>

--- a/EngineDriver/src/main/res/values-fr/arrays.xml
+++ b/EngineDriver/src/main/res/values-fr/arrays.xml
@@ -198,6 +198,7 @@
         <item>Correspondance exacte du texte - loco de tete toujours active, les autres locos suivent les règles suivantes</item>
         <item>Correspondance complete - Fonctions appliquees a toutes les locos en cas de correspondance exacte des libelles</item>
         <item>Correspondance partielle - Fonctions appliquees a toutes les locos en cas de correspondance partielle des libelles</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-it/arrays.xml
+++ b/EngineDriver/src/main/res/values-it/arrays.xml
@@ -207,6 +207,7 @@
         <item>testo complesso di corrispondenza - Loco di piombo sempre attivato, Sentiero segue le regole qui sotto</item>
         <item>Speciale esatta - Piombo e All Trail attivato se corrispondono esattamente le etichette delle funzioni</item>
         <item>Speciale parziale - Piombo e All Trail attivati ​​se in parte corrispondono alle etichette di funzione</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Lead Loco - Partial Part</item>

--- a/EngineDriver/src/main/res/values-pt/arrays.xml
+++ b/EngineDriver/src/main/res/values-pt/arrays.xml
@@ -205,6 +205,7 @@
         <item>Complexo de correspondência de texto - loco Chumbo sempre activado, Trail segue as regras abaixo</item>
         <item>Especial Exact - Chumbo e Tudo Trail activado se eles correspondem exactamente às etiquetas de função</item>
         <item>Especial Parcial - Chumbo e Tudo Trail ativado se eles correspondem parcialmente os rótulos de função</item>
+        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -1548,12 +1548,14 @@
         <item>complex</item>
         <item>specialExact</item>
         <item>specialPartial</item>
+        <item>specialPartialContainsOnly</item>
     </string-array>
     <string-array name="prefConsistFollowRuleStyleEntries">  <!-- display version -->
         <item>Simple text matching (original)</item>
-        <item>Complex text matching - Lead loco always activated, Trail follows rules below</item>
-        <item>Special Exact - Lead and All Trail activated if they exactly match the function labels</item>
-        <item>Special Partial - Lead and All Trail activated if they partially match the function labels</item>
+        <item>Complex text matching - Lead loco always activated, Trail follows preference rules below</item>
+        <item>Special Exact - Activated if the roster function label EXACTLY MATCHES the Default Label</item>
+        <item>Special Partial - Activated if the roster function label CONTAINS Default Label or vice-versa</item>
+        <item>Special Partial Contains Only - Activated if the roster function label CONTAINS Default Label</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntryValues" translatable="false">  <!-- DO NOT TRANSLATE -->

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1007,8 +1007,8 @@
     <string name="ConsistEditLabelLead">LEAD</string>
     <string name="ConsistEditLabelTrail">TRAIL</string>
 
-    <string name="prefConsistFollowRuleStyleTitle">Consist Functions - Follow Rule Style</string>
-    <string name="prefConsistFollowRuleStyleSummary" tools:ignore="TypographyEllipsis">Which style of rules to follow in a consist when function buttons are pressed.\nNote: If \'Use Default function labels\' is enabled, \'Special...\' will also apply to the lead (or only) loco.</string>
+    <string name="prefConsistFollowRuleStyleTitle">Consist &amp; Default Functions - Follow Rule Style</string>
+    <string name="prefConsistFollowRuleStyleSummary" tools:ignore="TypographyEllipsis">Which style of rules to follow when function buttons are pressed in either a) a consist , b) when enforcing the Default Function labels.\nNote: If \'Use Default function labels\' is enabled, \'Special...\' will also apply to the lead (or only) loco.</string>
     <string name="prefConsistFollowRuleStyleDefaultValue" translatable="false">original</string>  <!-- DO NOT TRANSLATE -->
 
     <string name="prefConsistFollowTitle">Consist Function Follow Preferences</string>


### PR DESCRIPTION
+ Additional option for the Consist Follow Function feature
+ bug fix in the Consist Follow Function feature
+ support for uppercase MAC addresses for DCC-EX ESP32

Additional option for the Consist Follow Function feature
- Special Partial Contains Only - Activated if the roster function label CONTAINS Default Label

Added because the existing 'Partial' option is a bidirectional contains check.  The new option is only one direction.
