### PR TITLE
Allow CV Programming On Main defaults to "No"

### DIFF
--- a/EngineDriver/src/main/res/layout/connection.xml
+++ b/EngineDriver/src/main/res/layout/connection.xml
@@ -157,7 +157,7 @@
             android:layout_height="wrap_content"
             android:layout_weight=".3"
             android:ellipsize="none"
-            android:entries="@array/prefYesNoAutoEntries"
+            android:entries="@array/prefDccexConnectionOptionsEntries"
             android:entryValues="@array/prefYesNoAutoEntryValues"
             android:padding="0dp"
             android:paddingLeft="20dp"

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -1572,6 +1572,12 @@
         <item>Auto</item>
     </string-array>
 
+    <string-array name="prefDccexConnectionOptionsEntries">  <!-- display version -->
+        <item>DCC-EX</item>
+        <item>WiThrottle</item>
+        <item>Auto</item>
+    </string-array>
+
     <string-array name="prefLocaleEntryValues" translatable="false">  <!-- DO NOT TRANSLATE -->
         <item>Default</item>
         <item>en_US</item>

--- a/EngineDriver/src/main/res/values/bool.xml
+++ b/EngineDriver/src/main/res/values/bool.xml
@@ -116,6 +116,6 @@
 
     <bool name="prefDoubleBackButtonToExitDefaultValue">false</bool>
 
-    <bool name="prefShowWitPomDefaultValue">true</bool>
+    <bool name="prefShowWitPomDefaultValue">false</bool>
 
 </resources>


### PR DESCRIPTION
- "Allow CV Programming On Main" defaults to "No". 
- "Connection Protocol" option changed to "WiThrottle", "DCC-EX", "Auto"