### PR TITLE
new preference to optionally include any server with port 2560 as a DCC-EX server

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -21,6 +21,7 @@
     <li>Support for 32 Function Roster Entries</li>
     <li>New WiThrottle CV Progaming on Main page. (note: not supported on all Command Stations)</li>
     <li>New preference to allow for double back button presses to exit the app</li>
+    <li>New preference to optional include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'</li>
     <li>Change the owner filter pref default to false</li>
     <li>UI improvements for the DCC-EX and Function Defaults pages</li>
     <li>Added intro/setup wizard page for DCC-EX</li>

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -99,6 +99,7 @@ public class comm_thread extends Thread {
         prefs = myPrefs;
 
         mainapp.prefUseDccexProtocol = prefs.getString("prefUseDccexProtocol", mainapp.getResources().getString(R.string.prefUseDccexProtocolDefaultValue));
+        mainapp.prefDccexIncludePort2560 = prefs.getBoolean("prefDccexIncludePort2560", mainapp.getResources().getBoolean(R.bool.prefDccexIncludePort2560DefaultValue));
         mainapp.prefAlwaysUseFunctionsFromServer = prefs.getBoolean("prefAlwaysUseFunctionsFromServer", mainapp.getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
         LATCHING_DEFAULT = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValue); // can change with language
         LATCHING_DEFAULT_ENGLISH = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValueEnglish); // can not change with language

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -236,7 +236,7 @@ public class connection_activity extends AppCompatActivity implements Permission
                         connected_ssid = mainapp.client_ssid;
                         break;
                 }
-                checkIfDccexServerName(connected_hostname);
+                checkIfDccexServerName(connected_hostname, connected_port);
                 connect();
                 mainapp.buttonVibration();
             }
@@ -293,7 +293,7 @@ public class connection_activity extends AppCompatActivity implements Permission
                 }
                 connected_hostname = connected_hostip; //copy ip to name
                 connected_ssid = mainapp.client_ssid;
-                checkIfDccexServerName(connected_hostname);
+                checkIfDccexServerName(connected_hostname, connected_port);
                 connect();
             } else {
                 if (!mainapp.prefHideInstructionalToasts) {
@@ -367,7 +367,7 @@ public class connection_activity extends AppCompatActivity implements Permission
                     }
                     connected_hostname = tm.get("host_name"); //copy ip to name
                     connected_ssid = mainapp.client_ssid;
-                    checkIfDccexServerName(connected_hostname);
+                    checkIfDccexServerName(connected_hostname, connected_port);
                     connect();
                     Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectConnected, connected_hostname, Integer.toString(connected_port)), LENGTH_LONG).show();
                 } else {
@@ -1105,7 +1105,7 @@ public class connection_activity extends AppCompatActivity implements Permission
                 case PermissionsHelper.CONNECT_TO_SERVER:
                     Log.d("Engine_Driver", "Got permission for READ_PHONE_STATE - navigate to connectImpl()");
 //                    connectImpl();
-                    checkIfDccexServerName(connected_hostname);
+                    checkIfDccexServerName(connected_hostname, connected_port);
                     connect();
                     break;
                 default:
@@ -1192,8 +1192,13 @@ public class connection_activity extends AppCompatActivity implements Permission
         }
     }
 
-    void checkIfDccexServerName(String serverName) {
-        mainapp.isDCCEX = ( (mainapp.prefUseDccexProtocol.equals(threaded_application.DCCEX_PROTOCOL_OPTION_AUTO))
-                && (serverName.matches("\\S*(DCCEX|dccex|DCC-EX|dcc-ex)\\S*")) );
+    void checkIfDccexServerName(String serverName, int serverPort) {
+        mainapp.prefUseDccexProtocol = prefs.getString("prefUseDccexProtocol", mainapp.getResources().getString(R.string.prefUseDccexProtocolDefaultValue));
+        mainapp.prefDccexIncludePort2560 = prefs.getBoolean("prefDccexIncludePort2560", mainapp.getResources().getBoolean(R.bool.prefDccexIncludePort2560DefaultValue));
+
+        mainapp.isDCCEX = ( ((mainapp.prefUseDccexProtocol.equals(threaded_application.DCCEX_PROTOCOL_OPTION_AUTO))
+                                && (serverName.matches("\\S*(DCCEX|dccex|DCC-EX|dcc-ex)\\S*")))
+                || ((mainapp.prefDccexIncludePort2560) && (serverPort==2560))
+                );
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -205,6 +205,7 @@ public class threaded_application extends Application {
     public HashMap<String, String> knownDCCEXserverIps = new HashMap<>();
     public boolean isDCCEX = false;  // is a DCC-EX EX-CommandStation
     public String prefUseDccexProtocol = "Auto";
+    public boolean prefDccexIncludePort2560 = false;
     public boolean prefAlwaysUseFunctionsFromServer = false;
     public String DccexVersion = "";
     public int DCCEXlistsRequested = -1;  // -1=not requested  0=requested  1,2,3= no. of lists received

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -96,6 +96,7 @@
     <bool name="prefFeedbackOnDisconnectDefaultValue">true</bool>
     <bool name="prefFeedbackWhenGoingToBackgroundDefaultValue">true</bool>
     <bool name="prefDccexConnectionOptionDefaultValue">false</bool>
+    <bool name="prefDccexIncludePort2560DefaultValue">false</bool>
     <bool name="prefFullScreenSwipeAreaDefaultValue">false</bool>
 
     <bool name="prefKidsTimerEnableReverseDefaultValue">false</bool>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1283,6 +1283,8 @@
 
     <string name="prefDccexTitle">Use native DCC-EX commands</string>
     <string name="prefDccexSummary">Use native DCC-EX &lt;&gt; commands instead of WiThrottle for all connections. For \'Auto\', name must contain \"DCCEX\" or \"DCC-EX\"\nNote: Will not take effect until you restart Engine Driver and connect to a server.</string>
+    <string name="prefDccexIncludePort2560Title">Include Port 2560 for Auto</string>
+    <string name="prefDccexIncludePort2560Summary">Include Port 2560 when determining to use DCC-EX &lt;&gt; commands instead of WiThrottle when set to \'Auto\'.</string>
 
     <string name="prefAlwaysUseFunctionsFromServerTitle">Always use function labels from server</string>
     <string name="prefAlwaysUseFunctionsFromServerSummary">When disabled, use EngineDriver default labels for locos selected by address (not Roster), ignoring server default labels.</string>

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -1859,6 +1859,13 @@
                     android:title="@string/prefDccexConnectionOptionTitle"
                     android:layout="@layout/checkbox_no_icon" />
 
+                <CheckBoxPreference
+                    android:defaultValue="@bool/prefDccexIncludePort2560DefaultValue"
+                    android:key="prefDccexIncludePort2560"
+                    android:summary="@string/prefDccexIncludePort2560Summary"
+                    android:title="@string/prefDccexIncludePort2560Title"
+                    android:layout="@layout/checkbox_no_icon" />
+
             </PreferenceCategory>
 
         </PreferenceScreen>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,7 +1,8 @@
 **Version 2.37.182
- * add intro/setup wizard page for DCC-EX
- * new WiThrottle CV PoM page
- * bug fix for <p 0|1>  (space after p)  - only seen in the JMRI DCC++ simulator
+ * Add intro/setup wizard page for DCC-EX
+ * New WiThrottle CV PoM page
+ * Bug fix for <p 0|1>  (space after p)  - only seen in the JMRI DCC++ simulator
+ * New preference to optional include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'
 **Version 2.37.180
  * fastclock fix
  * reinstate mipmap icon


### PR DESCRIPTION
new preference to optional include any server with port 2560 as a DCC-EX server when the connection preference is set to 'Auto' 