### PR TITLE
Added preference to hide Instructional/Help toast popups

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -21,6 +21,7 @@
     <li>Remove check for legacy files</li>
     <li>Permission changes to support API level 33</li>
     <li>Added close buttons to the Consist Edit and Consist Light Edit screens</li>
+    <li>* Added preference to hide Instructional/Help Toast popups</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/ConsistEdit.java
@@ -294,7 +294,9 @@ public class ConsistEdit extends AppCompatActivity implements OnGestureListener 
         result = RESULT_OK;
 
         if (!mainapp.shownToastConsistEdit) {
-            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConsistEditHelp), Toast.LENGTH_LONG).show();
+            if (!mainapp.prefHideInstructionalToasts) {
+                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConsistEditHelp), Toast.LENGTH_LONG).show();
+            }
             mainapp.shownToastConsistEdit = true;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -1915,6 +1915,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                                 getResources().getBoolean(R.bool.prefShowTimeOnLogEntryDefaultValue));
                         break;
 
+                    case "prefHideInstructionalToasts":
+                        parentActivity.mainapp.prefHideInstructionalToasts = sharedPreferences.getBoolean("prefHideInstructionalToasts",
+                                getResources().getBoolean(R.bool.prefHideInstructionalToastsDefaultValue));
+                        break;
+
                     case "prefSwitchingThrottleSliderDeadZone":
                         parentActivity.forceRestartAppOnPreferencesCloseReason = parentActivity.mainapp.FORCED_RESTART_REASON_DEAD_ZONE;
                         parentActivity.forceRestartAppOnPreferencesClose = true;

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -276,7 +276,9 @@ public class connection_activity extends AppCompatActivity implements Permission
                 connected_hostname = connected_hostip; //copy ip to name
                 connect();
             } else {
-                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectEnterAddress), Toast.LENGTH_SHORT).show();
+                if (!mainapp.prefHideInstructionalToasts) {
+                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectEnterAddress), Toast.LENGTH_SHORT).show();
+                }
             }
             mainapp.buttonVibration();
         }
@@ -304,7 +306,9 @@ public class connection_activity extends AppCompatActivity implements Permission
 
                 @Override
                 public void onAnimationEnd(Animation animation) {
-                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectRemoved), Toast.LENGTH_SHORT).show();
+                    if (!mainapp.prefHideInstructionalToasts) {
+                        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectRemoved), Toast.LENGTH_SHORT).show();
+                    }
 //                        new saveConnectionsList().execute();
                     importExportConnectionList.saveConnectionsListExecute(mainapp, connected_hostip, connected_hostname, connected_port, "");
                 }
@@ -343,7 +347,9 @@ public class connection_activity extends AppCompatActivity implements Permission
                     connect();
                     Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectConnected, connected_hostname, Integer.toString(connected_port)), Toast.LENGTH_LONG).show();
                 } else {
-                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectEnterAddress), Toast.LENGTH_SHORT).show();
+                    if (!mainapp.prefHideInstructionalToasts) {
+                        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectEnterAddress), Toast.LENGTH_SHORT).show();
+                    }
                 }
             }
         } catch (Exception ex) {
@@ -942,7 +948,9 @@ public class connection_activity extends AppCompatActivity implements Permission
                     if (((importExportConnectionList.foundDemoHost)
                             && (importExportConnectionList.connections_list.size() > 1)) || (importExportConnectionList.connections_list.size() > 0)) {
                         // use connToast so onPause can cancel toast if connection is made
-                        connToast.setText(threaded_application.context.getResources().getString(R.string.toastConnectionsListHelp));
+                        if (!mainapp.prefHideInstructionalToasts) {
+                            connToast.setText(threaded_application.context.getResources().getString(R.string.toastConnectionsListHelp));
+                        }
                         connToast.show();
                     }
                 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -1497,7 +1497,9 @@ public class select_loco extends AppCompatActivity {
                 rbRecentConsists.setChecked(false);
                 rbIDnGo.setChecked(false);
                 if (!mainapp.shownToastRoster) {
-                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRosterHelp), Toast.LENGTH_LONG).show();
+                    if (!mainapp.prefHideInstructionalToasts) {
+                        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRosterHelp), Toast.LENGTH_LONG).show();
+                    }
                     mainapp.shownToastRoster = true;
                 }
 
@@ -1522,7 +1524,9 @@ public class select_loco extends AppCompatActivity {
                 rbRecentConsists.setChecked(false);
                 rbIDnGo.setChecked(false);
                 if (!mainapp.shownToastRecentLocos) {
-                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentsHelp), Toast.LENGTH_LONG).show();
+                    if (!mainapp.prefHideInstructionalToasts) {
+                        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentsHelp), Toast.LENGTH_LONG).show();
+                    }
                     mainapp.shownToastRecentLocos = true;
                 }
 
@@ -1547,7 +1551,9 @@ public class select_loco extends AppCompatActivity {
                 rbRecentConsists.setChecked(true);
                 rbIDnGo.setChecked(false);
                 if (!mainapp.shownToastRecentConsists) {
-                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentConsistsHelp), Toast.LENGTH_LONG).show();
+                    if (!mainapp.prefHideInstructionalToasts) {
+                        Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentConsistsHelp), Toast.LENGTH_LONG).show();
+                    }
                     mainapp.shownToastRecentConsists = true;
                 }
 
@@ -1891,7 +1897,9 @@ public class select_loco extends AppCompatActivity {
                 recent_engine_list.remove(position);
                 saveRecentLocosList(true);
                 engine_list_view.invalidateViews();
-                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentCleared), Toast.LENGTH_SHORT).show();
+                if (!mainapp.prefHideInstructionalToasts) {
+                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentCleared), Toast.LENGTH_SHORT).show();
+                }
             }
 
             @Override
@@ -1934,7 +1942,9 @@ public class select_loco extends AppCompatActivity {
                 recent_consists_list.remove(position);
                 updateRecentConsists(true);
                 consists_list_view.invalidateViews();
-                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentConsistCleared), Toast.LENGTH_SHORT).show();
+                if (!mainapp.prefHideInstructionalToasts) {
+                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastRecentConsistCleared), Toast.LENGTH_SHORT).show();
+                }
             }
 
             @Override

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -358,6 +358,7 @@ public class threaded_application extends Application {
     public static final int SCREEN_SWIPE_INDEX_WEB = 2;
     public static final int SCREEN_SWIPE_INDEX_TURNOUTS = 3;
 
+    public boolean prefHideInstructionalToasts = false;
 
     public boolean prefSwipeThoughTurnouts = true;
     public boolean prefSwipeThoughRoutes = true;
@@ -587,6 +588,8 @@ public class threaded_application extends Application {
         prefFeedbackOnDisconnect = prefs.getBoolean("prefFeedbackOnDisconnect",
                 getResources().getBoolean(R.bool.prefFeedbackOnDisconnectDefaultValue));
 
+        prefHideInstructionalToasts = prefs.getBoolean("prefHideInstructionalToasts",
+                getResources().getBoolean(R.bool.prefHideInstructionalToastsDefaultValue));
 
     } // end onCreate
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/comm_handler.java
@@ -127,7 +127,11 @@ public class comm_handler extends Handler {
             //attempt connection to WiThrottle server
             comm_thread.socketWiT = new comm_thread.socketWifi();
             if (comm_thread.socketWiT.connect()) {
-               if (mainapp.isDCCEX) threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.usingProtocolDCCEX), Toast.LENGTH_LONG);
+               if (mainapp.isDCCEX) {
+                  if (!mainapp.prefHideInstructionalToasts) {
+                     threaded_application.safeToast(threaded_application.context.getResources().getString(R.string.usingProtocolDCCEX), Toast.LENGTH_LONG);
+                  }
+               }
 
                commThread.sendThrottleName();
                mainapp.sendMsgDelay(mainapp.comm_msg_handler, 5000L, message_type.CONNECTION_COMPLETED_CHECK);

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -1821,6 +1821,8 @@
         <item>prefHostImportExport</item>
         <item>prefShowTimeOnLogEntry</item>
 
+        <item>prefHideInstructionalToasts</item>
+
 
     </string-array>
 

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -110,4 +110,6 @@
     <bool name="prefActionBarShowDccExButtonDefaultValue">false</bool>
     <bool name="prefAlwaysUseFunctionsFromServerDefaultValue">false</bool>
 
+    <bool name="prefHideInstructionalToastsDefaultValue">false</bool>
+
 </resources>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1190,6 +1190,9 @@
     <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirm that you want remove all the Recent Turnouts</string>
     <string name="dialogRecentConnectionsConfirmClearQuestions">Confirm that you want remove all the Recent Connections</string>
 
+    <string name="prefHideInstructionalToastsTitle">Hide Instructional Hints</string>
+    <string name="prefHideInstructionalToastsSummary">Hide instructional \'toast\' popup help/hints</string>
+
     <string name="dialogConfirmResetPreferencesTitle">Reset Preferences</string>
     <string name="dialogResetPreferencesQuestion">Confirm that you want reset all preferences.\nALL current preferences will be lost.</string>
 

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -2052,13 +2052,20 @@
                     android:title="@string/prefHostImportExportTitle"
                     android:layout="@layout/checkbox_no_icon" />
 
-
                 <CheckBoxPreference
                     android:defaultValue="@bool/prefShowTimeOnLogEntryDefaultValue"
                     android:key="prefShowTimeOnLogEntry"
                     android:summary="@string/prefShowTimeOnLogEntrySummary"
                     android:title="@string/prefShowTimeOnLogEntryTitle"
                     android:layout="@layout/checkbox_no_icon" />
+
+                <CheckBoxPreference
+                    android:defaultValue="@bool/prefHideInstructionalToastsDefaultValue"
+                    android:key="prefHideInstructionalToasts"
+                    android:summary="@string/prefHideInstructionalToastsSummary"
+                    android:title="@string/prefHideInstructionalToastsTitle"
+                    android:layout="@layout/checkbox_no_icon" />
+
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -3,6 +3,7 @@
  * Permission changes to support API level 33
  * For Android 10+ - option to retain all data on uninstall
  * Added close buttons to the Consist Edit and Consist Light Edit screens
+ * Added preference to hide Instructional/Help toast popups
 **Version 2.35.172
  * Fix: allow 16 char for default function labels
  * Fix: avoid crash on DCC-EX roster entry


### PR DESCRIPTION
Enabling the new preference hides a number of purely instructional/help toast messages.  
It does not hide any error messages or many other important messages.