### PR TITLE
PoM add repeat and convert CV to base 0

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -914,9 +914,9 @@ public class comm_thread extends Thread {
         if (!mainapp.isDCCEX) { // WiThrottle only
             String msgTxt = "";
             if (args.length==5) {
-                msgTxt = String.format("D1%s %s %s %s %s", args[0], args[1], args[2], args[3], args[4] );
+                msgTxt = String.format("D2%s %s %s %s %s", args[0], args[1], args[2], args[3], args[4] );
             } else if (args.length==6) {
-                msgTxt = String.format("D1%s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5] );
+                msgTxt = String.format("D2%s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5] );
             }
             wifiSend(msgTxt);
             mainapp.alert_activities(message_type.WRITE_DIRECT_DCC_COMMAND_ECHO, msgTxt);

--- a/EngineDriver/src/main/java/jmri/enginedriver/withrottle_cv_programmer.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/withrottle_cv_programmer.java
@@ -17,8 +17,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver;
 
-import static android.text.InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -38,7 +36,6 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.SubMenu;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -52,9 +49,7 @@ import android.widget.TextView;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 import jmri.enginedriver.type.message_type;
@@ -203,7 +198,7 @@ public class withrottle_cv_programmer extends AppCompatActivity {
                         noSegments++;
                         directCmd = directCmd + bits  + " ";
                     }
-                    String cvBits = num2binStr(cv,10);
+                    String cvBits = num2binStr(cv - 1,10);
 
                     bits = "111011" + cvBits.substring(0,2);
                     segments[noSegments] = str2Bin(bits);


### PR DESCRIPTION
Programming on Main requires the DCC message to be sent twice in succession. the D1 command only sends the message once (repeat count 0 when tested via Loconet).  Changing to D2 sets the repeat count to 1.

The CV itself is 0-Base in the DCC Message, but 1-base in documents and the UI.  Changed to send (CV-1) in the DCC Message.