### PR TITLE
- Support for JMRI DCCppOverTCP Server. 

### DIFF
--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -21,7 +21,8 @@
     <li>Support for 32 Function Roster Entries</li>
     <li>New WiThrottle CV Progaming on Main page. (note: not supported on all Command Stations)</li>
     <li>New preference to allow for double back button presses to exit the app</li>
-    <li>New preference to optional include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'</li>
+    <li>Support for JMRI DCCppOverTCP Server.</li>
+    <li>Include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'</li>
     <li>Change the owner filter pref default to false</li>
     <li>UI improvements for the DCC-EX and Function Defaults pages</li>
     <li>Added intro/setup wizard page for DCC-EX</li>

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
@@ -85,7 +85,8 @@ public class comm_handler extends Handler {
                            //log message, but keep going if this fails
                            Log.d("Engine_Driver", "comm_handler.handleMessage: multicast_lock.acquire() failed");
                         }
-                        commThread.jmdns.addServiceListener("_withrottle._tcp.local.", commThread.listener);
+                        commThread.jmdns.addServiceListener(mainapp.JMDNS_SERVICE_WITHROTTLE, commThread.listener);
+                        commThread.jmdns.addServiceListener(mainapp.JMDNS_SERVICE_JMRI_DCCPP_OVERTCP, commThread.listener);
                         Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns listener added");
                      } else {
                         Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns not running, didn't start listener");

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -254,7 +254,7 @@ public class comm_thread extends Thread {
         hm.put("port", entryPort);
         hm.put("host_name", entryName);
         hm.put("ssid", mainapp.client_ssid);
-        hm.put("service_type",mainapp.JMDNS_SERVICE_WITHROTTLE);
+        hm.put("service_type",(serverType.equals("DCC-EX") ? mainapp.JMDNS_SERVICE_JMRI_DCCPP_OVERTCP : mainapp.JMDNS_SERVICE_WITHROTTLE) );
 
 //        mainapp.knownDCCEXserverIps.put(server_addr, serverType);
         String key = ""+server_addr+":"+entryPort;

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -99,7 +99,6 @@ public class comm_thread extends Thread {
         prefs = myPrefs;
 
         mainapp.prefUseDccexProtocol = prefs.getString("prefUseDccexProtocol", mainapp.getResources().getString(R.string.prefUseDccexProtocolDefaultValue));
-        mainapp.prefDccexIncludePort2560 = prefs.getBoolean("prefDccexIncludePort2560", mainapp.getResources().getBoolean(R.bool.prefDccexIncludePort2560DefaultValue));
         mainapp.prefAlwaysUseFunctionsFromServer = prefs.getBoolean("prefAlwaysUseFunctionsFromServer", mainapp.getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
         LATCHING_DEFAULT = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValue); // can change with language
         LATCHING_DEFAULT_ENGLISH = mainapp.getString(R.string.prefFunctionConsistLatchingLightBellDefaultValueEnglish); // can not change with language
@@ -136,7 +135,10 @@ public class comm_thread extends Thread {
 
             String serverType = event.getInfo().getPropertyString("jmri") == null ? "" : "JMRI";
 
-            String host_name = event.getInfo().getName(); //
+            String host_name = event.getInfo().getName();
+            if (event.getInfo().getType().toString().equals(mainapp.JMDNS_SERVICE_JMRI_DCCPP_OVERTCP)) {
+                host_name = host_name + " [DCC-EX]";
+            }
             Inet4Address[] ip_addresses = event.getInfo().getInet4Addresses();  //only get ipV4 address
             String ip_address = ip_addresses[0].toString().substring(1);  //use first one, since WiThrottle is only putting one in (for now), and remove leading slash
 
@@ -146,8 +148,10 @@ public class comm_thread extends Thread {
             hm.put("port", ((Integer) port).toString());
             hm.put("host_name", host_name);
             hm.put("ssid", mainapp.client_ssid);
+            hm.put("service_type", event.getInfo().getType().toString());
 
-            mainapp.knownDCCEXserverIps.put(ip_address, serverType);
+            String key = ""+ip_address+":"+port;
+            mainapp.knownDCCEXserverIps.put(key, serverType);
 
             Message service_message = Message.obtain();
             service_message.what = message_type.SERVICE_RESOLVED;
@@ -201,7 +205,8 @@ public class comm_thread extends Thread {
             public void run() {
                 try {
                     Log.d("Engine_Driver", "comm_thread.endJmdns: removing jmdns listener");
-                    jmdns.removeServiceListener("_withrottle._tcp.local.", listener);
+                    jmdns.removeServiceListener(mainapp.JMDNS_SERVICE_WITHROTTLE, listener);
+                    jmdns.removeServiceListener(mainapp.JMDNS_SERVICE_JMRI_DCCPP_OVERTCP, listener);
 
                     multicast_lock.release();
                 } catch (Exception e) {
@@ -249,8 +254,11 @@ public class comm_thread extends Thread {
         hm.put("port", entryPort);
         hm.put("host_name", entryName);
         hm.put("ssid", mainapp.client_ssid);
+        hm.put("service_type",mainapp.JMDNS_SERVICE_WITHROTTLE);
 
-        mainapp.knownDCCEXserverIps.put(server_addr, serverType);
+//        mainapp.knownDCCEXserverIps.put(server_addr, serverType);
+        String key = ""+server_addr+":"+entryPort;
+        mainapp.knownDCCEXserverIps.put(key, serverType);
 
         Message service_message = Message.obtain();
         service_message.what = message_type.SERVICE_RESOLVED;

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -395,13 +395,18 @@ public class connection_activity extends AppCompatActivity implements Permission
                 case message_type.SERVICE_RESOLVED:
                     HashMap<String, String> hm = (HashMap<String, String>) msg.obj;  //payload is already a hashmap
                     String found_host_name = hm.get("host_name");
+                    String found_ip_address = hm.get("ip_address");
+                    String found_port = hm.get("port");
+                    String found_service_type = hm.get("service_type");
                     boolean entryExists = false;
 
                     //stop if new address is already in the list
                     HashMap<String, String> tm;
                     for (int index = 0; index < discovery_list.size(); index++) {
                         tm = discovery_list.get(index);
-                        if (tm.get("host_name").equals(found_host_name)) {
+//                        if (tm.get("host_name").equals(found_host_name)) {
+                        if ( (tm.get("ip_address").equals(found_ip_address))
+                        && (tm.get("port").equals(found_port)) ) {
                             entryExists = true;
                             break;
                         }
@@ -999,7 +1004,7 @@ public class connection_activity extends AppCompatActivity implements Permission
     /*	private void withrottle_list() {
 		try {
 			JmDNS jmdns = JmDNS.create();
-			ServiceInfo[] infos = jmdns.list("_withrottle._tcp.local.");
+			ServiceInfo[] infos = jmdns.list(mainapp.JMDNS_SERVICE_WITHROTTLE);
 			String fh = "";
 			for (ServiceInfo info : infos) {
 				fh +=  info.getURL() + "\n";
@@ -1194,11 +1199,10 @@ public class connection_activity extends AppCompatActivity implements Permission
 
     void checkIfDccexServerName(String serverName, int serverPort) {
         mainapp.prefUseDccexProtocol = prefs.getString("prefUseDccexProtocol", mainapp.getResources().getString(R.string.prefUseDccexProtocolDefaultValue));
-        mainapp.prefDccexIncludePort2560 = prefs.getBoolean("prefDccexIncludePort2560", mainapp.getResources().getBoolean(R.bool.prefDccexIncludePort2560DefaultValue));
 
         mainapp.isDCCEX = ( ((mainapp.prefUseDccexProtocol.equals(threaded_application.DCCEX_PROTOCOL_OPTION_AUTO))
                                 && (serverName.matches("\\S*(DCCEX|dccex|DCC-EX|dcc-ex)\\S*")))
-                || ((mainapp.prefDccexIncludePort2560) && (serverPort==2560))
+                || (serverPort==2560)
                 );
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
@@ -63,7 +63,8 @@ public class ImportExportConnectionList {
                     String host_name;
                     String port_str;
                     Integer port = 0;
-                    String ssid_str;
+                    String ssid_str = "";
+                    String service_type = "";
                     List<String> parts = Arrays.asList(line.split(":", 4)); //split record from file, max of 4 parts
                     if (parts.size() > 1) {  //skip if not split
                         if (parts.size() == 2) {  //old style, use part 1 for ip and host
@@ -76,11 +77,17 @@ public class ImportExportConnectionList {
                             ip_address = parts.get(1);
                             port_str = parts.get(2);
                             ssid_str = "";
-                        } else { //new new style, get all 4 parts
+                        } else if (parts.size() == 4) { //new new style, get all 4 parts
                             host_name = parts.get(0);
                             ip_address = parts.get(1);
                             port_str = parts.get(2);
                             ssid_str = parts.get(3);
+                        } else { // additional service type format get all 5 parts
+                            host_name = parts.get(0);
+                            ip_address = parts.get(1);
+                            port_str = parts.get(2);
+                            ssid_str = parts.get(3);
+                            service_type = parts.get(4);
                         }
                         try {  //attempt to convert port to integer
                             port = Integer.decode(port_str);
@@ -95,6 +102,7 @@ public class ImportExportConnectionList {
                                     hm.put("host_name", host_name);
                                     hm.put("port", port.toString());
                                     hm.put("ssid", ssid_str);
+                                    hm.put("service_type", service_type);
                                     if (!connections_list.contains(hm)) {    // suppress dups
                                         connections_list.add(hm);
                                     }
@@ -124,6 +132,7 @@ public class ImportExportConnectionList {
             hm.put("host_name", demo_host);
             hm.put("port", demo_port);
             hm.put("ssid", "");
+            hm.put("service_type", "_withrottle._tcp.local.");
             connections_list.add(hm);
         }
 //        connection_list_adapter.notifyDataSetChanged();

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -116,6 +116,10 @@ public class threaded_application extends Application {
 
     private final threaded_application mainapp = this;
     public comm_thread commThread;
+
+    public String JMDNS_SERVICE_WITHROTTLE = "_withrottle._tcp.local.";
+    public String JMDNS_SERVICE_JMRI_DCCPP_OVERTCP = "_dccppovertcpserver._tcp.local.";
+
     public volatile String host_ip = null; //The IP address of the WiThrottle server.
     public volatile String logged_host_ip = null;
     public volatile int port = 0; //The TCP port that the WiThrottle server is running on
@@ -205,7 +209,6 @@ public class threaded_application extends Application {
     public HashMap<String, String> knownDCCEXserverIps = new HashMap<>();
     public boolean isDCCEX = false;  // is a DCC-EX EX-CommandStation
     public String prefUseDccexProtocol = "Auto";
-    public boolean prefDccexIncludePort2560 = false;
     public boolean prefAlwaysUseFunctionsFromServer = false;
     public String DccexVersion = "";
     public int DCCEXlistsRequested = -1;  // -1=not requested  0=requested  1,2,3= no. of lists received

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -96,7 +96,6 @@
     <bool name="prefFeedbackOnDisconnectDefaultValue">true</bool>
     <bool name="prefFeedbackWhenGoingToBackgroundDefaultValue">true</bool>
     <bool name="prefDccexConnectionOptionDefaultValue">false</bool>
-    <bool name="prefDccexIncludePort2560DefaultValue">false</bool>
     <bool name="prefFullScreenSwipeAreaDefaultValue">false</bool>
 
     <bool name="prefKidsTimerEnableReverseDefaultValue">false</bool>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1282,15 +1282,13 @@
     <string name="prefUseDccexProtocolDefaultValue">Auto</string>
 
     <string name="prefDccexTitle">Use native DCC-EX commands</string>
-    <string name="prefDccexSummary">Use native DCC-EX &lt;&gt; commands instead of WiThrottle for all connections. For \'Auto\', name must contain \"DCCEX\" or \"DCC-EX\"\nNote: Will not take effect until you restart Engine Driver and connect to a server.</string>
-    <string name="prefDccexIncludePort2560Title">Include Port 2560 for Auto</string>
-    <string name="prefDccexIncludePort2560Summary">Include Port 2560 when determining to use DCC-EX &lt;&gt; commands instead of WiThrottle when set to \'Auto\'.</string>
+    <string name="prefDccexSummary">Use native DCC-EX &lt;&gt; commands instead of WiThrottle for all connections. For \'Auto\', name must contain \"DCCEX\" or \"DCC-EX\" or use port 2560\nNote: Will not take effect until you restart Engine Driver and connect to a server.</string>
 
     <string name="prefAlwaysUseFunctionsFromServerTitle">Always use function labels from server</string>
     <string name="prefAlwaysUseFunctionsFromServerSummary">When disabled, use EngineDriver default labels for locos selected by address (not Roster), ignoring server default labels.</string>
 
     <string name="useProtocolDCCEX">Use native DCC-EX commands (not WiThrottle)"</string>
-    <string name="useProtocolDCCEXplusAutoHint">Use native DCC-EX commands. For \'Auto\', name must contain \"DCCEX\" or \"DCC-EX\"</string>
+    <string name="useProtocolDCCEXplusAutoHint">Use native DCC-EX? For \'Auto\', name must contain \"DCCEX\" or \"DCC-EX\" or use port 2560</string>
     <string name="usingProtocolDCCEX">Using the DCC-EX protocol.\nUncheck \"Use native DCC-EX commands\" preference to use the WiThrottle protocol.</string>
 
     <string name="prefDccexConnectionOptionTitle">Show protocol option</string>

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -1859,13 +1859,6 @@
                     android:title="@string/prefDccexConnectionOptionTitle"
                     android:layout="@layout/checkbox_no_icon" />
 
-                <CheckBoxPreference
-                    android:defaultValue="@bool/prefDccexIncludePort2560DefaultValue"
-                    android:key="prefDccexIncludePort2560"
-                    android:summary="@string/prefDccexIncludePort2560Summary"
-                    android:title="@string/prefDccexIncludePort2560Title"
-                    android:layout="@layout/checkbox_no_icon" />
-
             </PreferenceCategory>
 
         </PreferenceScreen>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -2,7 +2,8 @@
  * Add intro/setup wizard page for DCC-EX
  * New WiThrottle CV PoM page
  * Bug fix for <p 0|1>  (space after p)  - only seen in the JMRI DCC++ simulator
- * New preference to optional include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'
+ * Include any server with port 2560 as a DCC-EX server when connection preference set to 'Auto'
+ * Support for JMRI DCCppOverTCP Server. Now also checks for the mDNS service "_dccppovertcpserver._tcp.local."
 **Version 2.37.180
  * fastclock fix
  * reinstate mipmap icon


### PR DESCRIPTION
- Now also checks for the mDNSservice "_dccppovertcpserver._tcp.local."
- Now Always includes any server with port 2560 as a DCC-EX server - when the connection preference is set to 'Auto'