### PR TITLE
reinstate mipmap icon

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
         android:dataExtractionRules="@xml/auto_backup_rules_new"
         android:description="@string/app_description"
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
+        android:icon="@mipmap/icon"
         android:theme="@style/app_splash"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -112,7 +112,7 @@
     <bool name="prefAlwaysUseFunctionsFromServerDefaultValue">false</bool>
 
     <bool name="prefHideInstructionalToastsDefaultValue">false</bool>
-    <bool name="prefRosterOwnersFilterShowOptionDefaultValue">true</bool>
+    <bool name="prefRosterOwnersFilterShowOptionDefaultValue">false</bool>
 
     <bool name="prefDoubleBackButtonToExitDefaultValue">false</bool>
 


### PR DESCRIPTION
Reinstate mipmap icon - needed for older version of Android
Change the owner filter preference to false