### PR TITLE
code cleanup + DeviceID bug fix

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="186"
-    android:versionName="2.37.186a" android:installLocation="auto">
+    android:versionName="2.37.186" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />

--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="186"
-    android:versionName="2.37.186" android:installLocation="auto">
+    android:versionName="2.37.186a" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -1252,7 +1252,8 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     case "prefDeviceSounds1":
                         mainapp.prefDeviceSounds[1] = prefs.getString("prefDeviceSounds1", parentActivity.getApplicationContext().getResources().getString(R.string.prefDeviceSoundsDefaultValue));
                         mainapp.soundsReloadSounds = true;
-                        iplsLoader.loadSounds();
+                        // the sounds will actually be relaoded in the throttle.onResume()
+//                        iplsLoader.loadSounds();
                         break;
                     case "maximum_throttle_preference":
                     case "prefDeviceSoundsLocoVolume":

--- a/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
@@ -24,6 +24,7 @@ import android.os.Looper;
 import android.os.Message;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.text.Html;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -58,7 +59,7 @@ public class about_page extends AppCompatActivity {
 
         // format and show version info
         TextView v = findViewById(R.id.about_info);
-        v.setText(mainapp.getAboutInfo());
+        v.setText(Html.fromHtml(mainapp.getAboutInfo()));
 
         // show ED webpage
         WebView webview = findViewById(R.id.about_webview);

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
@@ -49,7 +49,7 @@ public class comm_handler extends Handler {
       commThread = myCommThread;
    }
 
-   @SuppressLint({"DefaultLocale", "ApplySharedPref"})
+   @SuppressLint({"DefaultLocale", "ApplySharedPref", "WebViewApiAvailability"})
    public void handleMessage(Message msg) {
 //                Log.d("Engine_Driver", "comm_handler.handleMessage: message: " +msg.what);
       switch (msg.what) {
@@ -306,9 +306,9 @@ public class comm_handler extends Handler {
          }
 
          case message_type.WRITE_DIRECT_DCC_COMMAND: { // WiThrottle only
-            int addr = msg.arg1;
+//            int addr = msg.arg1;
             String [] args = msg.obj.toString().split(" ");
-            String rslt = "";
+//            String rslt = "";
             comm_thread.sendWriteDirectDccCommand(args);
             break;
          }

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -84,6 +84,7 @@ import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.type.auto_import_export_option_type;
 import jmri.enginedriver.type.restart_reason_type;
 
+import jmri.enginedriver.util.BackgroundImageLoader;
 import jmri.enginedriver.util.PermissionsHelper;
 import jmri.enginedriver.util.PermissionsHelper.RequestCodes;
 import jmri.enginedriver.util.SwipeDetector;
@@ -642,7 +643,7 @@ public class connection_activity extends AppCompatActivity implements Permission
                     "");
         }
 
-        mainapp. gamepadFullReset();
+        mainapp.gamepadFullReset();
 
     } //end onCreate
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
@@ -64,47 +64,45 @@ public class dcc_ex extends AppCompatActivity {
     private threaded_application mainapp;  // hold pointer to mainapp
     private Menu menu;
 
-    private String DccexCv = "";
-    private String DccexCvValue = "";
+    private String dccexCv = "";
+    private String dccexCvValue = "";
     private EditText etDccexCv;
     private EditText etDccexCvValue;
 
-    private String DccexAddress = "";
+    private String dccexAddress = "";
     private EditText etDccexWriteAddressValue;
 
     private String dccexSendCommandValue = "";
     private EditText etDccexSendCommandValue;
 
-    private LinearLayout DccexWriteInfoLayout;
-    private TextView DccexWriteInfoLabel;
-    private String DccexInfoStr = "";
+    private LinearLayout dccexWriteInfoLayout;
+    private TextView dccexWriteInfoLabel;
+    private String dccexInfoStr = "";
 
-    private TextView DccexHeadingLabel;
+    private TextView dccexHeadingLabel;
 
-    private TextView DccexResponsesLabel;
-    private TextView DccexSendsLabel;
-    private String DccexResponsesStr = "";
-    private String DccexSendsStr = "";
-    private ScrollView DccexResponsesScrollView;
-    private ScrollView DccexSendsScrollView;
+    private TextView dccexResponsesLabel;
+    private TextView dccexSendsLabel;
+    private String dccexResponsesStr = "";
+    private String dccexSendsStr = "";
 
-    private Spinner dcc_action_type_spinner;
+    private Spinner dccActionTypeSpinner;
 
-    ArrayList<String> DccexResponsesListHtml = new ArrayList<>();
-    ArrayList<String> DccexSendsListHtml = new ArrayList<>();
+    final ArrayList<String> dccexResponsesListHtml = new ArrayList<>();
+    final ArrayList<String> dccexSendsListHtml = new ArrayList<>();
 
     private int dccCvsIndex = 0;
     String[] dccCvsEntryValuesArray;
     String[] dccCvsEntriesArray; // display version
 
     private int dccCmdIndex = 0;
-    String[] dccExCommonCommandsEntryValuesArray;
-    String[] dccExCommonCommandsEntriesArray; // display version
-    int[] dccExCommonCommandsHasParametersArray; // display version
+    String[] dccexCommonCommandsEntryValuesArray;
+    String[] dccexCommonCommandsEntriesArray; // display version
+    int[] dccexCommonCommandsHasParametersArray; // display version
 
-//    private int dccExActionTypeIndex = 0;
-    String[] dccExActionTypeEntryValuesArray;
-    String[] dccExActionTypeEntriesArray; // display version
+//    private int dccexActionTypeIndex = 0;
+    String[] dccexActionTypeEntryValuesArray;
+    String[] dccexActionTypeEntriesArray; // display version
 
 //    private boolean dccexHideSends = false;
 
@@ -128,17 +126,17 @@ public class dcc_ex extends AppCompatActivity {
     private LinearLayout dexcProgrammingCvLayout;
     private final LinearLayout[] dexcDccexTracklayout = {null, null, null, null, null, null, null, null};
     private LinearLayout dexcDccexTrackLinearLayout;
-    Spinner dccExCommonCvsSpinner;
-    Spinner dccExCommonCommandsSpinner;
+    Spinner dccexCommonCvsSpinner;
+    Spinner dccexCommonCommandsSpinner;
 
-    private final int[] dccExTrackTypeIndex = {1, 2, 1, 1, 1, 1, 1, 1};
-    private final Button[] dccExTrackPowerButton = {null, null, null, null, null, null, null, null};
-    private final Spinner[] dccExTrackTypeSpinner = {null, null, null, null, null, null, null, null};
-    private final EditText[] dccExTrackTypeIdEditText = {null, null, null, null, null, null, null, null};
-    private final LinearLayout[] dccExTrackTypeLayout = {null, null, null, null, null, null, null, null};
+    private final int[] dccexTrackTypeIndex = {1, 2, 1, 1, 1, 1, 1, 1};
+    private final Button[] dccexTrackPowerButton = {null, null, null, null, null, null, null, null};
+    private final Spinner[] dccexTrackTypeSpinner = {null, null, null, null, null, null, null, null};
+    private final EditText[] dccexTrackTypeIdEditText = {null, null, null, null, null, null, null, null};
+    private final LinearLayout[] dccexTrackTypeLayout = {null, null, null, null, null, null, null, null};
 
-    String[] dccExTrackTypeEntryValuesArray;
-    String[] dccExTrackTypeEntriesArray; // display version
+    String[] dccexTrackTypeEntryValuesArray;
+    String[] dccexTrackTypeEntriesArray; // display version
 
 //    private int dccexPreviousCommandIndex = -1;
 //    ArrayList<String> dccexPreviousCommandList = new ArrayList<>();
@@ -166,18 +164,14 @@ public class dcc_ex extends AppCompatActivity {
 
     float vn = 4; // DCC-EC Version number
 
-    private LinearLayout screenNameLine;
-    private Toolbar toolbar;
-    private LinearLayout statusLine;
-
     //**************************************
 
 
     //Handle messages from the communication thread back to this thread (responses from withrottle)
     @SuppressLint("HandlerLeak")
-    class dcc_ex_handler extends Handler {
+    class DccExMessageHandler extends Handler {
 
-        public dcc_ex_handler(Looper looper) {
+        public DccExMessageHandler(Looper looper) {
             super(looper);
         }
 
@@ -185,25 +179,25 @@ public class dcc_ex extends AppCompatActivity {
             switch (msg.what) {
                 case message_type.RECEIVED_DECODER_ADDRESS:
                     String response_str = msg.obj.toString();
-                    if ((response_str.length() > 0) && !(response_str.charAt(0) == '-')) {  //refresh address
-                        DccexAddress = response_str;
-                        DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
+                    if ((!response_str.isEmpty()) && !(response_str.charAt(0) == '-')) {  //refresh address
+                        dccexAddress = response_str;
+                        dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
                     } else {
-                        DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
+                        dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
                     }
                     refreshDccexView();
                     break;
                 case message_type.RECEIVED_CV:
                     String cvResponseStr = msg.obj.toString();
-                    if (cvResponseStr.length() > 0) {
+                    if (!cvResponseStr.isEmpty()) {
                         String[] cvArgs = cvResponseStr.split("(\\|)");
-                        if ((cvArgs[0].equals(DccexCv)) && !(cvArgs[1].charAt(0) == '-')) { // response matches what we got back
-                            DccexCvValue = cvArgs[1];
-                            DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
-                            checkCv29(DccexCv, DccexCvValue);
+                        if ((cvArgs[0].equals(dccexCv)) && !(cvArgs[1].charAt(0) == '-')) { // response matches what we got back
+                            dccexCvValue = cvArgs[1];
+                            dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
+                            checkCv29(dccexCv, dccexCvValue);
                         } else {
                             resetTextField(WHICH_CV_VALUE);
-                            DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
+                            dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
                         }
                         refreshDccexView();
                     }
@@ -222,11 +216,11 @@ public class dcc_ex extends AppCompatActivity {
                     break;
 
                 case message_type.WRITE_DECODER_SUCCESS:
-                    DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
+                    dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexSucceeded);
                     refreshDccexView();
                     break;
                 case message_type.WRITE_DECODER_FAIL:
-                    DccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
+                    dccexInfoStr = getApplicationContext().getResources().getString(R.string.DccexFailed);
                     refreshDccexView();
                     break;
                 case message_type.RECEIVED_TRACKS:
@@ -261,10 +255,10 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class read_address_button_listener implements View.OnClickListener {
+    public class ReadAddressButtonListener implements View.OnClickListener {
 
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
             resetTextField(WHICH_ADDRESS);
             mainapp.buttonVibration();
             mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_DECODER_ADDRESS, "*", -1);
@@ -273,14 +267,14 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class write_address_button_listener implements View.OnClickListener {
+    public class WriteAddressButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
             String addrStr = etDccexWriteAddressValue.getText().toString();
             try {
                 int addr = Integer.decode(addrStr);
                 if ((addr > 2) && (addr <= 10239)) {
-                    DccexAddress = Integer.toString(addr);
+                    dccexAddress = Integer.toString(addr);
                     mainapp.buttonVibration();
                     mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_DECODER_ADDRESS, "", addr);
                 } else {
@@ -294,15 +288,15 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class read_cv_button_listener implements View.OnClickListener {
+    public class ReadCvButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
             resetTextField(WHICH_CV_VALUE);
             String cvStr = etDccexCv.getText().toString();
             try {
                 int cv = Integer.decode(cvStr);
                 if (cv > 0) {
-                    DccexCv = Integer.toString(cv);
+                    dccexCv = Integer.toString(cv);
                     mainapp.buttonVibration();
                     mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_CV, "", cv);
                     refreshDccexView();
@@ -315,9 +309,9 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class write_cv_button_listener implements View.OnClickListener {
+    public class WriteCvButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
             String cvStr = etDccexCv.getText().toString();
             String cvValueStr = etDccexCvValue.getText().toString();
             String addrStr = etDccexWriteAddressValue.getText().toString();
@@ -326,8 +320,8 @@ public class dcc_ex extends AppCompatActivity {
                     int cv = Integer.decode(cvStr);
                     int cvValue = Integer.decode(cvValueStr);
                     if (cv > 0) {
-                        DccexCv = Integer.toString(cv);
-                        DccexCvValue = Integer.toString(cvValue);
+                        dccexCv = Integer.toString(cv);
+                        dccexCvValue = Integer.toString(cvValue);
                         mainapp.buttonVibration();
                         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_CV, cvValueStr, cv);
                     } else {
@@ -342,11 +336,11 @@ public class dcc_ex extends AppCompatActivity {
                     int cvValue = Integer.decode(cvValueStr);
                     int addr = Integer.decode(addrStr);
                     if ((addr > 2) && (addr <= 10239) && (cv > 0)) {
-                        DccexAddress = Integer.toString(addr);
-                        DccexCv = cv.toString();
-                        DccexCvValue = Integer.toString(cvValue);
+                        dccexAddress = Integer.toString(addr);
+                        dccexCv = cv.toString();
+                        dccexCvValue = Integer.toString(cvValue);
                         mainapp.buttonVibration();
-                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_POM_CV, DccexCv + " " + DccexCvValue, addr);
+                        mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_POM_CV, dccexCv + " " + dccexCvValue, addr);
                     } else {
                         resetTextField(WHICH_ADDRESS);
                     }
@@ -359,18 +353,18 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class send_command_button_listener implements View.OnClickListener {
+    public class SendCommandButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
             String cmdStr = etDccexSendCommandValue.getText().toString();
-            if ((cmdStr.length() > 0) && (cmdStr.charAt(0) != '<')) {
+            if ((!cmdStr.isEmpty()) && (cmdStr.charAt(0) != '<')) {
                 mainapp.buttonVibration();
                 mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DCCEX_SEND_COMMAND, "<" + cmdStr + ">");
 
                 if ((cmdStr.charAt(0) == '=') && (cmdStr.length() > 1)) // we don't get a response from a tracks command, so request an update
                     mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_TRACKS, "");
 
-                if ((mainapp.dccexPreviousCommandList.size() == 0) || !(mainapp.dccexPreviousCommandList.get(mainapp.dccexPreviousCommandList.size() - 1).equals(cmdStr))) {
+                if ((mainapp.dccexPreviousCommandList.isEmpty()) || !(mainapp.dccexPreviousCommandList.get(mainapp.dccexPreviousCommandList.size() - 1).equals(cmdStr))) {
                     mainapp.dccexPreviousCommandList.add(cmdStr);
                     if (mainapp.dccexPreviousCommandList.size() > 20) {
                         mainapp.dccexPreviousCommandList.remove(0);
@@ -384,9 +378,9 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class previous_command_button_listener implements View.OnClickListener {
+    public class PreviousCommandButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
 //            String cmdStr = etDccexSendCommandValue.getText().toString();
             if (mainapp.dccexPreviousCommandIndex > 0) {
                 dccexSendCommandValue = mainapp.dccexPreviousCommandList.get(mainapp.dccexPreviousCommandIndex - 1);
@@ -402,9 +396,9 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class next_command_button_listener implements View.OnClickListener {
+    public class NextCommandButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexInfoStr = "";
+            dccexInfoStr = "";
 //            String cmdStr = etDccexSendCommandValue.getText().toString();
             if (mainapp.dccexPreviousCommandIndex < mainapp.dccexPreviousCommandList.size() - 1) {
                 dccexSendCommandValue = mainapp.dccexPreviousCommandList.get(mainapp.dccexPreviousCommandIndex + 1);
@@ -421,8 +415,8 @@ public class dcc_ex extends AppCompatActivity {
     }
 
     public class SetTrackPowerButtonListener implements View.OnClickListener {
-        int myTrack;
-        char myTrackLetter;
+        final int myTrack;
+        final char myTrackLetter;
 
         public SetTrackPowerButtonListener(int track) {
             myTrack = track;
@@ -438,7 +432,7 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class write_tracks_button_listener implements View.OnClickListener {
+    public class WriteTracksButtonListener implements View.OnClickListener {
         public void onClick(View v) {
             int typeIndex;
             String type;
@@ -448,7 +442,7 @@ public class dcc_ex extends AppCompatActivity {
             for (int i = 0; i < threaded_application.DCCEX_MAX_TRACKS; i++) {
                 if (mainapp.DccexTrackAvailable[i]) {
                     trackLetter = (char) ('A' + i);
-                    typeIndex = dccExTrackTypeSpinner[i].getSelectedItemPosition();
+                    typeIndex = dccexTrackTypeSpinner[i].getSelectedItemPosition();
                     type = TRACK_TYPES[typeIndex];
                     mainapp.DccexTrackType[i] = typeIndex;
 
@@ -457,7 +451,7 @@ public class dcc_ex extends AppCompatActivity {
                             mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_TRACK, trackLetter + " " + type, 0);
                         } else {
                             try {
-                                id = Integer.parseInt(dccExTrackTypeIdEditText[i].getText().toString());
+                                id = Integer.parseInt(dccexTrackTypeIdEditText[i].getText().toString());
                                 mainapp.DccexTrackId[i] = Integer.toString(id);
                                 if (mainapp.DccexTrackType[i] != TRACK_TYPE_OFF_NONE_INDEX) {
                                     mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_TRACK, trackLetter + " " + type, id);
@@ -476,12 +470,12 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class clear_commands_button_listener implements View.OnClickListener {
+    public class ClearCommandsButtonListener implements View.OnClickListener {
         public void onClick(View v) {
-            DccexResponsesListHtml.clear();
-            DccexSendsListHtml.clear();
-            DccexResponsesStr = "";
-            DccexSendsStr = "";
+            dccexResponsesListHtml.clear();
+            dccexSendsListHtml.clear();
+            dccexResponsesStr = "";
+            dccexSendsStr = "";
             refreshDccexView();
         }
     }
@@ -519,15 +513,15 @@ public class dcc_ex extends AppCompatActivity {
     private void resetTextField(int which) {
         switch (which) {
             case WHICH_ADDRESS:
-                DccexAddress = "";
+                dccexAddress = "";
                 etDccexWriteAddressValue.setText("");
                 break;
             case WHICH_CV:
-                DccexCv = "";
+                dccexCv = "";
                 etDccexCv.setText("");
                 break;
             case WHICH_CV_VALUE:
-                DccexCvValue = "";
+                dccexCvValue = "";
                 etDccexCvValue.setText("");
                 break;
             case WHICH_COMMAND:
@@ -539,13 +533,13 @@ public class dcc_ex extends AppCompatActivity {
     private void readTextField(int which) {
         switch (which) {
             case WHICH_ADDRESS:
-                DccexAddress = etDccexWriteAddressValue.getText().toString();
+                dccexAddress = etDccexWriteAddressValue.getText().toString();
                 break;
             case WHICH_CV:
-                DccexCv = etDccexCv.getText().toString();
+                dccexCv = etDccexCv.getText().toString();
                 break;
             case WHICH_CV_VALUE:
-                DccexCvValue = etDccexCvValue.getText().toString();
+                dccexCvValue = etDccexCvValue.getText().toString();
                 break;
             case WHICH_COMMAND:
                 dccexSendCommandValue = etDccexSendCommandValue.getText().toString();
@@ -555,60 +549,60 @@ public class dcc_ex extends AppCompatActivity {
     private void showHideButtons() {
         if (mainapp.dccExActionTypeIndex != TRACK_MANAGER) {
             dexcProgrammingCommonCvsLayout.setVisibility(View.VISIBLE);
-            dccExCommonCvsSpinner.setVisibility(View.VISIBLE);
+            dccexCommonCvsSpinner.setVisibility(View.VISIBLE);
 
             dexcProgrammingAddressLayout.setVisibility(View.VISIBLE);
             dexcProgrammingCvLayout.setVisibility(View.VISIBLE);
             dexcDccexTrackLinearLayout.setVisibility(View.GONE);
-            DccexWriteInfoLayout.setVisibility(View.VISIBLE);
+            dccexWriteInfoLayout.setVisibility(View.VISIBLE);
 
             sendCommandButton.setEnabled(false);
-            writeAddressButton.setEnabled(DccexAddress.length() != 0);
-            readCvButton.setEnabled(DccexCv.length() != 0);
+            writeAddressButton.setEnabled(!dccexAddress.isEmpty());
+            readCvButton.setEnabled(!dccexCv.isEmpty());
             if (mainapp.dccExActionTypeIndex == PROGRAMMING_TRACK) {
-                writeCvButton.setEnabled(((DccexCv.length() != 0) && (DccexCvValue.length() != 0)));
+                writeCvButton.setEnabled(((!dccexCv.isEmpty()) && (!dccexCvValue.isEmpty())));
             } else {
-                writeCvButton.setEnabled(((DccexCv.length() != 0) && (DccexCvValue.length() != 0) && (DccexAddress.length() != 0)));
+                writeCvButton.setEnabled(((!dccexCv.isEmpty()) && (!dccexCvValue.isEmpty()) && (!dccexAddress.isEmpty())));
             }
         } else {
             dexcProgrammingCommonCvsLayout.setVisibility(View.GONE);
-            dccExCommonCvsSpinner.setVisibility(View.GONE);
+            dccexCommonCvsSpinner.setVisibility(View.GONE);
 
             dexcProgrammingAddressLayout.setVisibility(View.GONE);
             dexcProgrammingCvLayout.setVisibility(View.GONE);
-            DccexWriteInfoLayout.setVisibility(View.GONE);
+            dccexWriteInfoLayout.setVisibility(View.GONE);
             dexcDccexTrackLinearLayout.setVisibility(View.VISIBLE);
 
             for (int i = 0; i < threaded_application.DCCEX_MAX_TRACKS; i++) {
-                dccExTrackTypeIdEditText[i].setVisibility(TRACK_TYPES_NEED_ID[dccExTrackTypeIndex[i]] ? View.VISIBLE : View.GONE);
+                dccexTrackTypeIdEditText[i].setVisibility(TRACK_TYPES_NEED_ID[dccexTrackTypeIndex[i]] ? View.VISIBLE : View.GONE);
             }
         }
-        sendCommandButton.setEnabled((dccexSendCommandValue.length() != 0) && (dccexSendCommandValue.charAt(0) != '<'));
+        sendCommandButton.setEnabled((!dccexSendCommandValue.isEmpty()) && (dccexSendCommandValue.charAt(0) != '<'));
         previousCommandButton.setEnabled((mainapp.dccexPreviousCommandIndex >= 0));
         nextCommandButton.setEnabled((mainapp.dccexPreviousCommandIndex >= 0));
     }
 
     public void refreshDccexView() {
 
-        etDccexWriteAddressValue.setText(DccexAddress);
-        DccexWriteInfoLabel.setText(DccexInfoStr);
-        etDccexCv.setText(DccexCv);
-        etDccexCvValue.setText(DccexCvValue);
+        etDccexWriteAddressValue.setText(dccexAddress);
+        dccexWriteInfoLabel.setText(dccexInfoStr);
+        etDccexCv.setText(dccexCv);
+        etDccexCvValue.setText(dccexCvValue);
 //        etDccexSendCommandValue.setText(dccexSendCommandValue);
 
         if (mainapp.dccExActionTypeIndex == PROGRAMMING_TRACK) {
             readAddressButton.setVisibility(View.VISIBLE);
             writeAddressButton.setVisibility(View.VISIBLE);
             readCvButton.setVisibility(View.VISIBLE);
-            DccexHeadingLabel.setText(R.string.DCCEXheadingCvProgrammerProgTrack);
+            dccexHeadingLabel.setText(R.string.DCCEXheadingCvProgrammerProgTrack);
         } else {
             readAddressButton.setVisibility(View.GONE);
             writeAddressButton.setVisibility(View.GONE);
             readCvButton.setVisibility(View.GONE);
             if (mainapp.dccExActionTypeIndex != TRACK_MANAGER) {
-                DccexHeadingLabel.setText(R.string.DCCEXheadingCvProgrammerPoM);
+                dccexHeadingLabel.setText(R.string.DCCEXheadingCvProgrammerPoM);
             } else {
-                DccexHeadingLabel.setText(R.string.DCCEXheadingTrackManager);
+                dccexHeadingLabel.setText(R.string.DCCEXheadingTrackManager);
             }
         }
 
@@ -622,22 +616,22 @@ public class dcc_ex extends AppCompatActivity {
     }
 
     public void refreshDccexCommandsView() {
-        DccexResponsesLabel.setText(Html.fromHtml(DccexResponsesStr));
-        DccexSendsLabel.setText(Html.fromHtml(DccexSendsStr));
+        dccexResponsesLabel.setText(Html.fromHtml(dccexResponsesStr));
+        dccexSendsLabel.setText(Html.fromHtml(dccexSendsStr));
     }
 
     public void refreshDccexTracksView() {
 
         for (int i = 0; i < threaded_application.DCCEX_MAX_TRACKS; i++) {
-            dccExTrackTypeSpinner[i].setSelection(mainapp.DccexTrackType[i]);
-            dccExTrackTypeIdEditText[i].setText(mainapp.DccexTrackId[i]);
-            dccExTrackTypeLayout[i].setVisibility(mainapp.DccexTrackAvailable[i] ? View.VISIBLE : View.GONE);
+            dccexTrackTypeSpinner[i].setSelection(mainapp.DccexTrackType[i]);
+            dccexTrackTypeIdEditText[i].setText(mainapp.DccexTrackId[i]);
+            dccexTrackTypeLayout[i].setVisibility(mainapp.DccexTrackAvailable[i] ? View.VISIBLE : View.GONE);
             if (vn >= 5.002005) {
-                setPowerButton(dccExTrackPowerButton[i], mainapp.DccexTrackPower[i]);
+                setPowerButton(dccexTrackPowerButton[i], mainapp.DccexTrackPower[i]);
             } else {
-                dccExTrackPowerButton[i].setVisibility(View.GONE);
+                dccexTrackPowerButton[i].setVisibility(View.GONE);
             }
-            dccExTrackTypeSpinner[i].setEnabled(TRACK_TYPES_SELECTABLE[mainapp.DccexTrackType[i]]);
+            dccexTrackTypeSpinner[i].setEnabled(TRACK_TYPES_SELECTABLE[mainapp.DccexTrackType[i]]);
         }
         showHideButtons();
 
@@ -651,29 +645,44 @@ public class dcc_ex extends AppCompatActivity {
         String currentTime = sdf.format(new Date());
 
         if (inbound) {
-            DccexResponsesListHtml.add("<small><small>" + currentTime + " </small></small> ◄ : <b>" + Html.escapeHtml(msg) + "</b><br />");
+            dccexResponsesListHtml.add("<small><small>" + currentTime + " </small></small> ◄ : <b>" + Html.escapeHtml(msg) + "</b><br />");
         } else {
 //            DccexSendsListHtml.add("<small><small>" + currentTime + " </small></small> ► : &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp <i>" + Html.escapeHtml(msg) + "</i><br />");
-            DccexSendsListHtml.add("<small><small>" + currentTime + " </small></small> ► : <i>" + Html.escapeHtml(msg) + "</i><br />");
+            dccexSendsListHtml.add("<small><small>" + currentTime + " </small></small> ► : <i>" + Html.escapeHtml(msg) + "</i><br />");
         }
-        if (DccexResponsesListHtml.size() > 40) {
-            DccexResponsesListHtml.remove(0);
+        if (dccexResponsesListHtml.size() > 40) {
+            dccexResponsesListHtml.remove(0);
         }
-        if (DccexSendsListHtml.size() > 30) {
-            DccexSendsListHtml.remove(0);
+        if (dccexSendsListHtml.size() > 30) {
+            dccexSendsListHtml.remove(0);
         }
 
-        DccexResponsesStr = "<p>";
-        for (int i = 0; i < DccexResponsesListHtml.size(); i++) {
-            DccexResponsesStr = DccexResponsesListHtml.get(i) + DccexResponsesStr;
+//        dccexResponsesStr = "<p>";
+//        for (int i = 0; i < dccexResponsesListHtml.size(); i++) {
+//            dccexResponsesStr = dccexResponsesListHtml.get(i) + dccexResponsesStr;
+//        }
+//        dccexResponsesStr = dccexResponsesStr + "</p>";
+        StringBuilder sb = new StringBuilder(100);
+        sb.append("<p>");
+        for (int i = 0; i < dccexResponsesListHtml.size(); i++) {
+            sb.insert(0, dccexResponsesListHtml.get(i));
         }
-        DccexResponsesStr = DccexResponsesStr + "</p>";
+        sb.append("</p>");
+        dccexResponsesStr = sb.toString();
 
-        DccexSendsStr = "<p>";
-        for (int i=0; i < DccexSendsListHtml.size(); i++) {
-            DccexSendsStr = DccexSendsListHtml.get(i) + DccexSendsStr;
+//        dccexSendsStr = "<p>";
+//        for (int i=0; i < dccexSendsListHtml.size(); i++) {
+//            dccexSendsStr = dccexSendsListHtml.get(i) + dccexSendsStr;
+//        }
+//        dccexSendsStr = dccexSendsStr + "</p>";
+        sb = new StringBuilder(100);
+        sb.append("<p>");
+        for (int i = 0; i < dccexSendsListHtml.size(); i++) {
+            sb.insert(0, dccexSendsListHtml.get(i));
         }
-        DccexSendsStr = DccexSendsStr + "</p>";
+        sb.append("</p>");
+        dccexSendsStr = sb.toString();
+
     }
 
     // ************************************************************************************************************* //
@@ -694,15 +703,15 @@ public class dcc_ex extends AppCompatActivity {
         setContentView(R.layout.dcc_ex);
 
         //put pointer to this activity's handler in main app's shared variable (If needed)
-        mainapp.dcc_ex_msg_handler = new dcc_ex_handler(Looper.getMainLooper());
+        mainapp.dcc_ex_msg_handler = new DccExMessageHandler(Looper.getMainLooper());
 
         readAddressButton = findViewById(R.id.dexc_DccexReadAddressButton);
-        read_address_button_listener read_address_click_listener = new read_address_button_listener();
-        readAddressButton.setOnClickListener(read_address_click_listener);
+        ReadAddressButtonListener readAddressButtonListener = new ReadAddressButtonListener();
+        readAddressButton.setOnClickListener(readAddressButtonListener);
 
         writeAddressButton = findViewById(R.id.dexc_DccexWriteAddressButton);
-        write_address_button_listener write_address_click_listener = new write_address_button_listener();
-        writeAddressButton.setOnClickListener(write_address_click_listener);
+        WriteAddressButtonListener writeAddressButtonListener = new WriteAddressButtonListener();
+        writeAddressButton.setOnClickListener(writeAddressButtonListener);
 
         etDccexWriteAddressValue = findViewById(R.id.dexc_DccexWriteAddressValue);
         etDccexWriteAddressValue.setText("");
@@ -713,12 +722,12 @@ public class dcc_ex extends AppCompatActivity {
         });
 
         readCvButton = findViewById(R.id.dexc_DccexReadCvButton);
-        read_cv_button_listener readCvClickListener = new read_cv_button_listener();
-        readCvButton.setOnClickListener(readCvClickListener);
+        ReadCvButtonListener readCvButtonListener = new ReadCvButtonListener();
+        readCvButton.setOnClickListener(readCvButtonListener);
 
         writeCvButton = findViewById(R.id.dexc_DccexWriteCvButton);
-        write_cv_button_listener writeCvClickListener = new write_cv_button_listener();
-        writeCvButton.setOnClickListener(writeCvClickListener);
+        WriteCvButtonListener writeCvButtonListener = new WriteCvButtonListener();
+        writeCvButton.setOnClickListener(writeCvButtonListener);
 
         etDccexCv = findViewById(R.id.dexc_DccexCv);
         etDccexCv.setText("");
@@ -737,8 +746,8 @@ public class dcc_ex extends AppCompatActivity {
         });
 
         sendCommandButton = findViewById(R.id.dexc_DccexSendCommandButton);
-        send_command_button_listener sendCommandClickListener = new send_command_button_listener();
-        sendCommandButton.setOnClickListener(sendCommandClickListener);
+        SendCommandButtonListener sendCommandButtonListener = new SendCommandButtonListener();
+        sendCommandButton.setOnClickListener(sendCommandButtonListener);
 
         etDccexSendCommandValue = findViewById(R.id.dexc_DccexSendCommandValue);
         etDccexSendCommandValue.setInputType(TYPE_TEXT_FLAG_AUTO_CORRECT);
@@ -748,28 +757,28 @@ public class dcc_ex extends AppCompatActivity {
             public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
             public void onTextChanged(CharSequence s, int start, int before, int count) { }
         });
-        DccexWriteInfoLayout = findViewById(R.id.dexc_DccexWriteInfoLayout);
-        DccexWriteInfoLabel = findViewById(R.id.dexc_DccexWriteInfoLabel);
-        DccexWriteInfoLabel.setText("");
+        dccexWriteInfoLayout = findViewById(R.id.dexc_DccexWriteInfoLayout);
+        dccexWriteInfoLabel = findViewById(R.id.dexc_DccexWriteInfoLabel);
+        dccexWriteInfoLabel.setText("");
 
-        DccexHeadingLabel = findViewById(R.id.dccex_HeadingLabel);
+        dccexHeadingLabel = findViewById(R.id.dccex_HeadingLabel);
 
         previousCommandButton = findViewById(R.id.dexc_DccexPreviousCommandButton);
-        previous_command_button_listener previousCommandClickListener = new previous_command_button_listener();
-        previousCommandButton.setOnClickListener(previousCommandClickListener);
+        PreviousCommandButtonListener previousCommandButtonListener = new PreviousCommandButtonListener();
+        previousCommandButton.setOnClickListener(previousCommandButtonListener);
 
         nextCommandButton = findViewById(R.id.dexc_DccexNextCommandButton);
-        next_command_button_listener nextCommandClickListener = new next_command_button_listener();
-        nextCommandButton.setOnClickListener(nextCommandClickListener);
+        NextCommandButtonListener nextCommandButtonListener = new NextCommandButtonListener();
+        nextCommandButton.setOnClickListener(nextCommandButtonListener);
 
-        DccexResponsesLabel = findViewById(R.id.dexc_DccexResponsesLabel);
-        DccexResponsesLabel.setText("");
-        DccexSendsLabel = findViewById(R.id.dexc_DccexSendsLabel);
-        DccexSendsLabel.setText("");
+        dccexResponsesLabel = findViewById(R.id.dexc_DccexResponsesLabel);
+        dccexResponsesLabel.setText("");
+        dccexSendsLabel = findViewById(R.id.dexc_DccexSendsLabel);
+        dccexSendsLabel.setText("");
 
         Button closeButton = findViewById(R.id.dcc_ex_button_close);
-        close_button_listener closeClickListener = new close_button_listener();
-        closeButton.setOnClickListener(closeClickListener);
+        CloseButtonListener closeButtonListener = new CloseButtonListener();
+        closeButton.setOnClickListener(closeButtonListener);
 
         dccCvsEntryValuesArray = this.getResources().getStringArray(R.array.dccCvsEntryValues);
 //        final List<String> dccCvsValuesList = new ArrayList<>(Arrays.asList(dccCvsEntryValuesArray));
@@ -777,93 +786,93 @@ public class dcc_ex extends AppCompatActivity {
 //        final List<String> dccCvsEntriesList = new ArrayList<>(Arrays.asList(dccCvsEntriesArray));
 
         dccCvsIndex = 0;
-        dccExCommonCvsSpinner = findViewById(R.id.dexc_dcc_cv_list);
+        dccexCommonCvsSpinner = findViewById(R.id.dexc_dcc_cv_list);
         ArrayAdapter<?> spinner_adapter = ArrayAdapter.createFromResource(this, R.array.dccCvsEntries, android.R.layout.simple_spinner_item);
         spinner_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        dccExCommonCvsSpinner.setAdapter(spinner_adapter);
-        dccExCommonCvsSpinner.setOnItemSelectedListener(new spinner_listener());
-        dccExCommonCvsSpinner.setSelection(dccCvsIndex);
+        dccexCommonCvsSpinner.setAdapter(spinner_adapter);
+        dccexCommonCvsSpinner.setOnItemSelectedListener(new DccExCommonCvsSpinnerListener());
+        dccexCommonCvsSpinner.setSelection(dccCvsIndex);
 
-        dccExCommonCommandsEntryValuesArray = this.getResources().getStringArray(R.array.dccExCommonCommandsEntryValues);
+        dccexCommonCommandsEntryValuesArray = this.getResources().getStringArray(R.array.dccExCommonCommandsEntryValues);
 //        final List<String> dccCommonCommandsValuesList = new ArrayList<>(Arrays.asList(dccExCommonCommandsEntryValuesArray));
-        dccExCommonCommandsEntriesArray = this.getResources().getStringArray(R.array.dccExCommonCommandsEntries); // display version
+        dccexCommonCommandsEntriesArray = this.getResources().getStringArray(R.array.dccExCommonCommandsEntries); // display version
 //        final List<String> dccCommonCommandsEntriesList = new ArrayList<>(Arrays.asList(dccExCommonCommandsEntriesArray));
-        dccExCommonCommandsHasParametersArray = this.getResources().getIntArray(R.array.dccExCommonCommandsHasParameters);
+        dccexCommonCommandsHasParametersArray = this.getResources().getIntArray(R.array.dccExCommonCommandsHasParameters);
 
         dccCmdIndex = 0;
-        dccExCommonCommandsSpinner = findViewById(R.id.dexc_common_commands_list);
+        dccexCommonCommandsSpinner = findViewById(R.id.dexc_common_commands_list);
         spinner_adapter = ArrayAdapter.createFromResource(this, R.array.dccExCommonCommandsEntries, android.R.layout.simple_spinner_item);
         spinner_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        dccExCommonCommandsSpinner.setAdapter(spinner_adapter);
-        dccExCommonCommandsSpinner.setOnItemSelectedListener(new command_spinner_listener());
-        dccExCommonCommandsSpinner.setSelection(dccCmdIndex);
+        dccexCommonCommandsSpinner.setAdapter(spinner_adapter);
+        dccexCommonCommandsSpinner.setOnItemSelectedListener(new DccExCommonCommandsSpinnerListener());
+        dccexCommonCommandsSpinner.setSelection(dccCmdIndex);
 
         vn = 4;
         try {
-            vn = Float.valueOf(mainapp.DccexVersion);
+            vn = Float.parseFloat(mainapp.DccexVersion);
         } catch (Exception ignored) { } // invalid version
 
         if (vn <= 04.002007) {  // need to remove the track manager option
-            dccExActionTypeEntryValuesArray = new String[2];
-            dccExActionTypeEntriesArray = new String[2];
+            dccexActionTypeEntryValuesArray = new String[2];
+            dccexActionTypeEntriesArray = new String[2];
             for (int i = 0; i < 2; i++) {
-                dccExActionTypeEntryValuesArray[i] = this.getResources().getStringArray(R.array.dccExActionTypeEntryValues)[i];
-                dccExActionTypeEntriesArray[i] = this.getResources().getStringArray(R.array.dccExActionTypeEntries)[i];
+                dccexActionTypeEntryValuesArray[i] = this.getResources().getStringArray(R.array.dccExActionTypeEntryValues)[i];
+                dccexActionTypeEntriesArray[i] = this.getResources().getStringArray(R.array.dccExActionTypeEntries)[i];
             }
         } else {
-            dccExActionTypeEntryValuesArray = this.getResources().getStringArray(R.array.dccExActionTypeEntryValues);
-            dccExActionTypeEntriesArray = this.getResources().getStringArray(R.array.dccExActionTypeEntries); // display version
+            dccexActionTypeEntryValuesArray = this.getResources().getStringArray(R.array.dccExActionTypeEntryValues);
+            dccexActionTypeEntriesArray = this.getResources().getStringArray(R.array.dccExActionTypeEntries); // display version
         }
-        final List<String> dccActionTypeValuesList = new ArrayList<>(Arrays.asList(dccExActionTypeEntryValuesArray));
-        final List<String> dccActionTypeEntriesList = new ArrayList<>(Arrays.asList(dccExActionTypeEntriesArray));
+        final List<String> dccActionTypeValuesList = new ArrayList<>(Arrays.asList(dccexActionTypeEntryValuesArray));
+        final List<String> dccActionTypeEntriesList = new ArrayList<>(Arrays.asList(dccexActionTypeEntriesArray));
 
 //        mainapp.dccExActionTypeIndex = PROGRAMMING_TRACK;
-        dcc_action_type_spinner = findViewById(R.id.dexc_action_type_list);
-//        ArrayAdapter<?> action_type_spinner_adapter = ArrayAdapter.createFromResource(this, R.array.dccExActionTypeEntries, android.R.layout.simple_spinner_item);
-        ArrayAdapter<?> action_type_spinner_adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, dccExActionTypeEntriesArray);
-        action_type_spinner_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        dcc_action_type_spinner.setAdapter(action_type_spinner_adapter);
-        dcc_action_type_spinner.setOnItemSelectedListener(new action_type_spinner_listener());
-        dcc_action_type_spinner.setSelection(mainapp.dccExActionTypeIndex);
+        dccActionTypeSpinner = findViewById(R.id.dexc_action_type_list);
+//        ArrayAdapter<?> dccActionTypeSpinnerAdapter = ArrayAdapter.createFromResource(this, R.array.dccExActionTypeEntries, android.R.layout.simple_spinner_item);
+        ArrayAdapter<?> dccActionTypeSpinnerAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, dccexActionTypeEntriesArray);
+        dccActionTypeSpinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        dccActionTypeSpinner.setAdapter(dccActionTypeSpinnerAdapter);
+        dccActionTypeSpinner.setOnItemSelectedListener(new DccActionTypeSpinnerListener());
+        dccActionTypeSpinner.setSelection(mainapp.dccExActionTypeIndex);
 
         LinearLayout cv_programmer_layout = findViewById(R.id.dccex_cv_programmer_prog_track_layout);
-        dccex_navigation_button_listener navigation_button_listener = new dccex_navigation_button_listener(0);
-        cv_programmer_layout.setOnClickListener(navigation_button_listener);
+        DccExNavigationButtonListener dccExNavigationButtonListener = new DccExNavigationButtonListener(0);
+        cv_programmer_layout.setOnClickListener(dccExNavigationButtonListener);
         Button cv_programmer_button = findViewById(R.id.dccex_cv_programmer_prog_track_button);
-        navigation_button_listener = new dccex_navigation_button_listener(0);
-        cv_programmer_button.setOnClickListener(navigation_button_listener);
+        dccExNavigationButtonListener = new DccExNavigationButtonListener(0);
+        cv_programmer_button.setOnClickListener(dccExNavigationButtonListener);
 
         cv_programmer_layout = findViewById(R.id.dccex_cv_programmer_pom_layout);
-        navigation_button_listener = new dccex_navigation_button_listener(1);
-        cv_programmer_layout.setOnClickListener(navigation_button_listener);
+        dccExNavigationButtonListener = new DccExNavigationButtonListener(1);
+        cv_programmer_layout.setOnClickListener(dccExNavigationButtonListener);
         cv_programmer_button = findViewById(R.id.dccex_cv_programmer_pom_button);
-        navigation_button_listener = new dccex_navigation_button_listener(1);
-        cv_programmer_button.setOnClickListener(navigation_button_listener);
+        dccExNavigationButtonListener = new DccExNavigationButtonListener(1);
+        cv_programmer_button.setOnClickListener(dccExNavigationButtonListener);
 
         cv_programmer_layout = findViewById(R.id.dccex_track_manager_layout);
-        navigation_button_listener = new dccex_navigation_button_listener(2);
-        cv_programmer_layout.setOnClickListener(navigation_button_listener);
+        dccExNavigationButtonListener = new DccExNavigationButtonListener(2);
+        cv_programmer_layout.setOnClickListener(dccExNavigationButtonListener);
         cv_programmer_button = findViewById(R.id.dccex_track_manager_button);
-        navigation_button_listener = new dccex_navigation_button_listener(2);
-        cv_programmer_button.setOnClickListener(navigation_button_listener);
+        dccExNavigationButtonListener = new DccExNavigationButtonListener(2);
+        cv_programmer_button.setOnClickListener(dccExNavigationButtonListener);
 
         LinearLayout default_functions_layout = findViewById(R.id.dccex_default_functions_layout);
-        dccex_default_functions_button_listener default_functions_button_listener = new dccex_default_functions_button_listener(this);
-        default_functions_layout.setOnClickListener(default_functions_button_listener);
+        DccexDefaultFunctionsButtonListener dccexDefaultFunctionsButtonListener = new DccexDefaultFunctionsButtonListener(this);
+        default_functions_layout.setOnClickListener(dccexDefaultFunctionsButtonListener);
         Button default_functions_button = findViewById(R.id.dccex_default_functions_button);
-        default_functions_button_listener = new dccex_default_functions_button_listener(this);
-        default_functions_button.setOnClickListener(default_functions_button_listener);
+        dccexDefaultFunctionsButtonListener = new DccexDefaultFunctionsButtonListener(this);
+        default_functions_button.setOnClickListener(dccexDefaultFunctionsButtonListener);
 
         dexcProgrammingCommonCvsLayout = findViewById(R.id.dexc_programmingCommonCvsLayout);
         dexcProgrammingAddressLayout = findViewById(R.id.dexc_programmingAddressLayout);
         dexcProgrammingCvLayout = findViewById(R.id.dexc_programmingCvLayout);
         dexcDccexTrackLinearLayout = findViewById(R.id.dexc_DccexTrackLinearLayout);
 
-        dccExTrackTypeEntryValuesArray = this.getResources().getStringArray(R.array.dccExTrackTypeEntryValues);
+        dccexTrackTypeEntryValuesArray = this.getResources().getStringArray(R.array.dccExTrackTypeEntryValues);
 //        final List<String> dccTrackTypeValuesList = new ArrayList<>(Arrays.asList(dccExTrackTypeEntryValuesArray));
-        dccExTrackTypeEntriesArray = this.getResources().getStringArray(R.array.dccExTrackTypeEntries); // display version
+        dccexTrackTypeEntriesArray = this.getResources().getStringArray(R.array.dccExTrackTypeEntries); // display version
         if (vn <= 04.002068) {  /// need to change the NONE to OFF in track manager
-            dccExTrackTypeEntriesArray[0] = "OFF";
+            dccexTrackTypeEntriesArray[0] = "OFF";
         }
 //        final List<String> dccTrackTypeEntriesList = new ArrayList<>(Arrays.asList(dccExTrackTypeEntriesArray));
 
@@ -871,74 +880,74 @@ public class dcc_ex extends AppCompatActivity {
             switch (i) {
                 default:
                 case 0:
-                    dccExTrackTypeLayout[0] = findViewById(R.id.dexc_DccexTrack0layout);
-                    dccExTrackPowerButton[0] = findViewById(R.id.dccex_power_control_button_0);
-                    dccExTrackTypeSpinner[0] = findViewById(R.id.dexc_track_type_0_list);
-                    dccExTrackTypeIdEditText[0] = findViewById(R.id.dexc_track_0_value);
+                    dccexTrackTypeLayout[0] = findViewById(R.id.dexc_DccexTrack0layout);
+                    dccexTrackPowerButton[0] = findViewById(R.id.dccex_power_control_button_0);
+                    dccexTrackTypeSpinner[0] = findViewById(R.id.dexc_track_type_0_list);
+                    dccexTrackTypeIdEditText[0] = findViewById(R.id.dexc_track_0_value);
                     break;
                 case 1:
-                    dccExTrackTypeLayout[1] = findViewById(R.id.dexc_DccexTrack1layout);
-                    dccExTrackPowerButton[1] = findViewById(R.id.dccex_power_control_button_1);
-                    dccExTrackTypeSpinner[1] = findViewById(R.id.dexc_track_type_1_list);
-                    dccExTrackTypeIdEditText[1] = findViewById(R.id.dexc_track_1_value);
+                    dccexTrackTypeLayout[1] = findViewById(R.id.dexc_DccexTrack1layout);
+                    dccexTrackPowerButton[1] = findViewById(R.id.dccex_power_control_button_1);
+                    dccexTrackTypeSpinner[1] = findViewById(R.id.dexc_track_type_1_list);
+                    dccexTrackTypeIdEditText[1] = findViewById(R.id.dexc_track_1_value);
                     break;
                 case 2:
-                    dccExTrackTypeLayout[2] = findViewById(R.id.dexc_DccexTrack2layout);
-                    dccExTrackPowerButton[2] = findViewById(R.id.dccex_power_control_button_2);
-                    dccExTrackTypeSpinner[2] = findViewById(R.id.dexc_track_type_2_list);
-                    dccExTrackTypeIdEditText[2] = findViewById(R.id.dexc_track_2_value);
+                    dccexTrackTypeLayout[2] = findViewById(R.id.dexc_DccexTrack2layout);
+                    dccexTrackPowerButton[2] = findViewById(R.id.dccex_power_control_button_2);
+                    dccexTrackTypeSpinner[2] = findViewById(R.id.dexc_track_type_2_list);
+                    dccexTrackTypeIdEditText[2] = findViewById(R.id.dexc_track_2_value);
                     break;
                 case 3:
-                    dccExTrackTypeLayout[3] = findViewById(R.id.dexc_DccexTrack3layout);
-                    dccExTrackPowerButton[3] = findViewById(R.id.dccex_power_control_button_3);
-                    dccExTrackTypeSpinner[3] = findViewById(R.id.dexc_track_type_3_list);
-                    dccExTrackTypeIdEditText[3] = findViewById(R.id.dexc_track_3_value);
+                    dccexTrackTypeLayout[3] = findViewById(R.id.dexc_DccexTrack3layout);
+                    dccexTrackPowerButton[3] = findViewById(R.id.dccex_power_control_button_3);
+                    dccexTrackTypeSpinner[3] = findViewById(R.id.dexc_track_type_3_list);
+                    dccexTrackTypeIdEditText[3] = findViewById(R.id.dexc_track_3_value);
                     break;
                 case 4:
-                    dccExTrackTypeLayout[4] = findViewById(R.id.dexc_DccexTrack4layout);
-                    dccExTrackPowerButton[4] = findViewById(R.id.dccex_power_control_button_4);
-                    dccExTrackTypeSpinner[4] = findViewById(R.id.dexc_track_type_4_list);
-                    dccExTrackTypeIdEditText[4] = findViewById(R.id.dexc_track_4_value);
+                    dccexTrackTypeLayout[4] = findViewById(R.id.dexc_DccexTrack4layout);
+                    dccexTrackPowerButton[4] = findViewById(R.id.dccex_power_control_button_4);
+                    dccexTrackTypeSpinner[4] = findViewById(R.id.dexc_track_type_4_list);
+                    dccexTrackTypeIdEditText[4] = findViewById(R.id.dexc_track_4_value);
                     break;
                 case 5:
-                    dccExTrackTypeLayout[5] = findViewById(R.id.dexc_DccexTrack5layout);
-                    dccExTrackPowerButton[5] = findViewById(R.id.dccex_power_control_button_5);
-                    dccExTrackTypeSpinner[5] = findViewById(R.id.dexc_track_type_5_list);
-                    dccExTrackTypeIdEditText[5] = findViewById(R.id.dexc_track_5_value);
+                    dccexTrackTypeLayout[5] = findViewById(R.id.dexc_DccexTrack5layout);
+                    dccexTrackPowerButton[5] = findViewById(R.id.dccex_power_control_button_5);
+                    dccexTrackTypeSpinner[5] = findViewById(R.id.dexc_track_type_5_list);
+                    dccexTrackTypeIdEditText[5] = findViewById(R.id.dexc_track_5_value);
                     break;
                 case 6:
-                    dccExTrackTypeLayout[6] = findViewById(R.id.dexc_DccexTrack6layout);
-                    dccExTrackPowerButton[6] = findViewById(R.id.dccex_power_control_button_6);
-                    dccExTrackTypeSpinner[6] = findViewById(R.id.dexc_track_type_6_list);
-                    dccExTrackTypeIdEditText[6] = findViewById(R.id.dexc_track_6_value);
+                    dccexTrackTypeLayout[6] = findViewById(R.id.dexc_DccexTrack6layout);
+                    dccexTrackPowerButton[6] = findViewById(R.id.dccex_power_control_button_6);
+                    dccexTrackTypeSpinner[6] = findViewById(R.id.dexc_track_type_6_list);
+                    dccexTrackTypeIdEditText[6] = findViewById(R.id.dexc_track_6_value);
                     break;
                 case 7:
-                    dccExTrackTypeLayout[7] = findViewById(R.id.dexc_DccexTrack7layout);
-                    dccExTrackPowerButton[7] = findViewById(R.id.dccex_power_control_button_7);
-                    dccExTrackTypeSpinner[7] = findViewById(R.id.dexc_track_type_7_list);
-                    dccExTrackTypeIdEditText[7] = findViewById(R.id.dexc_track_7_value);
+                    dccexTrackTypeLayout[7] = findViewById(R.id.dexc_DccexTrack7layout);
+                    dccexTrackPowerButton[7] = findViewById(R.id.dccex_power_control_button_7);
+                    dccexTrackTypeSpinner[7] = findViewById(R.id.dexc_track_type_7_list);
+                    dccexTrackTypeIdEditText[7] = findViewById(R.id.dexc_track_7_value);
                     break;
             }
             ArrayAdapter<?> track_type_spinner_adapter = ArrayAdapter.createFromResource(this, R.array.dccExTrackTypeEntries, android.R.layout.simple_spinner_item);
             track_type_spinner_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-            dccExTrackTypeSpinner[i].setAdapter(track_type_spinner_adapter);
-            dccExTrackTypeSpinner[i].setOnItemSelectedListener(new track_type_spinner_listener(dccExTrackTypeSpinner[i], i));
-            dccExTrackTypeSpinner[i].setSelection(dccExTrackTypeIndex[i]);
+            dccexTrackTypeSpinner[i].setAdapter(track_type_spinner_adapter);
+            dccexTrackTypeSpinner[i].setOnItemSelectedListener(new TrackTypeCommonCvsSpinnerListenerr(dccexTrackTypeSpinner[i], i));
+            dccexTrackTypeSpinner[i].setSelection(dccexTrackTypeIndex[i]);
 
             SetTrackPowerButtonListener  buttonListener = new SetTrackPowerButtonListener(i);
-            dccExTrackPowerButton[i].setOnClickListener(buttonListener);
+            dccexTrackPowerButton[i].setOnClickListener(buttonListener);
         }
 
         writeTracksButton = findViewById(R.id.dexc_DccexWriteTracksButton);
-        write_tracks_button_listener writeTracksClickListener = new write_tracks_button_listener();
-        writeTracksButton.setOnClickListener(writeTracksClickListener);
+        WriteTracksButtonListener writeTracksButtonListener = new WriteTracksButtonListener();
+        writeTracksButton.setOnClickListener(writeTracksButtonListener);
 
-        DccexResponsesScrollView = findViewById(R.id.dexc_DccexResponsesScrollView);
-        DccexSendsScrollView = findViewById(R.id.dexc_DccexSendsScrollView);
+        ScrollView dccexResponsesScrollView = findViewById(R.id.dexc_DccexResponsesScrollView);
+        ScrollView dccexSendsScrollView = findViewById(R.id.dexc_DccexSendsScrollView);
 
         clearCommandsButton = findViewById(R.id.dexc_DCCEXclearCommandsButton);
-        clear_commands_button_listener clearCommandsClickListener = new clear_commands_button_listener();
-        clearCommandsButton.setOnClickListener(clearCommandsClickListener);
+        ClearCommandsButtonListener clearCommandsButtonListener = new ClearCommandsButtonListener();
+        clearCommandsButton.setOnClickListener(clearCommandsButtonListener);
 
 //            hideSendsButton = findViewById(R.id.dexc_DccexHideSendsButton);
 //            hide_sends_button_listener hideSendsClickListener = new hide_sends_button_listener();
@@ -947,9 +956,9 @@ public class dcc_ex extends AppCompatActivity {
 
         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQUEST_TRACKS, "");
 
-        screenNameLine = findViewById(R.id.screen_name_line);
-        toolbar = findViewById(R.id.toolbar);
-        statusLine = findViewById(R.id.status_line);
+        LinearLayout screenNameLine = findViewById(R.id.screen_name_line);
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        LinearLayout statusLine = findViewById(R.id.status_line);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
             Objects.requireNonNull(getSupportActionBar()).setDisplayShowTitleEnabled(false);
@@ -1038,7 +1047,7 @@ public class dcc_ex extends AppCompatActivity {
         super.attachBaseContext(LocaleHelper.onAttach(base));
     }
 
-    public class close_button_listener implements View.OnClickListener {
+    public class CloseButtonListener implements View.OnClickListener {
         public void onClick(View v) {
             mainapp.buttonVibration();
             finish();
@@ -1094,21 +1103,21 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class spinner_listener implements AdapterView.OnItemSelectedListener {
+    public class DccExCommonCvsSpinnerListener implements AdapterView.OnItemSelectedListener {
 
         @SuppressLint("ApplySharedPref")
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
 
-            dccCvsIndex = dccExCommonCvsSpinner.getSelectedItemPosition();
+            dccCvsIndex = dccexCommonCvsSpinner.getSelectedItemPosition();
             if (dccCvsIndex > 0) {
-                DccexCv = dccCvsEntryValuesArray[dccCvsIndex];
+                dccexCv = dccCvsEntryValuesArray[dccCvsIndex];
                 resetTextField(WHICH_CV_VALUE);
                 etDccexCvValue.requestFocus();
             }
             dccCvsIndex = 0;
-            dccExCommonCvsSpinner.setSelection(dccCvsIndex);
-            DccexInfoStr = "";
+            dccexCommonCvsSpinner.setSelection(dccCvsIndex);
+            dccexInfoStr = "";
 
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -1125,24 +1134,24 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class command_spinner_listener implements AdapterView.OnItemSelectedListener {
+    public class DccExCommonCommandsSpinnerListener implements AdapterView.OnItemSelectedListener {
 
         @SuppressLint("ApplySharedPref")
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
 
-            dccCmdIndex = dccExCommonCommandsSpinner.getSelectedItemPosition();
+            dccCmdIndex = dccexCommonCommandsSpinner.getSelectedItemPosition();
             if (dccCmdIndex > 0) {
-                dccexSendCommandValue = dccExCommonCommandsEntryValuesArray[dccCmdIndex];
-                if (dccExCommonCommandsHasParametersArray[dccCmdIndex] > 0)
+                dccexSendCommandValue = dccexCommonCommandsEntryValuesArray[dccCmdIndex];
+                if (dccexCommonCommandsHasParametersArray[dccCmdIndex] > 0)
                     dccexSendCommandValue = dccexSendCommandValue + " ";
                 etDccexSendCommandValue.setText(dccexSendCommandValue);
                 etDccexSendCommandValue.requestFocus();
                 etDccexSendCommandValue.setSelection(dccexSendCommandValue.length());
             }
             dccCmdIndex = 0;
-            dccExCommonCommandsSpinner.setSelection(dccCmdIndex);
-            DccexInfoStr = "";
+            dccexCommonCommandsSpinner.setSelection(dccCmdIndex);
+            dccexInfoStr = "";
 
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -1159,7 +1168,7 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class action_type_spinner_listener implements AdapterView.OnItemSelectedListener {
+    public class DccActionTypeSpinnerListener implements AdapterView.OnItemSelectedListener {
 
         @SuppressLint("ApplySharedPref")
         @Override
@@ -1169,7 +1178,7 @@ public class dcc_ex extends AppCompatActivity {
             mainapp.dccExActionTypeIndex = spinner.getSelectedItemPosition();
             resetTextField(WHICH_CV);
             resetTextField(WHICH_CV_VALUE);
-            DccexInfoStr = "";
+            dccexInfoStr = "";
 
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -1178,7 +1187,7 @@ public class dcc_ex extends AppCompatActivity {
             }
 
             dccCvsIndex = 0;
-            dccExCommonCvsSpinner.setSelection(dccCvsIndex);
+            dccexCommonCvsSpinner.setSelection(dccCvsIndex);
 
             refreshDccexView();
             refreshDccexTracksView();
@@ -1190,11 +1199,11 @@ public class dcc_ex extends AppCompatActivity {
         }
     }
 
-    public class track_type_spinner_listener implements AdapterView.OnItemSelectedListener {
-        Spinner mySpinner;
-        int myIndex;
+    public class TrackTypeCommonCvsSpinnerListenerr implements AdapterView.OnItemSelectedListener {
+        final Spinner mySpinner;
+        final int myIndex;
 
-        track_type_spinner_listener(Spinner spinner, int index) {
+        TrackTypeCommonCvsSpinnerListenerr(Spinner spinner, int index) {
             mySpinner = spinner;
             myIndex = index;
         }
@@ -1203,15 +1212,15 @@ public class dcc_ex extends AppCompatActivity {
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
 
-            dccExTrackTypeIndex[myIndex] = mySpinner.getSelectedItemPosition();
-            if (dccExTrackTypeIndex[myIndex] == TRACK_TYPE_DCC_PROG_INDEX) {
+            dccexTrackTypeIndex[myIndex] = mySpinner.getSelectedItemPosition();
+            if (dccexTrackTypeIndex[myIndex] == TRACK_TYPE_DCC_PROG_INDEX) {
                 for (int i=0; i < 8; i++) {
-                    if ((dccExTrackTypeIndex[i] == TRACK_TYPE_DCC_PROG_INDEX) && (myIndex != i)) { // only one prog allowed
-                        dccExTrackTypeSpinner[i].setSelection(TRACK_TYPE_OFF_NONE_INDEX);
+                    if ((dccexTrackTypeIndex[i] == TRACK_TYPE_DCC_PROG_INDEX) && (myIndex != i)) { // only one prog allowed
+                        dccexTrackTypeSpinner[i].setSelection(TRACK_TYPE_OFF_NONE_INDEX);
                     }
                 }
             }
-            if (!TRACK_TYPES_SELECTABLE[dccExTrackTypeIndex[myIndex]]) {  // invalid option. reset the lot.
+            if (!TRACK_TYPES_SELECTABLE[dccexTrackTypeIndex[myIndex]]) {  // invalid option. reset the lot.
                 refreshDccexTracksView();
             }
 
@@ -1272,12 +1281,12 @@ public class dcc_ex extends AppCompatActivity {
                 }
                 rslt = rslt + cv29AddressSize;
 
-                DccexResponsesStr = "<p>" + rslt + "</p>" + DccexResponsesStr;
+                dccexResponsesStr = "<p>" + rslt + "</p>" + dccexResponsesStr;
 
-                DccexResponsesStr = "<p>"
+                dccexResponsesStr = "<p>"
                         + String.format(getApplicationContext().getResources().getString(R.string.cv29SpeedToggleDirection),
                         mainapp.toggleBit(cvValue, 1))
-                        + "</p>" + DccexResponsesStr;
+                        + "</p>" + dccexResponsesStr;
 
             } catch (Exception e) {
                 Log.e("EX_Toolbox", "Error processing cv29: " + e.getMessage());
@@ -1302,24 +1311,24 @@ public class dcc_ex extends AppCompatActivity {
         btn.setBackground(img);
     }
 
-    public class dccex_navigation_button_listener implements View.OnClickListener {
-        int myIndex;
+    public class DccExNavigationButtonListener implements View.OnClickListener {
+        final int myIndex;
 
-        dccex_navigation_button_listener(int index) {
+        DccExNavigationButtonListener(int index) {
             myIndex = index;
         }
 
         public void onClick(View v) {
             mainapp.buttonVibration();
-            dcc_action_type_spinner.setSelection(myIndex);
+            dccActionTypeSpinner.setSelection(myIndex);
             mainapp.hideSoftKeyboard(v);
         }
     }
 
-    public class dccex_default_functions_button_listener implements View.OnClickListener {
-        Context myContext;
+    public class DccexDefaultFunctionsButtonListener implements View.OnClickListener {
+        final Context myContext;
 
-        dccex_default_functions_button_listener(Context context) {
+        DccexDefaultFunctionsButtonListener(Context context) {
             myContext = context;
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
@@ -41,7 +41,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.speech.tts.TextToSpeech;
+//import android.speech.tts.TextToSpeech;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -72,7 +72,9 @@ import java.util.List;
 import java.util.Locale;
 
 import jmri.enginedriver.type.message_type;
+import jmri.enginedriver.type.tts_msg_type;
 import jmri.enginedriver.util.LocaleHelper;
+import jmri.enginedriver.util.Tts;
 
 public class gamepad_test extends AppCompatActivity implements OnGestureListener {
 
@@ -130,16 +132,11 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
 
     private int decreaseButtonCount = 0;
 
-    private TextToSpeech myTts;
+    Tts tts;
 
     private LinearLayout screenNameLine;
     private Toolbar toolbar;
     private LinearLayout statusLine;
-
-//    @Override
-//    public boolean onTouchEvent(MotionEvent event) {
-//        return myGesture.onTouchEvent(event);
-//    }
 
     void GamepadFeedbackSound(boolean invalidAction) {
         if (invalidAction)
@@ -364,12 +361,12 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
             setAllButtonsOff();
         }
 
-        if ( (myTts != null) && (action==ACTION_DOWN) && (prefTtsGamepadTestKeys) ) {
+        if (action==ACTION_DOWN)  {
             String text = keyCodeString;
             if ( (keyCodeString.length()<4) || (!keyCodeString.startsWith("DPad")) ) {
                 text = "Button "+ btn.getText();
             }
-            myTts.speak(text+","+fn, TextToSpeech.QUEUE_ADD, null);
+            tts.speakWords(tts_msg_type.GAMEPAD_GAMEPAD_TEST_KEY_AND_PURPOSE, text+","+fn);
         }
 
         btn.setClickable(true);
@@ -703,7 +700,7 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
             getSupportActionBar().setDisplayShowTitleEnabled(false);
         }
 
-        setupTts();
+        tts = new Tts(prefs,mainapp);
 
     } // end onCreate
 
@@ -721,6 +718,7 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
         // suppress popup keyboard until EditText is touched
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
+        tts.loadPrefs(); // recheck the ttf prefs in case they have been changed
     }
 
     /**
@@ -865,25 +863,4 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(LocaleHelper.onAttach(base));
     }
-
-    private void setupTts() {
-        prefTtsGamepadTestKeys = prefs.getBoolean("prefTtsGamepadTestKeys", getResources().getBoolean(R.bool.prefTtsGamepadTestKeysDefaultValue));
-
-        if (prefTtsGamepadTestKeys) {
-            if (myTts == null) {
-                myTts = new TextToSpeech(getApplicationContext(), new TextToSpeech.OnInitListener() {
-                    @Override
-                    public void onInit(int status) {
-                        if (status != TextToSpeech.ERROR) {
-                            myTts.setLanguage(Locale.getDefault());
-                        } else {
-                            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastTtsFailed), Toast.LENGTH_SHORT).show();
-                        }
-                    }
-                });
-            }
-        }
-    }
-
-
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/gamepad_test.java
@@ -499,10 +499,8 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
     public boolean dispatchKeyEvent(KeyEvent event) {
 
         boolean isExternal = false;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
-            InputDevice idev = getDevice(event.getDeviceId());
-            if( idev.toString().contains("Location: external")) isExternal = true;
-        }
+        InputDevice idev = getDevice(event.getDeviceId());
+        if( idev.toString().contains("Location: external")) isExternal = true;
 
         if (isExternal) { // if has come from the phone itself, don't try to process it here
             if (!prefGamePadType.equals("None")) { // respond to the gamepad and keyboard inputs only if the preference is set
@@ -818,11 +816,6 @@ public class gamepad_test extends AppCompatActivity implements OnGestureListener
             resultIntent.putExtra("whichGamepadNo", whichGamepadNo+"2");  //pass whichGamepadNo as an extra - plus "2" for fail
             setResult(result, resultIntent);
             return true;
-
-            //this.finish();  //end this activity
-            //connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-            //return true;
-//            super.onBackPressed();
         }
         return (super.onKeyDown(key, event));
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
@@ -96,19 +96,19 @@ public class ImportExportConnectionList {
                         if (!(ip_address.equals(addressToRemove)) || !(port.toString().equals(portToRemove))) {
                             if (port > 0) {  //skip if port not converted to integer
 
-                                if (!prefHideDemoServer || !(host_name.equals(demo_host) && port.toString().equals(demo_port))) {
-                                    HashMap<String, String> hm = new HashMap<>();
-                                    hm.put("ip_address", ip_address);
-                                    hm.put("host_name", host_name);
-                                    hm.put("port", port.toString());
-                                    hm.put("ssid", ssid_str);
-                                    hm.put("service_type", service_type);
-                                    if (!connections_list.contains(hm)) {    // suppress dups
-                                        connections_list.add(hm);
-                                    }
-                                }
                                 if (host_name.equals(demo_host) && port.toString().equals(demo_port)) {
                                     foundDemoHost = true;
+                                    if (!prefHideDemoServer) {
+                                        HashMap<String, String> hm = new HashMap<>();
+                                        hm.put("ip_address", ip_address);
+                                        hm.put("host_name", host_name);
+                                        hm.put("port", port.toString());
+                                        hm.put("ssid", ssid_str);
+                                        hm.put("service_type", service_type);
+                                        if (!connections_list.contains(hm)) {    // suppress dups
+                                            connections_list.add(hm);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportPreferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportPreferences.java
@@ -249,6 +249,7 @@ public class ImportExportPreferences {
             int prefForcedRestartReason = sharedPreferences.getInt("prefForcedRestartReason", restart_reason_type.NONE);
             boolean prefImportExportLocoList = sharedPreferences.getBoolean("prefImportExportLocoList", context.getResources().getBoolean(R.bool.prefImportExportLocoListDefaultValue));
             String prefPreferencesImportFileName = sharedPreferences.getString("prefPreferencesImportFileName", "");
+            String prefAndroidId = sharedPreferences.getString("prefAndroidId", "");
 
             String prefPreferencesImportAll = sharedPreferences.getString("prefPreferencesImportAll", PREF_IMPORT_ALL_FULL);
             String prefTheme = "";
@@ -323,6 +324,7 @@ public class ImportExportPreferences {
                     prefEdit.putBoolean("prefForcedRestart", true);
                     prefEdit.putInt("prefForcedRestartReason", prefForcedRestartReason);
                     prefEdit.putString("prefPreferencesImportFileName", prefPreferencesImportFileName);  //reset the preference
+                    prefEdit.putString("prefAndroidId", prefAndroidId);  //reset the preference
 
                     if (prefPreferencesImportAll.equals(PREF_IMPORT_ALL_PARTIAL)) { // save some additional preferences for restoration
                         prefEdit.putString("prefTheme", prefTheme);

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
@@ -62,6 +62,8 @@ public class intro_activity extends AppIntro2 {
         originalPrefTheme = prefs.getString("prefTheme", getApplicationContext().getResources().getString(R.string.prefThemeDefaultValue));
         originalPrefThrottleType = prefs.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
+        mainapp.getDeviceId(true); // force getting a new ID
+
         // Note here that we DO NOT use setContentView();
 
         SliderPage sliderPage0 = new SliderPage();

--- a/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
@@ -351,24 +351,26 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
                         msg = data.substring(msgStart + 3);
                     }
                 }
-                msg = msg.replaceAll("&", "&amp;");
-                msg = msg.replaceAll("<", "&lt;");
-                msg = msg.replaceAll(">", "&gt;");
-                if (msg.indexOf("About: ") < 0) {
-                    if (mainapp.getSelectedTheme() == R.style.app_theme_colorful) {
-                        msg = "<span style=\"color: #404040\">" + msg;
+                if (!msg.substring(0,6).equals("<span>")) {
+                    msg = msg.replaceAll("&", "&amp;");
+                    msg = msg.replaceAll("<", "&lt;");
+                    msg = msg.replaceAll(">", "&gt;");
+                    if (msg.indexOf("About: ") < 0) {
+                        if (mainapp.getSelectedTheme() == R.style.app_theme_colorful) {
+                            msg = "<span style=\"color: #404040\">" + msg;
+                        } else {
+                            msg = "<span style=\"color: #CCCCCC\">" + msg;
+                        }
                     } else {
-                        msg = "<span style=\"color: #CCCCCC\">" + msg;
+                        msg = "<br/><span>" + msg;
                     }
-                } else {
-                    msg = "<br/><span>" + msg;
-                }
-                if (msg.indexOf("--&gt;") > 0) {
-                    msg = msg.replace("--&gt;", "</span><br/><b>--&gt;") + "</b>";
-                } else if (msg.indexOf("&lt;--") > 0) {
-                    msg = msg.replace("&lt;--", "</span><br/><b>&lt;--") + "</b>";
-                } else {
-                    msg = msg + "</span>";
+                    if (msg.indexOf("--&gt;") > 0) {
+                        msg = msg.replace("--&gt;", "</span><br/><b>--&gt;") + "</b>";
+                    } else if (msg.indexOf("&lt;--") > 0) {
+                        msg = msg.replace("&lt;--", "</span><br/><b>&lt;--") + "</b>";
+                    } else {
+                        msg = msg + "</span>";
+                    }
                 }
                 textview.setText(Html.fromHtml(msg));
                 return view;

--- a/EngineDriver/src/main/java/jmri/enginedriver/routes.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/routes.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import jmri.enginedriver.logviewer.ui.LogViewerActivity;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.type.screen_swipe_index_type;
+import jmri.enginedriver.util.BackgroundImageLoader;
 import jmri.enginedriver.util.LocaleHelper;
 import jmri.enginedriver.type.sort_type;
 
@@ -511,7 +512,7 @@ public class routes extends AppCompatActivity implements android.gesture.Gesture
 
         screenNameLine = findViewById(R.id.screen_name_line);
         toolbar = findViewById(R.id.toolbar);
-        statusLine = (LinearLayout) findViewById(R.id.status_line);
+        statusLine = findViewById(R.id.status_line);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
             getSupportActionBar().setDisplayShowTitleEnabled(false);
@@ -641,6 +642,7 @@ public class routes extends AppCompatActivity implements android.gesture.Gesture
         mainapp.displayThrottleMenuButton(menu, "swipe_through_routes_preference");
         mainapp.setPowerMenuOption(menu);
         mainapp.setDCCEXMenuOption(menu);
+        mainapp.displayDccExButton(menu);
         mainapp.setWithrottleCvProgrammerMenuOption(menu);
         mainapp.setPowerStateButton(menu);
         mainapp.setWebMenuOption(menu);
@@ -687,7 +689,7 @@ public class routes extends AppCompatActivity implements android.gesture.Gesture
             startActivityForResult(in, 0);
             connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             return true;
-        } else if (item.getItemId() == R.id.dcc_ex_mnu) {
+        } else if ( (item.getItemId() == R.id.dcc_ex_button) || (item.getItemId() == R.id.dcc_ex_mnu) ) {
             in = new Intent().setClass(this, dcc_ex.class);
             startActivity(in);
             connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -539,7 +539,7 @@ public class threaded_application extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Log.d("Engine_Driver", "t_a.onCreate()");
+        Log.d("Engine_Driver", "t_a: onCreate()");
         try {
             appVersion = "v" + getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException ignored) {
@@ -989,24 +989,29 @@ public class threaded_application extends Application {
     }
     @SuppressLint("DefaultLocale")
     public String getAboutInfo() {
-        String s = "";
+        String s = "<span>";
         // device info
-        s += "About: " + String.format("OS:%s, SDK:%s ", android.os.Build.VERSION.RELEASE, Build.VERSION.SDK_INT);
+        s += "About: " + String.format("<small>OS: </small><b>%s</b> <small>SDK: </small><b>%s</b>", android.os.Build.VERSION.RELEASE, Build.VERSION.SDK_INT);
         if (client_address_inet4 != null) {
-            s += ", " + String.format("IP:%s", client_address_inet4.toString().replaceAll("/", ""));
-            s += String.format(" SSID:%s Net:%s", client_ssid, client_type);
+            s += String.format("<small>, IP: </small><b>%s</b>", client_address_inet4.toString().replaceAll("/", ""));
+            s += String.format("<small>, SSID: </small><b>%s</b> <small>Net: </small><b>%s</b>", client_ssid, client_type);
         }
 
         // ED version info
-        s += ", EngineDriver: " + appVersion;
+        s += "<small>, EngineDriver: </small><b>" + appVersion + "</b>";
         if (getHostIp() != null) {
             // WiT info
             if (getWithrottleVersion() != 0.0) {
-                s += ", WiThrottle:v" + getWithrottleVersion();
-                s +=  String.format(", Heartbeat:%dms", heartbeatInterval);
+                s += "<small>, Protocol: </small>";
+                if (!isDCCEX) {
+                    s += "<b>WiThrottle</b> v</small><b>" + getWithrottleVersion() +"</b>";
+                    s += String.format("<small>, Heartbeat: </small><b>%dms</b>", heartbeatInterval);
+                } else {
+                    s += "<b>DCC-EX</b>";
+                }
             }
-            s += String.format(", Host:%s", getHostIp() );
-            s += String.format(", Port:%s", connectedPort);
+            s += String.format("<small>, Host: </small><b>%s</b>", getHostIp() );
+            s += String.format("<small> Port: </small><b>%s</b>", connectedPort);
             //show server type and description if set
             String sServer;
             if (getServerDescription().contains(getServerType())) {
@@ -1015,12 +1020,12 @@ public class threaded_application extends Application {
                 sServer = getServerType() + " " + getServerDescription();
             }
             if (!sServer.isEmpty()) {
-                s += ", Server:" + sServer;
+                s += "<small>, Server: </small><b>" + sServer + "</b>";
             }
+        } else {
+            s += "<small><br/>Not Connected</small>";
         }
-        if (isDCCEX) {
-            s += ", DCC-EX protocol";
-        }
+        s += "</span>";
         return s;
     }
 
@@ -1081,7 +1086,7 @@ public class threaded_application extends Application {
             consist_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
             roster_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
         } catch (Exception e) {
-            Log.d("Engine_Driver", "initShared object create exception");
+            Log.d("Engine_Driver", "t_a: initShared object create exception");
         }
         doFinish = false;
         turnouts_list_position = 0;
@@ -2010,11 +2015,11 @@ public class threaded_application extends Application {
                 break;
             default:
                 val = 0;
-                Log.d("debug", "TA.throttleCharToInt: no match for argument " + cWhichThrottle);
+                Log.d("debug", "t_a: throttleCharToInt: no match for argument " + cWhichThrottle);
                 break;
         }
         if (val > maxThrottlesCurrentScreen)
-            Log.d("debug", "TA.throttleCharToInt: argument exceeds max number of throttles for current screen " + cWhichThrottle);
+            Log.d("debug", "t_a: throttleCharToInt: argument exceeds max number of throttles for current screen " + cWhichThrottle);
         return val;
     }
 
@@ -2110,7 +2115,7 @@ public class threaded_application extends Application {
     }
 
     public static void safeToast(final String msg_txt, final int length) {
-        Log.d("Engine_Driver", "t_a.safeToast: " + msg_txt);
+        Log.d("Engine_Driver", "t_a: safeToast: " + msg_txt);
         //need to do Toast() on the main thread so create a handler
         Handler h = new Handler(Looper.getMainLooper());
         h.post(new Runnable() {
@@ -2299,7 +2304,7 @@ public class threaded_application extends Application {
 //    }
 //
 //    private void saveSharedPreferencesToFileImpl() {
-        Log.d("Engine_Driver", "TA: saveSharedPreferencesToFileImpl: start");
+        Log.d("Engine_Driver", "t_a: saveSharedPreferencesToFileImpl: start");
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", threaded_application.context.getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
@@ -2315,7 +2320,7 @@ public class threaded_application extends Application {
                     ImportExportPreferences importExportPreferences = new ImportExportPreferences();
                     importExportPreferences.saveSharedPreferencesToFile(threaded_application.context, sharedPreferences, exportedPreferencesFileName);
                 }
-                Log.d("Engine_Driver", "TA: saveSharedPreferencesToFileImpl: done");
+                Log.d("Engine_Driver", "t_a: saveSharedPreferencesToFileImpl: done");
             } else {
                 safeToast(threaded_application.context.getResources().getString(R.string.toastConnectUnableToSavePref), Toast.LENGTH_LONG);
             }
@@ -2382,7 +2387,7 @@ public class threaded_application extends Application {
                 importExportPreferences.recent_loco_source_list.remove(i);
                 keepFunctions = importExportPreferences.recent_loco_functions_list.get(i);
                 importExportPreferences.recent_loco_functions_list.remove(i);
-                Log.d("Engine_Driver", "ta: addLocoToRecents: Loco '" + loco_name + "' removed from Recents");
+                Log.d("Engine_Driver", "t_a: addLocoToRecents: Loco '" + loco_name + "' removed from Recents");
                 break;
             }
         }
@@ -2398,7 +2403,7 @@ public class threaded_application extends Application {
         importExportPreferences.recent_loco_functions_list.add(0, keepFunctions);  // restore from the previous value
 
         importExportPreferences.writeRecentLocosListToFile(prefs);
-        Log.d("Engine_Driver", "Loco '" + loco_name + "' added to Recents");
+        Log.d("Engine_Driver", "t_a: Loco '" + loco_name + "' added to Recents");
 
     }
 
@@ -2412,7 +2417,7 @@ public class threaded_application extends Application {
                     && size.equals(importExportPreferences.recent_loco_address_size_list.get(i))
                     && name.equals(importExportPreferences.recent_loco_name_list.get(i))) {
                 position = i;
-                Log.d("Engine_Driver", "ta: findLocoInRecents: Loco '" + name + "' found in Recents");
+                Log.d("Engine_Driver", "t_a: findLocoInRecents: Loco '" + name + "' found in Recents");
                 break;
             }
         }
@@ -2450,7 +2455,7 @@ public class threaded_application extends Application {
                 Message msg = Message.obtain();
                 msg.what = message_type.RESTART_APP;
                 msg.arg1 = restart_reason_type.AUTO_IMPORT;
-                Log.d("Engine_Driver", "updateConnectionList: Reload of Server Preferences. Restart Requested: " + connectedHostName);
+                Log.d("Engine_Driver", "t_a: updateConnectionList: Reload of Server Preferences. Restart Requested: " + connectedHostName);
                 comm_msg_handler.sendMessage(msg);
             } else {
                 Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectUnableToLoadPref), Toast.LENGTH_LONG).show();
@@ -2481,7 +2486,7 @@ public class threaded_application extends Application {
             if ((xSpeed - xLastSpeed >= 1) || (xLastSpeed - xSpeed >= 1)
                     || ((xSpeed == 0) && (xLastSpeed != 0))
                     || ((xSpeed == 126) && (xLastSpeed != 126))) {
-//                    Log.d("Engine_Driver", "ta: haptic_test: " + "beep");
+//                    Log.d("Engine_Driver", "t_a: haptic_test: " + "beep");
                 vibrate(prefHapticFeedbackDuration);
             }
         }
@@ -2610,7 +2615,7 @@ public class threaded_application extends Application {
     }
 
     public void stopAllSounds() {
-        Log.d("Engine_Driver", "ta - stopAllSounds (locoSounds)");
+        Log.d("Engine_Driver", "t_a: stopAllSounds (locoSounds)");
         if (soundPool != null) {
             for (int soundType = 0; soundType < 3; soundType++) {
                 for (int throttleIndex = 0; throttleIndex < 2; throttleIndex++) {

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2958,7 +2958,7 @@ public class threaded_application extends Application {
         mainapp.deviceId = prefs.getString("prefAndroidId", "");
         if ( (mainapp.deviceId.equals("")) || (forceNewId) ) {
             Random rand = new Random();
-            mainapp.deviceId = String.valueOf(rand.nextInt(9999)); //use random string
+            mainapp.deviceId = String.valueOf(rand.nextInt(999999)); //use random string
             prefs.edit().putString("prefAndroidId", deviceId).commit();
         }
         return mainapp.deviceId;

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -992,6 +992,9 @@ public class threaded_application extends Application {
         String s = "<span>";
         // device info
         s += "About: " + String.format("<small>OS: </small><b>%s</b> <small>SDK: </small><b>%s</b>", android.os.Build.VERSION.RELEASE, Build.VERSION.SDK_INT);
+
+        s += String.format("<small>, DeviceID: </small><b>%s</b>", getDeviceId());
+
         if (client_address_inet4 != null) {
             s += String.format("<small>, IP: </small><b>%s</b>", client_address_inet4.toString().replaceAll("/", ""));
             s += String.format("<small>, SSID: </small><b>%s</b> <small>Net: </small><b>%s</b>", client_ssid, client_type);
@@ -2945,11 +2948,15 @@ public class threaded_application extends Application {
         }
     }
 
-    @SuppressLint("ApplySharedPref")
     public String getDeviceId() {
+        return getDeviceId(false);
+    }
+
+    @SuppressLint("ApplySharedPref")
+    public String getDeviceId(boolean forceNewId) {
 //        return Settings.System.getString(getContentResolver(), Settings.Secure.ANDROID_ID);  // no longer permitted
         mainapp.deviceId = prefs.getString("prefAndroidId", "");
-        if (mainapp.deviceId.equals("")) {
+        if ( (mainapp.deviceId.equals("")) || (forceNewId) ) {
             Random rand = new Random();
             mainapp.deviceId = String.valueOf(rand.nextInt(9999)); //use random string
             prefs.edit().putString("prefAndroidId", deviceId).commit();

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -152,10 +152,11 @@ import jmri.enginedriver.type.direction_button;
 import jmri.enginedriver.type.function_button;
 
 import jmri.enginedriver.type.screen_swipe_index_type;
+import jmri.enginedriver.type.sounds_type;
 import jmri.enginedriver.type.tts_msg_type;
-import jmri.enginedriver.util.Tts;
 import jmri.enginedriver.util.BackgroundImageLoader;
 import jmri.enginedriver.util.HorizontalSeekBar;
+import jmri.enginedriver.util.Tts;
 import jmri.enginedriver.util.VerticalSeekBar;
 import jmri.enginedriver.util.InPhoneLocoSoundsLoader;
 import jmri.enginedriver.util.PermissionsHelper;
@@ -327,26 +328,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private static final int FUNCTION_CONSIST_LATCHING_NO = 1;
     private static final int FUNCTION_CONSIST_LATCHING_YES = 2;
 
-    private static final int SOUNDS_TYPE_LOCO = 0;
-    private static final int SOUNDS_TYPE_BELL = 1;
-    private static final int SOUNDS_TYPE_HORN = 2;
-    private static final int SOUNDS_TYPE_HORN_SHORT = 3;
-
-    private static final int SOUNDS_BUTTON_BELL = 0;
-    private static final int SOUNDS_BUTTON_HORN = 1;
-    private static final int SOUNDS_BUTTON_HORN_SHORT = 2;
-
-    private static final int SOUNDS_BELL_HORN_START = 0;
-    private static final int SOUNDS_BELL_HORN_LOOP = 1;
-//    private static final int SOUNDS_BELL_HORN_END = 2;
-
-    private static final int SOUNDS_REPEAT_INFINITE = -1;
-    private static final int SOUNDS_REPEAT_NONE = 0;
-
-    private static final int SOUNDS_NOTHING_CURRENTLY_PLAYING = -1;
-    private static final int SOUNDS_STARTUP_INDEX = 20;
-//    private static final int SOUNDS_SHUTDOWN_INDEX = 21;
-
     protected InPhoneLocoSoundsLoader iplsLoader;
 
     // function number-to-button maps
@@ -505,7 +486,36 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                      -1,       9,   5,          7,         8,         6,         0,         1,         3,         2,         4,        10,11,12,13,14,15,-1,-1,-1,-1};
 
     Tts tts;
-	
+    //    // For TTS
+////    private int MY_TTS_DATA_CHECK_CODE = 1234;
+//    private static final String PREF_TTS_THROTTLE_RESPONSE_NONE = "None";
+////    private static final String PREF_TTS_THROTTLE_RESPONSE_THROTTLE = "Throttle";
+//    private static final String PREF_TTS_THROTTLE_RESPONSE_LOCO = "Loco";
+//    private static final String PREF_TTS_THROTTLE_RESPONSE_SPEED = "Speed";
+//    private static final String PREF_TTS_THROTTLE_RESPONSE_LOCO_SPEED = "LocoSpeed";
+//
+//    private Tts tts;
+//    private String lastTts = "none";
+//    private String prefTtsWhen = "None";
+//    private String prefTtsThrottleResponse = "Throttle";
+//    private String prefTtsThrottleSpeed = "Zero + Max";
+//    private boolean prefTtsGamepadTest = true;
+//    private boolean prefTtsGamepadTestComplete = true;
+//    private boolean prefTtsGamepadTestKeys = false;
+////    private Time lastTtsTime;
+//    private long lastTtsTime;
+//    private static final String PREF_TT_WHEN_NONE = "None";
+////    private static final String PREF_TT_WHEN_KEY = "Key";
+//    private static final int TTS_MSG_VOLUME_THROTTLE = 1;
+//    private static final int TTS_MSG_GAMEPAD_THROTTLE = 2;
+//    private static final int TTS_MSG_GAMEPAD_GAMEPAD_TEST = 3;
+//    private static final int TTS_MSG_GAMEPAD_GAMEPAD_TEST_COMPLETE = 4;
+//    private static final int TTS_MSG_GAMEPAD_GAMEPAD_TEST_SKIPPED = 5;
+//    private static final int TTS_MSG_GAMEPAD_GAMEPAD_TEST_RESET = 6;
+//    private static final int TTS_MSG_GAMEPAD_GAMEPAD_TEST_FAIL = 7;
+//    private static final int TTS_MSG_GAMEPAD_THROTTLE_SPEED = 8;
+
+
     private ToneGenerator tg;
     private Handler gamepadRepeatUpdateHandler = new Handler();
     private boolean mGamepadAutoIncrement = false;
@@ -930,9 +940,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     // Handle messages from the communication thread TO this thread (responses from withrottle)
     @SuppressLint("HandlerLeak")
-    private class throttle_handler extends Handler {
+    private class ThrottleMessageHandler extends Handler {
 
-        public throttle_handler(Looper looper) {
+        public ThrottleMessageHandler(Looper looper) {
             super(looper);
         }
 
@@ -1044,16 +1054,16 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                                     && (!mainapp.prefDeviceSounds[whichThrottle].equals("none"))
                                                     && (mainapp.prefDeviceSoundsF1F2ActivateBellHorn) ) {
                                                 if (function==1) {
-                                                    if ((action==0) && ((!bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle].isSelected()))) {
+                                                    if ((action==0) && ((!bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle].isSelected()))) {
                                                     } else {
-                                                        handleDeviceButtonAction(whichThrottle, SOUNDS_BUTTON_BELL, SOUNDS_TYPE_BELL,
+                                                        handleDeviceButtonAction(whichThrottle, sounds_type.BUTTON_BELL, sounds_type.BELL,
                                                                 (action == 0) ? MotionEvent.ACTION_UP : MotionEvent.ACTION_DOWN);
                                                     }
                                                 } else {
-                                                    if ((action==0) && ((!bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle].isSelected()))) {
+                                                    if ((action==0) && ((!bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle].isSelected()))) {
                                                     } else {
-                                                    handleDeviceButtonAction(whichThrottle, SOUNDS_BUTTON_HORN, SOUNDS_TYPE_HORN,
-                                                            (action==0) ? MotionEvent.ACTION_UP : MotionEvent.ACTION_DOWN);
+                                                        handleDeviceButtonAction(whichThrottle, sounds_type.BUTTON_HORN, sounds_type.HORN,
+                                                                (action==0) ? MotionEvent.ACTION_UP : MotionEvent.ACTION_DOWN);
                                                     }
                                                 }
                                             }
@@ -1097,7 +1107,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 case message_type.REQUEST_REFRESH_THROTTLE:
 //                    refreshMenu();
                     set_labels();
-                    Log.d("Engine_Driver", "throttle.throttle_handler: REQUEST_REFRESH_THROTTLE");
+                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: REQUEST_REFRESH_THROTTLE");
                     break;
                 case message_type.REFRESH_FUNCTIONS:
                     setAllFunctionLabelsAndListeners();
@@ -1159,7 +1169,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     kidsTimerActions(kids_timer_action_type.ENDED,0);
                     break;
                 case message_type.IMPORT_SERVER_AUTO_AVAILABLE:
-                    Log.d("Engine_Driver", "throttle handleMessage AUTO_IMPORT_URL_AVAILABLE " + response_str );
+                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: AUTO_IMPORT_URL_AVAILABLE " + response_str );
                     autoImportUrlAskToImport();
                     break;
                 case message_type.SOUNDS_FORCE_LOCO_SOUNDS_TO_START:
@@ -1168,7 +1178,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     }
                     break;
                 case message_type.GAMEPAD_ACTION:
-                    Log.d("Engine_Driver", "throttle handleMessage GAMEPAD_ACTION " + response_str );
+                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: GAMEPAD_ACTION " + response_str );
                     if (response_str.length()>0) {
                         String[] splitString = response_str.split(":");
                         externalGamepadAction = Integer.parseInt(splitString[0]);
@@ -1359,7 +1369,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             screenBrightnessOriginal = getScreenBrightness();
             setScreenBrightness(screenBrightnessDim);
         }
-
     }
 
     // set or restore the screen brightness and lock or unlock the sceen when used for the Swipe Up or Shake
@@ -1379,7 +1388,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (!prefThrottleViewImmersiveMode)
                 setImmersiveModeOn(webView, true);
         }
-
     }
 
     private void setupSensor () {
@@ -1431,7 +1439,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             } else {
                 Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastAccelerometerNotFound), Toast.LENGTH_LONG).show();
             }
-
         }
     }
 
@@ -1859,7 +1866,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         if (speed > MAX_SPEED_VAL_WIT)
             speed = MAX_SPEED_VAL_WIT;
 
-
         if (prefLimitSpeedButton && isLimitSpeeds[whichThrottle] && (speed > limitSpeedMax[whichThrottle] )) {
             speed = limitSpeedMax[whichThrottle];
         }
@@ -1985,7 +1991,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 ,getSpeedFromCurrentSliderPosition(whichThrottle,false)
                                 ,getSpeedFromCurrentSliderPosition(whichThrottle,true)
                                 ,"");
-				
                 break;
         }
         doLocoSound(whichThrottle);
@@ -3031,7 +3036,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (isActive && (action==ACTION_DOWN) && (repeatCnt == 0)) {
                 GamepadFeedbackSound(false);
                 if ( (isPauseSpeeds[whichThrottle]==PAUSE_SPEED_TO_RETURN)
-                   || ( ( getSpeed(whichThrottle) == 0) && (isPauseSpeeds[whichThrottle]==PAUSE_SPEED_ZERO) ) ) {
+                        || ( ( getSpeed(whichThrottle) == 0) && (isPauseSpeeds[whichThrottle]==PAUSE_SPEED_ZERO) ) ) {
                     disablePauseSpeed(whichThrottle);
                 }
                 speedUpdateAndNotify(whichThrottle, 0);
@@ -3042,7 +3047,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         ,"");
 
                 if ((whichLastGamepadButtonPressed==buttonNo)
-                && (System.currentTimeMillis() <= (gamePadDoublePressStopTime+1000) ) ){  // double press - within 1 second
+                        && (System.currentTimeMillis() <= (gamePadDoublePressStopTime+1000) ) ){  // double press - within 1 second
                     if (prefGamePadDoublePressStop.equals(pref_gamepad_button_option_type.ALL_STOP)) {
                         speedUpdateAndNotify(0);         // update all throttles
                     } else if (prefGamePadDoublePressStop.equals(pref_gamepad_button_option_type.FORWARD_REVERSE_TOGGLE)) {
@@ -3120,36 +3125,36 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
         } else if (prefGamePadButtons[buttonNo].equals(pref_gamepad_button_option_type.SOUNDS_BELL)) {  // IPLS Sounds - Bell
             if (isActive && (action == ACTION_UP)) {
-                boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_BELL - 1];
-                doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_BELL);
-                setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle], rslt);
-                mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_BELL -1] = rslt;
+                boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BELL - 1];
+                doDeviceButtonSound(whichThrottle, sounds_type.BELL);
+                setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle], rslt);
+                mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BELL -1] = rslt;
             }
         } else if (prefGamePadButtons[buttonNo].equals(pref_gamepad_button_option_type.SOUNDS_HORN)) {  // IPLS Sounds - Horn
             if (isActive) {
                 if (action == ACTION_UP) {
-                    doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN);
-                    setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle], false);
-                    mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1] = false;
+                    doDeviceButtonSound(whichThrottle, sounds_type.HORN);
+                    setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle], false);
+                    mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1] = false;
                 } else {
-                    if (!mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1]) {
-                        doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN);
-                        setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle], true);
-                        mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1] = true;
+                    if (!mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1]) {
+                        doDeviceButtonSound(whichThrottle, sounds_type.HORN);
+                        setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle], true);
+                        mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1] = true;
                     }
                 }
             }
         } else if (prefGamePadButtons[buttonNo].equals(pref_gamepad_button_option_type.SOUNDS_HORN_SHORT)) {  // IPLS Sounds - Horn Short
             if (isActive) {
                 if (action == ACTION_UP) {
-                    doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN_SHORT);
-                    setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle], false);
-                    mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1] = false;
+                    doDeviceButtonSound(whichThrottle, sounds_type.HORN_SHORT);
+                    setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle], false);
+                    mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1] = false;
                 } else {
-                    if (!mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1]) {
-                        doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN_SHORT);
-                        setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle], true);
-                        mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1] = true;
+                    if (!mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1]) {
+                        doDeviceButtonSound(whichThrottle, sounds_type.HORN_SHORT);
+                        setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle], true);
+                        mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1] = true;
                     }
                 }
             }
@@ -3177,10 +3182,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
         } else if (prefGamePadButtons[buttonNo].equals(pref_gamepad_button_option_type.SPEAK_CURRENT_SPEED)) {
             tts.speakWords(tts_msg_type.GAMEPAD_THROTTLE,whichThrottle, true
-                            ,whichLastGamepad1
-                            ,getDisplaySpeedFromCurrentSliderPosition(whichThrottle,true)
-                            ,0
-                            ,getConsistAddressString(whichThrottle));
+                    ,whichLastGamepad1
+                    ,getDisplaySpeedFromCurrentSliderPosition(whichThrottle,true)
+                    ,0
+                    ,getConsistAddressString(whichThrottle));
         }
 
         whichLastGamepadButtonPressed = buttonNo;
@@ -3206,10 +3211,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 GamepadFeedbackSound(false);
                 speedUpdateAndNotify(whichThrottle, 0);
                 tts.speakWords(tts_msg_type.GAMEPAD_THROTTLE_SPEED,whichThrottle,false
-                            ,getMaxSpeed(whichThrottle)
-                            ,getSpeedFromCurrentSliderPosition(whichThrottle,false)
-                            ,getSpeedFromCurrentSliderPosition(whichThrottle,true)
-                            ,"");
+                        ,getMaxSpeed(whichThrottle)
+                        ,getSpeedFromCurrentSliderPosition(whichThrottle,false)
+                        ,getSpeedFromCurrentSliderPosition(whichThrottle,true)
+                        ,"");
                 resetKeyboardString();
             }
         } else if (keyCode==KEYCODE_N) {  // Next Throttle
@@ -3291,25 +3296,25 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
         } else if (keyCode==KEYCODE_B) {  // IPLS Sounds - Bell
             if (isActive && (action == ACTION_UP) && (repeatCnt == 0)) {
-                boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_BELL - 1];
-                doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_BELL);
-                setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle], rslt);
-                mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_BELL -1] = rslt;
+                boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BELL - 1];
+                doDeviceButtonSound(whichThrottle, sounds_type.BELL);
+                setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle], rslt);
+                mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BELL -1] = rslt;
                 resetKeyboardString();
             }
         } else if ( (keyCode==KEYCODE_H) && (!isShiftPressed) ) {  // IPLS Sounds - Horn
             if (isActive) {
                 if (action == ACTION_UP) {
-                    doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN);
-                    setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle], false);
-                    mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1] = false;
+                    doDeviceButtonSound(whichThrottle, sounds_type.HORN);
+                    setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle], false);
+                    mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1] = false;
                     resetKeyboardString();
                 } else {
                     if (repeatCnt == 0) {
-                        if (!mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1]) {
-                            doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN);
-                            setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle], true);
-                            mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN - 1] = true;
+                        if (!mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1]) {
+                            doDeviceButtonSound(whichThrottle, sounds_type.HORN);
+                            setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle], true);
+                            mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN - 1] = true;
                         }
                     }
                 }
@@ -3317,16 +3322,16 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         } else if ( (keyCode==KEYCODE_H) && (isShiftPressed) ) {  // IPLS Sounds - Horn Short
             if (isActive) {
                 if (action == ACTION_UP) {
-                    doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN_SHORT);
-                    setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle], false);
-                    mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1] = false;
+                    doDeviceButtonSound(whichThrottle, sounds_type.HORN_SHORT);
+                    setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle], false);
+                    mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1] = false;
                     resetKeyboardString();
                 } else {
                     if (repeatCnt == 0) {
-                        if (!mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1]) {
-                            doDeviceButtonSound(whichThrottle, SOUNDS_TYPE_HORN_SHORT);
-                            setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle], true);
-                            mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_TYPE_HORN_SHORT - 1] = true;
+                        if (!mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1]) {
+                            doDeviceButtonSound(whichThrottle, sounds_type.HORN_SHORT);
+                            setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle], true);
+                            mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.HORN_SHORT - 1] = true;
                         }
                     }
                 }
@@ -3366,24 +3371,23 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 keyboardThrottle = -1;  //reset it
             }
         } else if ( ((keyCode>=KEYCODE_0) && (keyCode<=KEYCODE_9))
-                    || ( (keyCode>=KEYCODE_F1) && (keyCode<=KEYCODE_F10)) )
+                || ( (keyCode>=KEYCODE_F1) && (keyCode<=KEYCODE_F10)) )
         {  // Start of a Function, Speed, or Throttle command
-           String num;
-           if ((keyCode>=KEYCODE_0) && (keyCode<=KEYCODE_9)) {
-               num = Integer.toString(keyCode - KEYCODE_0);
-           } else {
-               if (keyCode!=KEYCODE_F10) {
-                   num = Integer.toString(keyCode - KEYCODE_F1 + 1);
-               } else {
+            String num;
+            if ((keyCode>=KEYCODE_0) && (keyCode<=KEYCODE_9)) {
+                num = Integer.toString(keyCode - KEYCODE_0);
+            } else {
+                if (keyCode!=KEYCODE_F10) {
+                    num = Integer.toString(keyCode - KEYCODE_F1 + 1);
+                } else {
                     num = "0";
-               }
-           }
+                }
+            }
 
-           if ((keyboardString.length() > 0) && (keyboardString.charAt(0) == 'F')) {  // Function
-               if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
-//                   keyboardString = keyboardString + Integer.toString(keyCode - KEYCODE_0);
-                   keyboardString = keyboardString + num;
-               }
+            if ((keyboardString.length() > 0) && (keyboardString.charAt(0) == 'F')) {  // Function
+                if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
+                    keyboardString = keyboardString + num;
+                }
                 if (keyboardString.length() == 3) {  // have a two digit function number now
                     int fKey = Integer.parseInt(keyboardString.substring(1, 3));
                     if (action == ACTION_DOWN) {
@@ -3393,61 +3397,55 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         resetKeyboardString();
                     }
                 }
-           } else if ((keyboardString.length() > 0) && (keyboardString.charAt(0) == 'S')) {  // speed
-               if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
-//                   keyboardString = keyboardString + Integer.toString(keyCode - KEYCODE_0);
-                   keyboardString = keyboardString + num;
-//               }
-//               if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
-                 if (keyboardString.length() == 4) {  // have a three digit speed amount now
-                    int newSpeed = Math.min(Integer.parseInt(keyboardString.substring(1, 4)), 100);
-                    float vSpeed = 126 * ((float) newSpeed) / 100;
-                    newSpeed = (int) vSpeed;
-                    speedUpdateAndNotify(whichThrottle, newSpeed);
-//                        resetKeyboardString();
-                  }
-               }
-               if (action == ACTION_UP) {
-                   if (keyboardString.length() == 4) {  // have a three digit speed amount now
-                       resetKeyboardString();
-                   }
-               }
+            } else if ((keyboardString.length() > 0) && (keyboardString.charAt(0) == 'S')) {  // speed
+                if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
+                    keyboardString = keyboardString + num;
+                    if (keyboardString.length() == 4) {  // have a three digit speed amount now
+                        int newSpeed = Math.min(Integer.parseInt(keyboardString.substring(1, 4)), 100);
+                        float vSpeed = 126 * ((float) newSpeed) / 100;
+                        newSpeed = (int) vSpeed;
+                        speedUpdateAndNotify(whichThrottle, newSpeed);
+                    }
+                }
+                if (action == ACTION_UP) {
+                    if (keyboardString.length() == 4) {  // have a three digit speed amount now
+                        resetKeyboardString();
+                    }
+                }
             } else if ((keyboardString.length() > 0) && (keyboardString.charAt(0) == 'T')) {    // specify Throttle number
                 if ( (action == ACTION_DOWN) && (repeatCnt == 0) ) {
-//                    keyboardString = keyboardString + Integer.toString(keyCode - KEYCODE_0);
                     keyboardString = keyboardString + num;
                 }
-               if (action == ACTION_DOWN) {
-                   if (keyboardString.length() == 2) {  // have a complete Throttle number
-                       keyboardThrottle = Integer.parseInt(keyboardString.substring(1, 2));
-                       if (keyboardThrottle > MAX_SCREEN_THROTTLES) {
-                           keyboardThrottle = -1;
-                       }
-                   }
-               } else {
-                   keyboardString = "";
-               }
-           } else if (keyboardString.length() == 0) {  // direct function 0-9
-//                int fKey = keyCode - KEYCODE_0;
-               int fKey;
-               if ((keyCode>=KEYCODE_0) && (keyCode<=KEYCODE_9)) {
-                  fKey = keyCode - KEYCODE_0;
-               } else {
-                  if (keyCode!=KEYCODE_F10) {
-                      fKey = keyCode - KEYCODE_F1 + 1;
-                  } else {
-                      fKey = 0;
-                  }
-               }
-               if (fKey<10) { // special case for attached keyboards keys 0-9
-                   mainapp.numericKeyIsPressed[fKey] = action;
-                   if (action == ACTION_DOWN) {
-                       mainapp.numericKeyFunctionStateAtTimePressed[fKey] = ((mainapp.function_states[whichThrottle][fKey]) ? 1 : 0);
-                   }
-               }
-               doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt);
-               resetKeyboardString();
-           }
+                if (action == ACTION_DOWN) {
+                    if (keyboardString.length() == 2) {  // have a complete Throttle number
+                        keyboardThrottle = Integer.parseInt(keyboardString.substring(1, 2));
+                        if (keyboardThrottle > MAX_SCREEN_THROTTLES) {
+                            keyboardThrottle = -1;
+                        }
+                    }
+                } else {
+                    keyboardString = "";
+                }
+            } else if (keyboardString.length() == 0) {  // direct function 0-9
+                int fKey;
+                if ((keyCode>=KEYCODE_0) && (keyCode<=KEYCODE_9)) {
+                    fKey = keyCode - KEYCODE_0;
+                } else {
+                    if (keyCode!=KEYCODE_F10) {
+                        fKey = keyCode - KEYCODE_F1 + 1;
+                    } else {
+                        fKey = 0;
+                    }
+                }
+                if (fKey<10) { // special case for attached keyboards keys 0-9
+                    mainapp.numericKeyIsPressed[fKey] = action;
+                    if (action == ACTION_DOWN) {
+                        mainapp.numericKeyFunctionStateAtTimePressed[fKey] = ((mainapp.function_states[whichThrottle][fKey]) ? 1 : 0);
+                    }
+                }
+                doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt);
+                resetKeyboardString();
+            }
         }
     }
 
@@ -3893,10 +3891,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     // For volume speed buttons.
-    private class volumeKeysRptUpdater implements Runnable {
+    private class VolumeKeysRptUpdater implements Runnable {
         int whichThrottle;
 
-        private volumeKeysRptUpdater(int WhichThrottle) {
+        private VolumeKeysRptUpdater(int WhichThrottle) {
             whichThrottle = WhichThrottle;
 
             try {
@@ -3910,10 +3908,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         public void run() {
             if (mVolumeKeysAutoIncrement) {
                 incrementSpeed(whichThrottle, SPEED_COMMAND_FROM_VOLUME);
-                volumeKeysRepeatUpdateHandler.postDelayed(new volumeKeysRptUpdater(whichThrottle), REP_DELAY);
+                volumeKeysRepeatUpdateHandler.postDelayed(new VolumeKeysRptUpdater(whichThrottle), REP_DELAY);
             } else if (mVolumeKeysAutoDecrement) {
                 decrementSpeed(whichThrottle, SPEED_COMMAND_FROM_VOLUME);
-                volumeKeysRepeatUpdateHandler.postDelayed(new volumeKeysRptUpdater(whichThrottle), REP_DELAY);
+                volumeKeysRepeatUpdateHandler.postDelayed(new VolumeKeysRptUpdater(whichThrottle), REP_DELAY);
             }
         }
     }
@@ -4313,13 +4311,13 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
 // Listeners for the Select Loco buttons
-//    protected class select_function_button_touch_listener implements View.OnClickListener, View.OnTouchListener, View.OnLongClickListener {
-    protected class select_function_button_touch_listener implements View.OnClickListener, View.OnLongClickListener {
+//    protected class SelectFunctionButtonTouchListener implements View.OnClickListener, View.OnTouchListener, View.OnLongClickListener {
+protected class SelectFunctionButtonTouchListener implements View.OnClickListener, View.OnLongClickListener {
     int whichThrottle;
 
-    protected select_function_button_touch_listener(int new_whichThrottle) {
-            whichThrottle = new_whichThrottle;
-        }
+    protected SelectFunctionButtonTouchListener(int new_whichThrottle) {
+        whichThrottle = new_whichThrottle;
+    }
 
         @Override
         public void onClick(View v) {
@@ -4348,10 +4346,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     //listeners for the Limit Speed Button
-    protected class limit_speed_button_touch_listener implements View.OnTouchListener {
+    protected class LimitSpeedButtonTouchListener implements View.OnTouchListener {
         int whichThrottle;
 
-        protected limit_speed_button_touch_listener(int new_whichThrottle) {
+        protected LimitSpeedButtonTouchListener(int new_whichThrottle) {
             whichThrottle = new_whichThrottle;
         }
 
@@ -4387,11 +4385,11 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     //listeners for the increase/decrease speed buttons (not the slider)
-    protected class arrow_speed_button_touch_listener implements View.OnClickListener, View.OnLongClickListener, View.OnTouchListener {
+    protected class ArrowSpeedButtonTouchListener implements View.OnClickListener, View.OnLongClickListener, View.OnTouchListener {
         int whichThrottle;
         String arrowDirection;
 
-        protected arrow_speed_button_touch_listener(int new_whichThrottle, String new_arrowDirection) {
+        protected ArrowSpeedButtonTouchListener(int new_whichThrottle, String new_arrowDirection) {
             whichThrottle = new_whichThrottle;
             arrowDirection = new_arrowDirection;
         }
@@ -4444,11 +4442,11 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     // Listeners for the direction buttons
-    private class direction_button_touch_listener implements View.OnTouchListener {
+    private class DirectionButtonTouchListener implements View.OnTouchListener {
         int function;
         int whichThrottle;
 
-        private direction_button_touch_listener(int new_function, int new_whichThrottle) {
+        private DirectionButtonTouchListener(int new_function, int new_whichThrottle) {
             function = new_function;    // store these values for this button
             whichThrottle = new_whichThrottle;
         }
@@ -4683,19 +4681,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
                         Log.d("Engine_Driver", "doLocoSound               : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                         if ((mSound >= 0)) {
-                            if (mainapp.soundsLocoCurrentlyPlaying[whichThrottle] == SOUNDS_NOTHING_CURRENTLY_PLAYING) { // nothing currently playing
+                            if (mainapp.soundsLocoCurrentlyPlaying[whichThrottle] == sounds_type.NOTHING_CURRENTLY_PLAYING) { // nothing currently playing
 //                                Log.d("Engine_Driver", "doLocoSound 2              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                                 //see if there is a startup sound for this profile
-                                if (mainapp.soundsLocoDuration[whichThrottle][SOUNDS_STARTUP_INDEX] > 0) {
+                                if (mainapp.soundsLocoDuration[whichThrottle][sounds_type.STARTUP_INDEX] > 0) {
 //                                    Log.d("Engine_Driver", "doLocoSound 3              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
-                                    soundStart(SOUNDS_TYPE_LOCO, whichThrottle, SOUNDS_STARTUP_INDEX, SOUNDS_REPEAT_NONE);
-                                    soundScheduleNextLocoSound(whichThrottle, mSound, mainapp.soundsLocoDuration[whichThrottle][SOUNDS_STARTUP_INDEX]);
+                                    soundStart(sounds_type.LOCO, whichThrottle, sounds_type.STARTUP_INDEX, sounds_type.REPEAT_NONE);
+                                    soundScheduleNextLocoSound(whichThrottle, mSound, mainapp.soundsLocoDuration[whichThrottle][sounds_type.STARTUP_INDEX]);
                                     soundQueueNextLocoSound(whichThrottle, mSound);
                                 } else {
 //                                    Log.d("Engine_Driver", "doLocoSound 4              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
-                                    soundStart(SOUNDS_TYPE_LOCO, whichThrottle, mSound, SOUNDS_REPEAT_INFINITE);
+                                    soundStart(sounds_type.LOCO, whichThrottle, mSound, sounds_type.REPEAT_INFINITE);
                                     mainapp.soundsLocoQueue[whichThrottle].setLastAddedValue(mSound);
                                 }
+
                             } else {
                                 soundQueueNextLocoSound(whichThrottle, mSound);
                             }
@@ -4733,13 +4732,13 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         if (forcedExpectedEndTime>0) {
             expectedEndTime = forcedExpectedEndTime;
         } else { // != -1
-            expectedEndTime = soundStop(SOUNDS_TYPE_LOCO, whichThrottle, mainapp.soundsLocoCurrentlyPlaying[whichThrottle], false);
+            expectedEndTime = soundStop(sounds_type.LOCO, whichThrottle, mainapp.soundsLocoCurrentlyPlaying[whichThrottle], false);
         }
         int nextSound = mainapp.soundsLocoQueue[whichThrottle].frontOfQueue();
 
         if (nextSound >= 0) {
             mainapp.throttle_msg_handler.postDelayed(
-                    new SoundScheduleNextSoundToPlay(SOUNDS_TYPE_LOCO, whichThrottle, nextSound),
+                    new SoundScheduleNextSoundToPlay(sounds_type.LOCO, whichThrottle, nextSound),
                     expectedEndTime-100);
 //            Log.d("Engine_Driver", "soundScheduleNextLocoSound : (locoSound) wt:" + whichThrottle + " snd: " + nextSound + " Start in: " + expectedEndTime + "msec");
         }
@@ -4785,9 +4784,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             default:
                 isPlaying = -1;
                 break;
-            case SOUNDS_TYPE_BELL: // bell
-            case SOUNDS_TYPE_HORN: // horn
-            case SOUNDS_TYPE_HORN_SHORT: // horn short
+            case sounds_type.BELL: // bell
+            case sounds_type.HORN: // horn
+            case sounds_type.HORN_SHORT: // horn short
                 isPlaying = mainapp.soundsExtrasCurrentlyPlaying[soundTypeArrayIndex][whichThrottle];
                 break;
         }
@@ -4799,12 +4798,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         int soundTypeArrayIndex = soundType - 1;
 
         if (soundIsPlaying(soundType,whichThrottle) < 0) { // check if the loop sound is not currently playing
-            if (soundType != SOUNDS_TYPE_HORN_SHORT) {
-                soundStart(soundType, whichThrottle, SOUNDS_BELL_HORN_START, 0);
+            if (soundType != sounds_type.HORN_SHORT) {
+                soundStart(soundType, whichThrottle, sounds_type.BELL_HORN_START, 0);
                 // queue up the loop sound to be played when the start sound is finished
                 mainapp.throttle_msg_handler.postDelayed(
-                        new SoundScheduleNextSoundToPlay(soundType, whichThrottle, SOUNDS_BELL_HORN_START),
-                        mainapp.soundsExtrasDuration[soundTypeArrayIndex][whichThrottle][SOUNDS_BELL_HORN_START]);
+                        new SoundScheduleNextSoundToPlay(soundType, whichThrottle, sounds_type.BELL_HORN_START),
+                        mainapp.soundsExtrasDuration[soundTypeArrayIndex][whichThrottle][sounds_type.BELL_HORN_START]);
             } else {
                 soundStart(soundType, whichThrottle, 0, 0);   // mSound always 0 for the short horn (not really used)
             }
@@ -4815,19 +4814,19 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 //        Log.d("Engine_Driver", "stopBellHornSound        : soundType:" + soundType + " wt: " + whichThrottle + " playing: " + soundIsPlaying(soundType,whichThrottle));
         int soundTypeArrayIndex = soundType - 1;
 
-        if (soundType != SOUNDS_TYPE_HORN_SHORT) {
+        if (soundType != sounds_type.HORN_SHORT) {
             if (soundIsPlaying(soundType, whichThrottle) == 0) {
                 // if the start sound is currently playing need to do something special
                 // as the loop is probably scheduled to run but has not started yet
                 mainapp.throttle_msg_handler.postDelayed(
-                        new SoundScheduleSoundToStop(soundType, whichThrottle, SOUNDS_BELL_HORN_LOOP),
-                        mainapp.soundsExtrasDuration[soundTypeArrayIndex][whichThrottle][SOUNDS_BELL_HORN_START] + 100);
+                        new SoundScheduleSoundToStop(soundType, whichThrottle, sounds_type.BELL_HORN_LOOP),
+                        mainapp.soundsExtrasDuration[soundTypeArrayIndex][whichThrottle][sounds_type.BELL_HORN_START] + 100);
 
             } else if (soundIsPlaying(soundType, whichThrottle) == 1) { // check if the loop sound is currently playing
-                int expectedEndTime = soundStop(soundType, whichThrottle, SOUNDS_BELL_HORN_LOOP, false);
+                int expectedEndTime = soundStop(soundType, whichThrottle, sounds_type.BELL_HORN_LOOP, false);
                 // queue up the end sound
                 mainapp.throttle_msg_handler.postDelayed(
-                        new SoundScheduleNextSoundToPlay(soundType, whichThrottle, SOUNDS_BELL_HORN_LOOP),
+                        new SoundScheduleNextSoundToPlay(soundType, whichThrottle, sounds_type.BELL_HORN_LOOP),
                         expectedEndTime);
             }
         } else { // for the short horn, stop immediately
@@ -4841,23 +4840,23 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         switch (soundType) {
             default:
-            case SOUNDS_TYPE_LOCO: // loco
+            case sounds_type.LOCO: // loco
 //                Log.d("Engine_Driver", "soundStart               : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop);
                 if (mSound>=0) {
                     if (mainapp.soundsLocoCurrentlyPlaying[whichThrottle] != mSound) {
-                        if (mSound < SOUNDS_STARTUP_INDEX) {
+                        if (mSound < sounds_type.STARTUP_INDEX) {
                             mainapp.soundsLocoStreamId[whichThrottle][mSound]
                                     = mainapp.soundPool.play(mainapp.soundsLoco[whichThrottle][mSound],
-                                    soundsVolume(SOUNDS_TYPE_LOCO, whichThrottle), soundsVolume(SOUNDS_TYPE_LOCO, whichThrottle),
-                                    0, SOUNDS_REPEAT_INFINITE, 1);
-                        } else if (mSound == SOUNDS_STARTUP_INDEX) {
+                                    soundsVolume(sounds_type.LOCO, whichThrottle), soundsVolume(sounds_type.LOCO, whichThrottle),
+                                    0, sounds_type.REPEAT_INFINITE, 1);
+                        } else if (mSound == sounds_type.STARTUP_INDEX) {
                             mainapp.soundsLocoStreamId[whichThrottle][mSound]
-                            = mainapp.soundPool.play(mainapp.soundsLoco[whichThrottle][mSound],
-                            soundsVolume(SOUNDS_TYPE_LOCO,whichThrottle), soundsVolume(SOUNDS_TYPE_LOCO,whichThrottle),
-                            0, SOUNDS_REPEAT_NONE, 1);
+                                    = mainapp.soundPool.play(mainapp.soundsLoco[whichThrottle][mSound],
+                                    soundsVolume(sounds_type.LOCO,whichThrottle), soundsVolume(sounds_type.LOCO,whichThrottle),
+                                    0, sounds_type.REPEAT_NONE, 1);
 //                            Log.d("Engine_Driver", "soundStart SU            : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop + " Sid: " + mainapp.soundsLocoStreamId[whichThrottle][mSound]);
 
-//                        } else if (mSound == SOUNDS_SHUTDOWN_INDEX) {
+//                        } else if (mSound == sounds_type.SHUTDOWN_INDEX) {
                         }
                         mainapp.soundsLocoCurrentlyPlaying[whichThrottle] = mSound;
                         mainapp.soundsLocoStartTime[whichThrottle][mSound] = System.currentTimeMillis();
@@ -4865,9 +4864,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 break;
 
-            case SOUNDS_TYPE_BELL: // bell
-            case SOUNDS_TYPE_HORN: // horn
-            case SOUNDS_TYPE_HORN_SHORT: // horn short
+            case sounds_type.BELL: // bell
+            case sounds_type.HORN: // horn
+            case sounds_type.HORN_SHORT: // horn short
                 if (mainapp.soundsExtrasCurrentlyPlaying[soundTypeArrayIndex][whichThrottle] != mSound) { // nothing playing
                     mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][mSound]
                             = mainapp.soundPool.play(mainapp.soundsExtras[soundTypeArrayIndex][whichThrottle][mSound],
@@ -4888,10 +4887,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         switch (soundType) {
             default:
-            case SOUNDS_TYPE_LOCO: // loco
+            case sounds_type.LOCO: // loco
 //                Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " mSound: " + snd + " forceStop:" + forceStop);
                 if (mSound>=0) {
-                    if (mSound < SOUNDS_STARTUP_INDEX) {
+                    if (mSound < sounds_type.STARTUP_INDEX) {
                         if (!forceStop) {
                             double duration = mainapp.soundsLocoDuration[whichThrottle][mSound];
 
@@ -4926,7 +4925,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                             mainapp.soundPool.stop(mainapp.soundsLocoStreamId[whichThrottle][mSound]);
 //                        Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " FORCED STOP");
                         }
-                    } else if (mSound == SOUNDS_STARTUP_INDEX) {
+                    } else if (mSound == sounds_type.STARTUP_INDEX) {
                         // this will only ever play once
                         if (!forceStop) {
                             expectedEndTime = mainapp.soundsLocoStartTime[whichThrottle][mSound] + mainapp.soundsLocoDuration[whichThrottle][mSound] - System.currentTimeMillis();
@@ -4940,12 +4939,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 break;
 
-            case SOUNDS_TYPE_BELL: // bell
-            case SOUNDS_TYPE_HORN: // horn
+            case sounds_type.BELL: // bell
+            case sounds_type.HORN: // horn
                 if (mainapp.soundsExtrasCurrentlyPlaying[soundTypeArrayIndex][whichThrottle] >=0) {
-                    if (mSound == SOUNDS_BELL_HORN_LOOP) { // assume it is looping
+                    if (mSound == sounds_type.BELL_HORN_LOOP) { // assume it is looping
                         mainapp.soundPool.pause(mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][mSound]);
-                        mainapp.soundPool.setLoop(mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][mSound], SOUNDS_REPEAT_NONE);  // don't really stop it, just let it finish
+                        mainapp.soundPool.setLoop(mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][mSound], sounds_type.REPEAT_NONE);  // don't really stop it, just let it finish
                         mainapp.soundPool.resume(mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][mSound]);
                         timesPlayed = (int) ((System.currentTimeMillis() - mainapp.soundsExtrasStartTime[soundTypeArrayIndex][whichThrottle][mSound])
                                 / mainapp.soundsExtrasDuration[soundTypeArrayIndex][whichThrottle][mSound]);
@@ -4959,7 +4958,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 break;
 
-            case SOUNDS_TYPE_HORN_SHORT: // horn short
+            case sounds_type.HORN_SHORT: // horn short
                 if (mainapp.soundsExtrasCurrentlyPlaying[soundTypeArrayIndex][whichThrottle] >=0) {
                     mainapp.soundPool.stop(mainapp.soundsExtrasStreamId[soundTypeArrayIndex][whichThrottle][0]);
                     mainapp.soundsExtrasCurrentlyPlaying[soundTypeArrayIndex][whichThrottle] = -1;
@@ -4988,22 +4987,22 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             switch (soundType) {
                 default:
                     break;
-                case SOUNDS_TYPE_LOCO: // loco
+                case sounds_type.LOCO: // loco
                     // pull the next sound off the queue
 //                    Log.d("Engine_Driver", "SoundScheduleNextSoundToPlay.run: (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                     soundStop(soundType, whichThrottle, mainapp.soundsLocoCurrentlyPlaying[whichThrottle], true);
-                    soundStart(soundType, whichThrottle, mSound, SOUNDS_REPEAT_INFINITE);
+                    soundStart(soundType, whichThrottle, mSound, sounds_type.REPEAT_INFINITE);
                     mainapp.soundsLocoQueue[whichThrottle].dequeue();
                     if (mainapp.soundsLocoQueue[whichThrottle].queueCount()>0) {  // if there are more on the queue, start the process to stop the one you just started
                         soundScheduleNextLocoSound(whichThrottle, mainapp.soundsLocoQueue[whichThrottle].frontOfQueue(), -1);
                     }
                     break;
-                case SOUNDS_TYPE_BELL: // bell
-                case SOUNDS_TYPE_HORN: // horn
-                    int loop = (mSound==SOUNDS_BELL_HORN_START) ? SOUNDS_REPEAT_INFINITE : SOUNDS_REPEAT_NONE; // of 0 now, then we will be playig the lop sound next.
+                case sounds_type.BELL: // bell
+                case sounds_type.HORN: // horn
+                    int loop = (mSound==sounds_type.BELL_HORN_START) ? sounds_type.REPEAT_INFINITE : sounds_type.REPEAT_NONE; // of 0 now, then we will be playig the lop sound next.
                     soundStart(soundType, whichThrottle, mSound+1, loop);
                     break;
-//                case SOUNDS_TYPE_HORN_SHORT:
+//                case sounds_type.HORN_SHORT:
 //                    break;
             }
         }
@@ -5026,17 +5025,17 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             switch (soundType) {
                 default:
                     break;
-                case SOUNDS_TYPE_HORN: // horn
-                case SOUNDS_TYPE_BELL: // bell
+                case sounds_type.HORN: // horn
+                case sounds_type.BELL: // bell
                     soundStop(soundType, whichThrottle, mSound, false);
                     break;
-//                case SOUNDS_TYPE_HORN_SHORT:
+//                case sounds_type.HORN_SHORT:
 //                    break;
             }
         }
     } // end class SoundScheduleSoundToStop
 
-    protected class function_button_touch_listener implements View.OnTouchListener {
+    protected class FunctionButtonTouchListener implements View.OnTouchListener {
     int function;
     int whichThrottle;
     boolean leadOnly;       // function only applies to the lead loco
@@ -5045,11 +5044,11 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     String lab;
     Integer functionNumber = -1;
 
-        protected function_button_touch_listener(int new_function, int new_whichThrottle) {
+        protected FunctionButtonTouchListener(int new_function, int new_whichThrottle) {
             this(new_function, new_whichThrottle, "");
         }
 
-        protected function_button_touch_listener(int new_function, int new_whichThrottle, String funcLabel) {
+        protected FunctionButtonTouchListener(int new_function, int new_whichThrottle, String funcLabel) {
             mainapp.exitDoubleBackButtonInitiated = 0;
             function = new_function;    // store these values for this button
             whichThrottle = new_whichThrottle;
@@ -5152,12 +5151,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     //Listeners for the throttle slider
-    protected class throttle_listener implements SeekBar.OnSeekBarChangeListener, View.OnTouchListener {
+    protected class ThrottleSeekBarListener implements SeekBar.OnSeekBarChangeListener, View.OnTouchListener {
         int whichThrottle;
         int lastSpeed;
         int jumpSpeed;
 
-        protected throttle_listener(int new_whichThrottle) {
+        protected ThrottleSeekBarListener(int new_whichThrottle) {
             whichThrottle = new_whichThrottle; // store values for this listener
             lastSpeed = 0;
             limitedJump[whichThrottle] = false;
@@ -5167,7 +5166,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         @Override
         public boolean onTouch(View v, MotionEvent event) {
             mainapp.exitDoubleBackButtonInitiated = 0;
-//             Log.d("Engine_Driver", "throttle_listener: onTouch: Throttle action " + event.getAction());
+//             Log.d("Engine_Driver", "throttle: ThrottleSeekBarListener: onTouch: Throttle action " + event.getAction());
             // consume event if gesture is in progress, otherwise pass it to the SeekBar onProgressChanged()
             return (gestureInProgress);
         }
@@ -5411,10 +5410,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         ov.addOnGestureListener(this);
         ov.setGestureVisible(false);
 
-        direction_button_touch_listener dbtl;
-        function_button_touch_listener fbtl;
-        select_function_button_touch_listener sfbt;
-        arrow_speed_button_touch_listener asbl;
+        DirectionButtonTouchListener directionButtonTouchListener;
+        FunctionButtonTouchListener functionButtonTouchListener;
+        SelectFunctionButtonTouchListener selectFunctionButtonTouchListener;
+        ArrowSpeedButtonTouchListener arrowSpeedButtonTouchListener;
 
         initialiseArrays();
 
@@ -5463,10 +5462,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             bSels[i] = bSel;
             tvbSelsLabels[i] = tvbSelsLabel;
             bSels[i].setClickable(true);
-            sfbt = new select_function_button_touch_listener(i);
-            bSels[i].setOnClickListener(sfbt);
+            selectFunctionButtonTouchListener = new SelectFunctionButtonTouchListener(i);
+            bSels[i].setOnClickListener(selectFunctionButtonTouchListener);
 //            bSels[i].setOnTouchListener(sfbt);
-            bSels[i].setOnLongClickListener(sfbt);  // Consist Light Edit
+            bSels[i].setOnLongClickListener(selectFunctionButtonTouchListener);  // Consist Light Edit
             tvLeftDirInds[i] = tvLeft;
             tvRightDirInds[i] = tvRight;
 
@@ -5499,17 +5498,17 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 bRSpds[i] = bRight;
                 bRSpds[i].setClickable(true);
-                asbl = new arrow_speed_button_touch_listener(i, "right");
-                bRSpds[i].setOnLongClickListener(asbl);
-                bRSpds[i].setOnTouchListener(asbl);
-                bRSpds[i].setOnClickListener(asbl);
+                arrowSpeedButtonTouchListener = new ArrowSpeedButtonTouchListener(i, "right");
+                bRSpds[i].setOnLongClickListener(arrowSpeedButtonTouchListener);
+                bRSpds[i].setOnTouchListener(arrowSpeedButtonTouchListener);
+                bRSpds[i].setOnClickListener(arrowSpeedButtonTouchListener);
 
                 bLSpds[i] = bLeft;
                 bLSpds[i].setClickable(true);
-                asbl = new arrow_speed_button_touch_listener(i, "left");
-                bLSpds[i].setOnLongClickListener(asbl);
-                bLSpds[i].setOnTouchListener(asbl);
-                bLSpds[i].setOnClickListener(asbl);
+                arrowSpeedButtonTouchListener = new ArrowSpeedButtonTouchListener(i, "left");
+                bLSpds[i].setOnLongClickListener(arrowSpeedButtonTouchListener);
+                bLSpds[i].setOnTouchListener(arrowSpeedButtonTouchListener);
+                bLSpds[i].setOnClickListener(arrowSpeedButtonTouchListener);
 
             } catch (Exception ex) {
                 Log.d("debug", "onCreate: " + ex.getMessage());
@@ -5556,19 +5555,19 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
 
             bFwds[i] = bFwd;
-            dbtl = new direction_button_touch_listener(direction_button.LEFT, i);
-            bFwds[i].setOnTouchListener(dbtl);
+            directionButtonTouchListener = new DirectionButtonTouchListener(direction_button.LEFT, i);
+            bFwds[i].setOnTouchListener(directionButtonTouchListener);
 
             bStops[i] = bStop;
-            fbtl = new function_button_touch_listener(function_button.STOP, i);
-            bStops[i].setOnTouchListener(fbtl);
+            functionButtonTouchListener = new FunctionButtonTouchListener(function_button.STOP, i);
+            bStops[i].setOnTouchListener(functionButtonTouchListener);
 
             bRevs[i] = bRev;
-            dbtl = new direction_button_touch_listener(direction_button.RIGHT, i);
-            bRevs[i].setOnTouchListener(dbtl);
+            directionButtonTouchListener = new DirectionButtonTouchListener(direction_button.RIGHT, i);
+            bRevs[i].setOnTouchListener(directionButtonTouchListener);
 
-            fbtl = new function_button_touch_listener(function_button.SPEED_LABEL, i);
-            v.setOnTouchListener(fbtl);
+            functionButtonTouchListener = new FunctionButtonTouchListener(function_button.SPEED_LABEL, i);
+            v.setOnTouchListener(functionButtonTouchListener);
 
             // set up listeners for all throttles
             SeekBar s = findViewById(R.id.speed_0);
@@ -5589,9 +5588,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     s = findViewById(R.id.speed_5);
                     break;
             }
-            throttle_listener thl;
+            ThrottleSeekBarListener thl;
             sbs[i] = s;
-            thl = new throttle_listener(i);
+            thl = new ThrottleSeekBarListener(i);
             sbs[i].setOnSeekBarChangeListener(thl);
             sbs[i].setOnTouchListener(thl);
 
@@ -5675,7 +5674,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         prefThrottleScreenType = prefs.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         if ( (!prefThrottleScreenType.contains("Switch")) || (prefThrottleScreenType.equals("Switching Horizontal")) ) {
             // set listeners for the limit speed buttons for each throttle
-            limit_speed_button_touch_listener lstl;
+            LimitSpeedButtonTouchListener limitSpeedButtonTouchListener;
             Button bLimitSpeed = findViewById(R.id.limit_speed_0);
 
             for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
@@ -5701,8 +5700,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 bLimitSpeeds[throttleIndex] = bLimitSpeed;
                 limitSpeedSliderScalingFactors[throttleIndex] = 1;
-                lstl = new limit_speed_button_touch_listener(throttleIndex);
-                bLimitSpeeds[throttleIndex].setOnTouchListener(lstl);
+                limitSpeedButtonTouchListener = new LimitSpeedButtonTouchListener(throttleIndex);
+                bLimitSpeeds[throttleIndex].setOnTouchListener(limitSpeedButtonTouchListener);
                 isLimitSpeeds[throttleIndex] = false;
                 if (!prefLimitSpeedButton) {
                     bLimitSpeed.setVisibility(View.GONE);
@@ -5711,7 +5710,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
 
         // set listeners for the pause buttons for each throttle
-        pause_speed_button_touch_listener psvtl;
+        PauseSpeedButtonTouchListener pauseSpeedButtonTouchListener;
         Button bPauseSpeed = findViewById(R.id.pause_speed_0);
 
         for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
@@ -5736,8 +5735,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     break;
             }
             bPauseSpeeds[throttleIndex] = bPauseSpeed;
-            psvtl = new pause_speed_button_touch_listener(throttleIndex);
-            bPauseSpeeds[throttleIndex].setOnTouchListener(psvtl);
+            pauseSpeedButtonTouchListener = new PauseSpeedButtonTouchListener(throttleIndex);
+            bPauseSpeeds[throttleIndex].setOnTouchListener(pauseSpeedButtonTouchListener);
             isPauseSpeeds[throttleIndex] = PAUSE_SPEED_INACTIVE;
             if (!prefPauseSpeedButton) {
                 bPauseSpeed.setVisibility(View.GONE);
@@ -5745,7 +5744,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
 
         //device sounds buttons
-        sound_device_mute_button_touch_listener muteTl;
+        SoundDeviceMuteButtonTouchListener muteTl;
         Button bMute = findViewById(R.id.device_sounds_mute_0);
         SoundDeviceExtrasButtonTouchListener soundsExtrasTl;
         Button bBell = findViewById(R.id.device_sounds_bell_0);
@@ -5769,20 +5768,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
             if (bMute != null) { // some layouts only have one throttle or no mute buttons so this may be null
                 bMutes[throttleIndex] = bMute;
-                muteTl = new sound_device_mute_button_touch_listener(throttleIndex);
+                muteTl = new SoundDeviceMuteButtonTouchListener(throttleIndex);
                 bMutes[throttleIndex].setOnTouchListener(muteTl);
 
-                bSoundsExtras[SOUNDS_BUTTON_BELL][throttleIndex] = bBell;
-                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, SOUNDS_BUTTON_BELL, SOUNDS_TYPE_BELL);
-                bSoundsExtras[SOUNDS_BUTTON_BELL][throttleIndex].setOnTouchListener(soundsExtrasTl);
+                bSoundsExtras[sounds_type.BUTTON_BELL][throttleIndex] = bBell;
+                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, sounds_type.BUTTON_BELL, sounds_type.BELL);
+                bSoundsExtras[sounds_type.BUTTON_BELL][throttleIndex].setOnTouchListener(soundsExtrasTl);
 
-                bSoundsExtras[SOUNDS_BUTTON_HORN][throttleIndex] = bHorn;
-                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, SOUNDS_BUTTON_HORN, SOUNDS_TYPE_HORN);
-                bSoundsExtras[SOUNDS_BUTTON_HORN][throttleIndex].setOnTouchListener(soundsExtrasTl);
+                bSoundsExtras[sounds_type.BUTTON_HORN][throttleIndex] = bHorn;
+                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, sounds_type.BUTTON_HORN, sounds_type.HORN);
+                bSoundsExtras[sounds_type.BUTTON_HORN][throttleIndex].setOnTouchListener(soundsExtrasTl);
 
-                bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][throttleIndex] = bHornShort;
-                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, SOUNDS_BUTTON_HORN_SHORT, SOUNDS_TYPE_HORN_SHORT);
-                bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][throttleIndex].setOnTouchListener(soundsExtrasTl);
+                bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][throttleIndex] = bHornShort;
+                soundsExtrasTl = new SoundDeviceExtrasButtonTouchListener(throttleIndex, sounds_type.BUTTON_HORN_SHORT, sounds_type.HORN_SHORT);
+                bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][throttleIndex].setOnTouchListener(soundsExtrasTl);
 
                 soundsShowHideDeviceSoundsButton(throttleIndex);
             }
@@ -5934,7 +5933,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         setupSensor(); // setup the support for shake actions.
 
         tts = new Tts(prefs, mainapp);
-		
+
         if (prefs.getBoolean("prefImportServerAuto", getApplicationContext().getResources().getBoolean(R.bool.prefImportServerAutoDefaultValue))) {
             autoImportFromURL();
         }
@@ -6000,6 +5999,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         applySpeedRelatedOptions();  // update all throttles
 
+        if (mainapp.soundsReloadSounds) loadSounds();
+
         set_labels(); // handle labels and update view
         pauseResumeWebView();
 
@@ -6049,7 +6050,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
         }
 
-        tts.loadPrefs(); // recheck the tts prefs in case they have been changed
+        tts.loadPrefs();
 
         setActivityTitle();
 
@@ -6228,7 +6229,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         Log.d("Engine_Driver", "throttle.onStart() called");
         // put pointer to this activity's handler in main app's shared variable
         if (mainapp.throttle_msg_handler == null)
-            mainapp.throttle_msg_handler = new throttle_handler(Looper.getMainLooper());
+            mainapp.throttle_msg_handler = new ThrottleMessageHandler(Looper.getMainLooper());
     }
 
     @Override
@@ -6360,7 +6361,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (fbs[0] != null) {
                 ViewGroup tv; // group
                 ViewGroup r; // row
-                function_button_touch_listener fbtl;
+                FunctionButtonTouchListener functionButtonTouchListener;
                 Button b; // button
                 int k = 0; // button count
                 LinkedHashMap<Integer, String> function_labels_temp;
@@ -6408,8 +6409,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 functionButtonMap.put(func, b); // save function to button
                                 // mapping
                                 String bt = function_labels_temp.get(func);
-                                fbtl = new function_button_touch_listener(func, whichThrottle, bt);
-                                b.setOnTouchListener(fbtl);
+                                functionButtonTouchListener = new FunctionButtonTouchListener(func, whichThrottle, bt);
+                                b.setOnTouchListener(functionButtonTouchListener);
                                 bt = bt + "                      ";  // pad with spaces, and limit to 20 characters
                                 b.setText(bt.trim());
                                 b.setVisibility(View.VISIBLE);
@@ -6567,12 +6568,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 //                        if (key == KEYCODE_VOLUME_UP) {
 //                            if (repeatCnt == 0) {
 //                                mVolumeKeysAutoIncrement = true;
-//                                volumeKeysRepeatUpdateHandler.post(new volumeKeysRptUpdater(throttleIndex));
+//                                volumeKeysRepeatUpdateHandler.post(new VolumeKeysRptUpdater(throttleIndex));
 //                            }
 //                        } else {
 //                            if (repeatCnt == 0) {
 //                                mVolumeKeysAutoDecrement = true;
-//                                volumeKeysRepeatUpdateHandler.post(new volumeKeysRptUpdater(throttleIndex));
+//                                volumeKeysRepeatUpdateHandler.post(new VolumeKeysRptUpdater(throttleIndex));
 //                            }
 //                        }
 //                    }
@@ -6619,12 +6620,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         if (key == KEYCODE_VOLUME_UP) {
                             if (repeatCnt == 0) {
                                 mVolumeKeysAutoIncrement = true;
-                                volumeKeysRepeatUpdateHandler.post(new volumeKeysRptUpdater(throttleIndex));
+                                volumeKeysRepeatUpdateHandler.post(new VolumeKeysRptUpdater(throttleIndex));
                             }
                         } else {
                             if (repeatCnt == 0) {
                                 mVolumeKeysAutoDecrement = true;
-                                volumeKeysRepeatUpdateHandler.post(new volumeKeysRptUpdater(throttleIndex));
+                                volumeKeysRepeatUpdateHandler.post(new VolumeKeysRptUpdater(throttleIndex));
                             }
                         }
                     }
@@ -6881,7 +6882,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         switch (requestCode) {
             case ACTIVITY_SELECT_LOCO:
                 if (resultCode == select_loco.RESULT_LOCO_EDIT) {
-                    ActivityConsistUpdate(resultCode, data.getExtras());
+                    activityConsistUpdate(resultCode, data.getExtras());
                 }
                 try {
                     overrideThrottleNames[mainapp.throttleCharToInt(data.getCharExtra("whichThrottle",' '))] = data.getStringExtra("overrideThrottleName");
@@ -6906,7 +6907,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 break;
             case ACTIVITY_CONSIST:         // edit loco or edit consist
                 if (resultCode == ConsistEdit.RESULT_CON_EDIT)
-                    ActivityConsistUpdate(resultCode, data.getExtras());
+                    activityConsistUpdate(resultCode, data.getExtras());
                 break;
             case ACTIVITY_CONSIST_LIGHTS:         // edit consist lights
                 break;   // nothing to do
@@ -6995,7 +6996,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         soundsShowHideAllMuteButtons();
     }
 
-    private void ActivityConsistUpdate(int resultCode, Bundle extras) {
+    private void activityConsistUpdate(int resultCode, Bundle extras) {
         if (extras != null) {
             int whichThrottle = mainapp.throttleCharToInt(extras.getChar("whichThrottle"));
             int dir;
@@ -7383,15 +7384,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     private void autoImportFromURL() {
-//        navigateToHandler(PermissionsHelper.STORE_SERVER_AUTO_PREFERENCES);
-//        autoImportFromURLImpl();
-//    }
-//
-//    public void autoImportFromURLImpl() {
-        new autoImportFromURL().execute();
+        new AutoImportFromURL().execute();
     }
 
-    public class autoImportFromURL extends AsyncTask<String, String, String> {   // Background Async Task to download file
+    public class AutoImportFromURL extends AsyncTask<String, String, String> {   // Background Async Task to download file
 
         // Importing file in background thread
         @SuppressLint("ApplySharedPref")
@@ -7581,10 +7577,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     //listeners for the Pause Speed Button
-    protected class pause_speed_button_touch_listener implements View.OnTouchListener {
+    protected class PauseSpeedButtonTouchListener implements View.OnTouchListener {
         int whichThrottle;
 
-        protected pause_speed_button_touch_listener(int new_whichThrottle) {
+        protected PauseSpeedButtonTouchListener(int new_whichThrottle) {
             whichThrottle = new_whichThrottle;
         }
 
@@ -7711,10 +7707,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     //listeners for the Mute Button
-    protected class sound_device_mute_button_touch_listener implements View.OnTouchListener {
+    protected class SoundDeviceMuteButtonTouchListener implements View.OnTouchListener {
         int whichThrottle;
 
-        protected sound_device_mute_button_touch_listener(int new_whichThrottle) {
+        protected SoundDeviceMuteButtonTouchListener(int new_whichThrottle) {
             whichThrottle = new_whichThrottle;
         }
 
@@ -7759,9 +7755,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 return (true);
             }
 
-            if ( ((buttonType==SOUNDS_BUTTON_BELL) && (mainapp.prefDeviceSoundsBellIsMomentary))
-            || (buttonType==SOUNDS_BUTTON_HORN)
-            || (buttonType==SOUNDS_BUTTON_HORN_SHORT)
+            if ( ((buttonType==sounds_type.BUTTON_BELL) && (mainapp.prefDeviceSoundsBellIsMomentary))
+                    || (buttonType==sounds_type.BUTTON_HORN)
+                    || (buttonType==sounds_type.BUTTON_HORN_SHORT)
             ) {
                 // if gesture just failed, insert one DOWN event on this control
                 if (gestureFailed) {
@@ -7781,7 +7777,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private void handleDeviceButtonAction(int whichThrottle, int buttonType, int soundType, int action) {
         Log.d("Engine_Driver", "handleDeviceButtonAction: handleAction - action: " + action);
 
-        if ( (buttonType==SOUNDS_BUTTON_BELL) && (!mainapp.prefDeviceSoundsBellIsMomentary) ) {
+        if ( (buttonType==sounds_type.BUTTON_BELL) && (!mainapp.prefDeviceSoundsBellIsMomentary) ) {
             boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][buttonType];
             doDeviceButtonSound(whichThrottle, soundType);
             setSoundButtonState(bSoundsExtras[buttonType][whichThrottle], rslt);
@@ -7822,14 +7818,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         rslt = View.GONE;
                     }
                     bMutes[whichThrottle].setVisibility( (mainapp.prefDeviceSoundsHideMuteButton) ? View.GONE : rslt);
-                    bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle].setVisibility(rslt);
-                    bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle].setVisibility(rslt);
-                    bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle].setVisibility(rslt);
+                    bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle].setVisibility(rslt);
+                    bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle].setVisibility(rslt);
+                    bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle].setVisibility(rslt);
                     if (rslt == View.VISIBLE) {
                         setSoundButtonState(bMutes[whichThrottle], soundsIsMuted[whichThrottle]);
-                        setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_BUTTON_BELL]);
-                        setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_BUTTON_HORN]);
-                        setSoundButtonState(bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][SOUNDS_BUTTON_HORN_SHORT]);
+                        setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BUTTON_BELL]);
+                        setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BUTTON_HORN]);
+                        setSoundButtonState(bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle], mainapp.soundsDeviceButtonStates[whichThrottle][sounds_type.BUTTON_HORN_SHORT]);
                     }
                 }
             }
@@ -7840,12 +7836,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         if ( (whichThrottle<mainapp.maxThrottlesCurrentScreen) && (whichThrottle<threaded_application.SOUND_MAX_SUPPORTED_THROTTLES) ) {
             if (bMutes!=null) {
                 if (bMutes[whichThrottle]!=null) {
-                    bMutes[whichThrottle].setEnabled(newEnabledState);
-                    bSoundsExtras[SOUNDS_BUTTON_BELL][whichThrottle].setEnabled(newEnabledState);
-                    bSoundsExtras[SOUNDS_BUTTON_HORN][whichThrottle].setEnabled(newEnabledState);
-                    bSoundsExtras[SOUNDS_BUTTON_HORN_SHORT][whichThrottle].setEnabled(newEnabledState);
-                    if (newEnabledState) {
-                        setSoundButtonState(bMutes[whichThrottle], soundsIsMuted[whichThrottle]);
+                    if (bMutes[whichThrottle]!=null) {
+                        bMutes[whichThrottle].setEnabled(newEnabledState);
+                        bSoundsExtras[sounds_type.BUTTON_BELL][whichThrottle].setEnabled(newEnabledState);
+                        bSoundsExtras[sounds_type.BUTTON_HORN][whichThrottle].setEnabled(newEnabledState);
+                        bSoundsExtras[sounds_type.BUTTON_HORN_SHORT][whichThrottle].setEnabled(newEnabledState);
+                        if (newEnabledState) {
+                            setSoundButtonState(bMutes[whichThrottle], soundsIsMuted[whichThrottle]);
+                        }
                     }
                 }
             }
@@ -7858,14 +7856,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (!soundsIsMuted[whichThrottle]) {
                 switch (soundType) {
                     default:
-                    case SOUNDS_TYPE_LOCO: // loco
+                    case sounds_type.LOCO: // loco
                         volume = mainapp.prefDeviceSoundsLocoVolume;
                         break;
-                    case SOUNDS_TYPE_BELL: // bell
+                    case sounds_type.BELL: // bell
                         volume = mainapp.prefDeviceSoundsBellVolume;
                         break;
-                    case SOUNDS_TYPE_HORN: // horn
-                    case SOUNDS_TYPE_HORN_SHORT: // horn
+                    case sounds_type.HORN: // horn
+                    case sounds_type.HORN_SHORT: // horn
                         volume = mainapp.prefDeviceSoundsHornVolume;
                         break;
                 }
@@ -7880,12 +7878,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 int mSound = mainapp.soundsLocoCurrentlyPlaying[whichThrottle];
                 if (mSound >= 0) {
                     mainapp.soundPool.setVolume(mainapp.soundsLocoStreamId[whichThrottle][mSound],
-                            soundsVolume(SOUNDS_TYPE_LOCO, whichThrottle),
-                            soundsVolume(SOUNDS_TYPE_LOCO, whichThrottle));
+                            soundsVolume(sounds_type.LOCO, whichThrottle),
+                            soundsVolume(sounds_type.LOCO, whichThrottle));
                 }
                 for (int soundType = 0; soundType < 2; soundType++ ) {  // don't worry about the short horn
-                    if (mainapp.soundsExtrasCurrentlyPlaying[soundType][whichThrottle] == SOUNDS_BELL_HORN_LOOP) {
-                        mainapp.soundPool.setVolume(mainapp.soundsExtrasStreamId[soundType][whichThrottle][SOUNDS_BELL_HORN_LOOP],
+                    if (mainapp.soundsExtrasCurrentlyPlaying[soundType][whichThrottle] == sounds_type.BELL_HORN_LOOP) {
+                        mainapp.soundPool.setVolume(mainapp.soundsExtrasStreamId[soundType][whichThrottle][sounds_type.BELL_HORN_LOOP],
                                 soundsVolume(soundType+1, whichThrottle),
                                 soundsVolume(soundType+1, whichThrottle));
                     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -152,6 +152,7 @@ import jmri.enginedriver.type.direction_button;
 import jmri.enginedriver.type.function_button;
 
 import jmri.enginedriver.type.screen_swipe_index_type;
+import jmri.enginedriver.util.BackgroundImageLoader;
 import jmri.enginedriver.util.HorizontalSeekBar;
 import jmri.enginedriver.util.VerticalSeekBar;
 import jmri.enginedriver.util.InPhoneLocoSoundsLoader;
@@ -565,9 +566,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     protected boolean prefShowAddressInsteadOfName = false;
     protected boolean prefIncreaseWebViewSize = false;
 
-    protected boolean prefBackgroundImage = false;
-    protected String prefBackgroundImageFileName = "";
-    protected String prefBackgroundImagePosition = "FIT_CENTER";
+//    protected boolean prefBackgroundImage = false;
+//    protected String prefBackgroundImageFileName = "";
+//    protected String prefBackgroundImagePosition = "FIT_CENTER";
 
     // preference to change the consist's on long clicks
     boolean prefConsistLightsLongClick;
@@ -1376,16 +1377,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     private boolean directionButtonsAreCurrentlyReversed(int throttleIndexNo) {
-        boolean isOk = ((!prefSwapForwardReverseButtons) && (currentSwapForwardReverseButtons[throttleIndexNo]))
+        return ((!prefSwapForwardReverseButtons) && (currentSwapForwardReverseButtons[throttleIndexNo]))
                 || (((prefSwapForwardReverseButtons) && (!currentSwapForwardReverseButtons[throttleIndexNo])));
-        return isOk;
     }
 
     private boolean gamepadDirectionButtonsAreCurrentlyReversed(int throttleIndexNo) {
-        boolean isOk = (prefGamepadSwapForwardReverseWithScreenButtons)
+        return (prefGamepadSwapForwardReverseWithScreenButtons)
                 && (((currentSwapForwardReverseButtons[throttleIndexNo]) && (!prefSwapForwardReverseButtons))
                 || ((!currentSwapForwardReverseButtons[throttleIndexNo]) && (prefSwapForwardReverseButtons)));
-        return isOk;
     }
 
     // set or restore the screen brightness when used for the Swipe Up or Shake
@@ -1612,9 +1611,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         prefSelectiveLeadSoundF1 = prefs.getBoolean("SelectiveLeadSoundF1", getResources().getBoolean(R.bool.prefSelectiveLeadSoundF1DefaultValue));
         prefSelectiveLeadSoundF2 = prefs.getBoolean("SelectiveLeadSoundF2", getResources().getBoolean(R.bool.prefSelectiveLeadSoundF2DefaultValue));
 
-        prefBackgroundImage = prefs.getBoolean("prefBackgroundImage", getResources().getBoolean(R.bool.prefBackgroundImageDefaultValue));
-        prefBackgroundImageFileName = prefs.getString("prefBackgroundImageFileName", getResources().getString(R.string.prefBackgroundImageFileNameDefaultValue));
-        prefBackgroundImagePosition = prefs.getString("prefBackgroundImagePosition", getResources().getString(R.string.prefBackgroundImagePositionDefaultValue));
+//        prefBackgroundImage = prefs.getBoolean("prefBackgroundImage", getResources().getBoolean(R.bool.prefBackgroundImageDefaultValue));
+//        prefBackgroundImageFileName = prefs.getString("prefBackgroundImageFileName", getResources().getString(R.string.prefBackgroundImageFileNameDefaultValue));
+//        prefBackgroundImagePosition = prefs.getString("prefBackgroundImagePosition", getResources().getString(R.string.prefBackgroundImagePositionDefaultValue));
 
         prefHideSlider = prefs.getBoolean("hide_slider_preference", getResources().getBoolean(R.bool.prefHideSliderDefaultValue));
 
@@ -1895,7 +1894,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         int speed = (int) Math.round(scaleSpeed / displayUnitScale);
 //        Log.d("Engine_Driver","throttle: speedChange -  change: " + change + " lastSpeed: " + lastSpeed+ " lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed:" + scaleSpeed);
         if (lastScaleSpeed == scaleSpeed) {
-            speed += Math.signum(change);
+            speed += (int) Math.signum(change);
         }
         if (speed < 0)  //insure speed is inside bounds
             speed = 0;
@@ -2453,8 +2452,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     private boolean isSelectLocoAllowed(int whichThrottle) {
         // check whether loco change is permitted
-        boolean isAllowed = !getConsist(whichThrottle).isActive() || locoSelectWhileMoving || (getSpeed(whichThrottle) == 0);
-        return isAllowed;
+        return !getConsist(whichThrottle).isActive() || locoSelectWhileMoving || (getSpeed(whichThrottle) == 0);
     }
 
     void start_select_loco_activity(int whichThrottle) {
@@ -3792,11 +3790,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         boolean isExternal = false;
         if (event!=null) {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
-                InputDevice idev = getDevice(event.getDeviceId());
-                if (idev != null && idev.toString().contains("Location: external"))
+            InputDevice idev = getDevice(event.getDeviceId());
+            if (idev != null && idev.toString().contains("Location: external"))
                     isExternal = true;
-            }
         } else { // received from another activity (Turnouts or Routes)
             isExternal = true;
         }
@@ -5500,7 +5496,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     "");
     }
 
-    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     @SuppressLint({"Recycle", "SetJavaScriptEnabled","ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -6086,7 +6081,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         queryAllSpeedsAndDirectionsWiT();
 
-        loadBackgroundImage();
+//        loadBackgroundImage();
+        BackgroundImageLoader backgroundImageLoader = new BackgroundImageLoader(prefs, mainapp, findViewById(R.id.backgroundImgView));
+        backgroundImageLoader.loadBackgroundImage();
 
         if (!mainapp.webServerNameHasBeenChecked) {
             mainapp.getServerNameFromWebServer();
@@ -6838,187 +6835,184 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         // Handle all of the possible menu actions.
         Intent in;
-        switch (item.getItemId()) {
-            case R.id.turnouts_mnu:
-                in = new Intent().setClass(this, turnouts.class);
-                startACoreActivity(this, in, false, 0);
-                return true;
-            case R.id.routes_mnu:
-                in = new Intent().setClass(this, routes.class);
-                startACoreActivity(this, in, false, 0);
-                return true;
-            case R.id.web_mnu:
-                in = new Intent().setClass(this, web_activity.class);
-                startACoreActivity(this, in, false, 0);
-                mainapp.webMenuSelected = true;
-                return true;
-            case R.id.exit_mnu:
-                mainapp.checkAskExit(this);
-                return true;
-            case R.id.power_control_mnu:
-                in = new Intent().setClass(this, power_control.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        if ( item.getItemId() == R.id.turnouts_mnu ) {
+            in = new Intent().setClass(this, turnouts.class);
+            startACoreActivity(this, in, false, 0);
+            return true;
+        } else if ( item.getItemId() == R.id.routes_mnu) {
+            in = new Intent().setClass(this, routes.class);
+            startACoreActivity(this, in, false, 0);
+            return true;
+        } else if ( item.getItemId() == R.id.web_mnu ) {
+            in = new Intent().setClass(this, web_activity.class);
+            startACoreActivity(this, in, false, 0);
+            mainapp.webMenuSelected = true;
+            return true;
 
-            case R.id.dcc_ex_button:
-            case R.id.dcc_ex_mnu:
-                in = new Intent().setClass(this, dcc_ex.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.exit_mnu) {
+            mainapp.checkAskExit(this);
+            return true;
+        } else if ( item.getItemId() == R.id.power_control_mnu) {
+            in = new Intent().setClass(this, power_control.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.withrottle_cv_programmer_mnu:
-                in = new Intent().setClass(this, withrottle_cv_programmer.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( (item.getItemId() == R.id.dcc_ex_button) || (item.getItemId() == R.id.dcc_ex_mnu) ) {
+            in = new Intent().setClass(this, dcc_ex.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.settings_mnu:
-                in = new Intent().setClass(this, SettingsActivity.class);
-                startActivityForResult(in, 0);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.withrottle_cv_programmer_mnu) {
+            in = new Intent().setClass(this, withrottle_cv_programmer.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.function_defaults_mnu:
-                in = new Intent().setClass(this, function_settings.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.function_consist_settings_mnu:
-                in = new Intent().setClass(this, function_consist_settings.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.settings_mnu) {
+            in = new Intent().setClass(this, SettingsActivity.class);
+            startActivityForResult(in, 0);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.about_mnu:
-                in = new Intent().setClass(this, about_page.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.logviewer_menu:
-                Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
-                startActivity(logviewer);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.function_defaults_mnu) {
+            in = new Intent().setClass(this, function_settings.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.function_consist_settings_mnu) {
+            in = new Intent().setClass(this, function_consist_settings.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.EmerStop:
-                mainapp.sendEStopMsg();
-                speedUpdate(0);  // update all throttles
-                applySpeedRelatedOptions();  // update all three throttles
-                if (IS_ESU_MCII) {
-                    Log.d("Engine_Driver", "ESU_MCII: Move knob request for EStop");
-                    setEsuThrottleKnobPosition(whichVolume, 0);
-                }
-                mainapp.buttonVibration();
-                return true;
-            case R.id.power_layout_button:
-                if (!mainapp.isPowerControlAllowed()) {
-                    mainapp.powerControlNotAllowedDialog(TMenu);
-                } else {
-                    mainapp.powerStateMenuButton();
-                }
-                mainapp.buttonVibration();
-                return true;
+        } else if ( item.getItemId() == R.id.about_mnu) {
+            in = new Intent().setClass(this, about_page.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.logviewer_menu) {
+            Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
+            startActivity(logviewer);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.EditConsist0_menu:
-                Intent consistEdit = new Intent().setClass(this, ConsistEdit.class);
-                consistEdit.putExtra("whichThrottle", '0');
-                startActivityForResult(consistEdit, ACTIVITY_CONSIST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EditConsist1_menu:
-                Intent consistEdit2 = new Intent().setClass(this, ConsistEdit.class);
-                consistEdit2.putExtra("whichThrottle", '1');
-                startActivityForResult(consistEdit2, ACTIVITY_CONSIST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EditConsist2_menu:
-                Intent consistEdit3 = new Intent().setClass(this, ConsistEdit.class);
-                consistEdit3.putExtra("whichThrottle", '2');
-                startActivityForResult(consistEdit3, ACTIVITY_CONSIST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EditLightsConsist0_menu:
-                Intent consistLightsEdit = new Intent().setClass(this, ConsistLightsEdit.class);
-                consistLightsEdit.putExtra("whichThrottle", '0');
-                startActivityForResult(consistLightsEdit, ACTIVITY_CONSIST_LIGHTS);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EditLightsConsist1_menu:
-                Intent consistLightsEdit2 = new Intent().setClass(this, ConsistLightsEdit.class);
-                consistLightsEdit2.putExtra("whichThrottle", '1');
-                startActivityForResult(consistLightsEdit2, ACTIVITY_CONSIST_LIGHTS);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EditLightsConsist2_menu:
-                Intent consistLightsEdit3 = new Intent().setClass(this, ConsistLightsEdit.class);
-                consistLightsEdit3.putExtra("whichThrottle", '2');
-                startActivityForResult(consistLightsEdit3, ACTIVITY_CONSIST_LIGHTS);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.EmerStop) {
+            mainapp.sendEStopMsg();
+            speedUpdate(0);  // update all throttles
+            applySpeedRelatedOptions();  // update all three throttles
+            if (IS_ESU_MCII) {
+                Log.d("Engine_Driver", "ESU_MCII: Move knob request for EStop");
+                setEsuThrottleKnobPosition(whichVolume, 0);
+            }
+            mainapp.buttonVibration();
+            return true;
+        } else if ( item.getItemId() == R.id.power_layout_button) {
+            if (!mainapp.isPowerControlAllowed()) {
+                mainapp.powerControlNotAllowedDialog(TMenu);
+            } else {
+                mainapp.powerStateMenuButton();
+            }
+            mainapp.buttonVibration();
+            return true;
 
-            case R.id.gamepad_test_reset:
-                mainapp.gamepadFullReset();
-                mainapp.setGamepadTestMenuOption(TMenu,mainapp.gamepadCount);
-                setGamepadIndicator();
-                speakWords(TTS_MSG_GAMEPAD_GAMEPAD_TEST_RESET,' ');
-                return true;
-            case R.id.gamepad_test_mnu1:
-                in = new Intent().setClass(this, gamepad_test.class);
-                in.putExtra("whichGamepadNo", "0");
-                startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.gamepad_test_mnu2:
-                in = new Intent().setClass(this, gamepad_test.class);
-                in.putExtra("whichGamepadNo", "1");
-                startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.gamepad_test_mnu3:
-                in = new Intent().setClass(this, gamepad_test.class);
-                in.putExtra("whichGamepadNo", "2");
-                startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.EditConsist0_menu) {
+            Intent consistEdit = new Intent().setClass(this, ConsistEdit.class);
+            consistEdit.putExtra("whichThrottle", '0');
+            startActivityForResult(consistEdit, ACTIVITY_CONSIST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.EditConsist1_menu) {
+            Intent consistEdit2 = new Intent().setClass(this, ConsistEdit.class);
+            consistEdit2.putExtra("whichThrottle", '1');
+            startActivityForResult(consistEdit2, ACTIVITY_CONSIST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.EditConsist2_menu) {
+            Intent consistEdit3 = new Intent().setClass(this, ConsistEdit.class);
+            consistEdit3.putExtra("whichThrottle", '2');
+            startActivityForResult(consistEdit3, ACTIVITY_CONSIST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.EditLightsConsist0_menu) {
+            Intent consistLightsEdit = new Intent().setClass(this, ConsistLightsEdit.class);
+            consistLightsEdit.putExtra("whichThrottle", '0');
+            startActivityForResult(consistLightsEdit, ACTIVITY_CONSIST_LIGHTS);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.EditLightsConsist1_menu) {
+            Intent consistLightsEdit2 = new Intent().setClass(this, ConsistLightsEdit.class);
+            consistLightsEdit2.putExtra("whichThrottle", '1');
+            startActivityForResult(consistLightsEdit2, ACTIVITY_CONSIST_LIGHTS);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.EditLightsConsist2_menu) {
+            Intent consistLightsEdit3 = new Intent().setClass(this, ConsistLightsEdit.class);
+            consistLightsEdit3.putExtra("whichThrottle", '2');
+            startActivityForResult(consistLightsEdit3, ACTIVITY_CONSIST_LIGHTS);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.timer_mnu:
-                showTimerPasswordDialog();
-                return true;
-            case R.id.timer_button:
-                prefKidsTime = Integer.parseInt(prefKidsTimerButtonDefault) * 60000;
-                prefKidsTimer = prefKidsTimerButtonDefault;
-                prefs.edit().putString("prefKidsTimer", prefKidsTimerButtonDefault).commit();
-                kidsTimerActions(kids_timer_action_type.ENABLED, 0);
-                return true;
+        } else if ( item.getItemId() == R.id.gamepad_test_reset) {
+            mainapp.gamepadFullReset();
+            mainapp.setGamepadTestMenuOption(TMenu,mainapp.gamepadCount);
+            setGamepadIndicator();
+            speakWords(TTS_MSG_GAMEPAD_GAMEPAD_TEST_RESET,' ');
+            return true;
+        } else if ( item.getItemId() == R.id.gamepad_test_mnu1) {
+            in = new Intent().setClass(this, gamepad_test.class);
+            in.putExtra("whichGamepadNo", "0");
+            startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.gamepad_test_mnu2) {
+            in = new Intent().setClass(this, gamepad_test.class);
+            in.putExtra("whichGamepadNo", "1");
+            startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( item.getItemId() == R.id.gamepad_test_mnu3) {
+            in = new Intent().setClass(this, gamepad_test.class);
+            in.putExtra("whichGamepadNo", "2");
+            startActivityForResult(in, ACTIVITY_GAMEPAD_TEST);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
 
-            case R.id.flashlight_button:
-                mainapp.toggleFlashlight(this, TMenu);
-                mainapp.buttonVibration();
-                return true;
-            case R.id.throttle_switch_button:
-                switchThrottleScreenType();
-                mainapp.buttonVibration();
-                return true;
-            case R.id.web_view_button:
-                showHideWebView("");
-                return true;
-            case R.id.EsuMc2Knob_button:
-                toggleEsuMc2Knob(this, TMenu);
-                return true;
+        } else if ( item.getItemId() == R.id.timer_mnu) {
+            showTimerPasswordDialog();
+            return true;
+        } else if ( item.getItemId() == R.id.timer_button) {
+            prefKidsTime = Integer.parseInt(prefKidsTimerButtonDefault) * 60000;
+            prefKidsTimer = prefKidsTimerButtonDefault;
+            prefs.edit().putString("prefKidsTimer", prefKidsTimerButtonDefault).commit();
+            kidsTimerActions(kids_timer_action_type.ENABLED, 0);
+            return true;
 
-            case R.id.device_sounds_button:
-                mainapp.buttonVibration();
-            case R.id.device_sounds_menu:
-                in = new Intent().setClass(this, device_sounds_settings.class);
-                startActivityForResult(in, ACTIVITY_DEVICE_SOUNDS_SETTINGS);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
+        } else if ( item.getItemId() == R.id.flashlight_button) {
+            mainapp.toggleFlashlight(this, TMenu);
+            mainapp.buttonVibration();
+            return true;
+        } else if ( item.getItemId() == R.id.throttle_switch_button) {
+            switchThrottleScreenType();
+            mainapp.buttonVibration();
+            return true;
+        } else if ( item.getItemId() == R.id.web_view_button) {
+            showHideWebView("");
+            return true;
+        } else if ( item.getItemId() == R.id.EsuMc2Knob_button) {
+            toggleEsuMc2Knob(this, TMenu);
+            return true;
 
-            default:
-                return super.onOptionsItemSelected(item);
+        } else if ( (item.getItemId() == R.id.device_sounds_button) || ( item.getItemId() == R.id.device_sounds_menu) ) {
+            if (item.getItemId() == R.id.device_sounds_button) mainapp.buttonVibration();
+            in = new Intent().setClass(this, device_sounds_settings.class);
+            startActivityForResult(in, ACTIVITY_DEVICE_SOUNDS_SETTINGS);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+
         }
+        return super.onOptionsItemSelected(item);
     }
 
     // handle return from menu items
@@ -7704,51 +7698,6 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 vsbSwitchingSpeeds[throttleIndex].tickMarksChecked = false;
                 vsbSwitchingSpeeds[throttleIndex].invalidate();
             }
-        }
-    }
-
-    protected void loadBackgroundImage() {
-        if (prefBackgroundImage) {
-//            if (PermissionsHelper.getInstance().isPermissionGranted(throttle.this, PermissionsHelper.READ_IMAGES)) {
-//                loadBackgroundImageImpl();
-//            }
-//<!-- needed for API 33 -->
-            if ( ( (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
-                    && (PermissionsHelper.getInstance().isPermissionGranted(this, PermissionsHelper.READ_IMAGES)) )
-                    || ( (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-                    && (PermissionsHelper.getInstance().isPermissionGranted(this, PermissionsHelper.READ_MEDIA_IMAGES)) ) ) {
-                loadBackgroundImageImpl();
-            }
-//<!-- needed for API 33 -->
-        }
-    }
-
-    protected void loadBackgroundImageImpl() {
-        ImageView myImage = findViewById(R.id.backgroundImgView);
-        try {
-//            File sdcard_path = Environment.getExternalStorageDirectory();
-            File image_file = new File(prefBackgroundImageFileName);
-//            File image_file = new File(getApplicationContext().getExternalFilesDir(null), prefBackgroundImageFileName);
-            myImage.setImageBitmap(BitmapFactory.decodeFile(image_file.getPath()));
-            switch (prefBackgroundImagePosition){
-                case "FIT_CENTER":
-                    myImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
-                break;
-                case "CENTER_CROP":
-                    myImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
-                break;
-                case "CENTER":
-                    myImage.setScaleType(ImageView.ScaleType.CENTER);
-                break;
-                case "FIT_XY":
-                    myImage.setScaleType(ImageView.ScaleType.FIT_XY);
-                break;
-                case "CENTER_INSIDE":
-                    myImage.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-                break;
-            }
-        } catch (Exception e) {
-            Log.d("Engine_Driver", "Throttle: failed loading background image");
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_big_buttons.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_big_buttons.java
@@ -95,7 +95,7 @@ public class throttle_big_buttons extends throttle {
         svFnBtns[0] = findViewById(R.id.function_buttons_scroller_0);
         bPauses[0] = findViewById(R.id.button_pause_0);
 
-        pause_speed_button_touch_listener psvtl = new pause_speed_button_touch_listener(0);
+        PauseSpeedButtonTouchListener psvtl = new PauseSpeedButtonTouchListener(0);
         bPauses[0].setOnTouchListener(psvtl);
 
         setAllFunctionLabelsAndListeners();

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_simple.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_simple.java
@@ -130,7 +130,7 @@ public class throttle_simple extends throttle {
                     break;
             }
 
-            pause_speed_button_touch_listener psvtl = new pause_speed_button_touch_listener(throttleIndex);
+            PauseSpeedButtonTouchListener psvtl = new PauseSpeedButtonTouchListener(throttleIndex);
             bPauses[throttleIndex].setOnTouchListener(psvtl);
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
@@ -157,7 +157,7 @@ public class throttle_switching_left_or_right extends throttle {
                     break;
             }
 
-            pause_speed_button_touch_listener psvtl = new pause_speed_button_touch_listener(throttleIndex);
+            PauseSpeedButtonTouchListener psvtl = new PauseSpeedButtonTouchListener(throttleIndex);
             bPauses[throttleIndex].setOnTouchListener(psvtl);
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_vertical_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_vertical_left_or_right.java
@@ -178,8 +178,8 @@ public class throttle_vertical_left_or_right extends throttle {
                     break;
             }
 
-            pause_speed_button_touch_listener psvtl = new pause_speed_button_touch_listener(throttleIndex);
-            bPauses[throttleIndex].setOnTouchListener(psvtl);
+            PauseSpeedButtonTouchListener pauseSpeedButtonTouchListener = new PauseSpeedButtonTouchListener(throttleIndex);
+            bPauses[throttleIndex].setOnTouchListener(pauseSpeedButtonTouchListener);
         }
 
         sliderType = SLIDER_TYPE_VERTICAL;

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -871,6 +871,7 @@ public class turnouts extends AppCompatActivity implements android.gesture.Gestu
         mainapp.displayThrottleMenuButton(menu, "swipe_through_turnouts_preference");
         mainapp.setPowerMenuOption(menu);
         mainapp.setDCCEXMenuOption(menu);
+        mainapp.displayDccExButton(menu);
         mainapp.setWithrottleCvProgrammerMenuOption(menu);
         mainapp.setPowerStateButton(menu);
         mainapp.setWebMenuOption(menu);
@@ -887,73 +888,70 @@ public class turnouts extends AppCompatActivity implements android.gesture.Gestu
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handle all of the possible menu actions.
         Intent in;
-        switch (item.getItemId()) {
-            case R.id.throttle_button_mnu:
-            case R.id.throttle_mnu:
-                in = mainapp.getThrottleIntent();
-                startACoreActivity(this, in, false, 0);
-                return true;
-            case R.id.routes_mnu:
-                in = new Intent().setClass(this, routes.class);
-                startACoreActivity(this, in, false, 0);
-                return true;
-            case R.id.web_mnu:
-                in = new Intent().setClass(this, web_activity.class);
-                startACoreActivity(this, in, false, 0);
-                mainapp.webMenuSelected = true;
-                return true;
-            case R.id.exit_mnu:
-                mainapp.checkAskExit(this);
-                return true;
-            case R.id.power_control_mnu:
-                in = new Intent().setClass(this, power_control.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.settings_mnu:
-                in = new Intent().setClass(this, SettingsActivity.class);
-                startActivityForResult(in, 0);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.about_mnu:
-                in = new Intent().setClass(this, about_page.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.dcc_ex_mnu:
-                in = new Intent().setClass(this, dcc_ex.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.withrottle_cv_programmer_mnu:
-                in = new Intent().setClass(this, withrottle_cv_programmer.class);
-                startActivity(in);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.logviewer_menu:
-                Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
-                startActivity(logviewer);
-                connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
-                return true;
-            case R.id.EmerStop:
-                mainapp.sendEStopMsg();
-                mainapp.buttonVibration();
-                return true;
-            case R.id.power_layout_button:
-                if (!mainapp.isPowerControlAllowed()) {
-                    mainapp.powerControlNotAllowedDialog(TuMenu);
-                } else {
-                    mainapp.powerStateMenuButton();
-                }
-                mainapp.buttonVibration();
-                return true;
-            case R.id.flashlight_button:
-                mainapp.toggleFlashlight(this, TuMenu);
-                mainapp.buttonVibration();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if ( (item.getItemId() == R.id.throttle_button_mnu) || (item.getItemId() == R.id.throttle_mnu) ) {
+            in = mainapp.getThrottleIntent();
+            startACoreActivity(this, in, false, 0);
+            return true;
+        } else if (item.getItemId() == R.id.routes_mnu) {
+            in = new Intent().setClass(this, routes.class);
+            startACoreActivity(this, in, false, 0);
+            return true;
+        } else if (item.getItemId() == R.id.web_mnu) {
+            in = new Intent().setClass(this, web_activity.class);
+            startACoreActivity(this, in, false, 0);
+            mainapp.webMenuSelected = true;
+            return true;
+        } else if (item.getItemId() == R.id.exit_mnu) {
+            mainapp.checkAskExit(this);
+            return true;
+        } else if (item.getItemId() == R.id.power_control_mnu) {
+            in = new Intent().setClass(this, power_control.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if (item.getItemId() == R.id.settings_mnu) {
+            in = new Intent().setClass(this, SettingsActivity.class);
+            startActivityForResult(in, 0);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if (item.getItemId() == R.id.about_mnu) {
+            in = new Intent().setClass(this, about_page.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if ( (item.getItemId() == R.id.dcc_ex_button) || (item.getItemId() == R.id.dcc_ex_mnu) ) {
+            in = new Intent().setClass(this, dcc_ex.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if (item.getItemId() == R.id.withrottle_cv_programmer_mnu) {
+            in = new Intent().setClass(this, withrottle_cv_programmer.class);
+            startActivity(in);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if (item.getItemId() == R.id.logviewer_menu) {
+            Intent logviewer = new Intent().setClass(this, LogViewerActivity.class);
+            startActivity(logviewer);
+            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            return true;
+        } else if (item.getItemId() == R.id.EmerStop) {
+            mainapp.sendEStopMsg();
+            mainapp.buttonVibration();
+            return true;
+        } else if (item.getItemId() == R.id.power_layout_button) {
+            if (!mainapp.isPowerControlAllowed()) {
+                mainapp.powerControlNotAllowedDialog(TuMenu);
+            } else {
+                mainapp.powerStateMenuButton();
+            }
+            mainapp.buttonVibration();
+            return true;
+        } else if (item.getItemId() == R.id.flashlight_button) {
+            mainapp.toggleFlashlight(this, TuMenu);
+            mainapp.buttonVibration();
+            return true;
         }
+        return super.onOptionsItemSelected(item);
     }
 
     //handle return from menu items

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/message_type.java
@@ -1,4 +1,4 @@
-/*/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/pref_gamepad_button_option_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/pref_gamepad_button_option_type.java
@@ -1,0 +1,36 @@
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package jmri.enginedriver.type;
+
+public interface pref_gamepad_button_option_type {
+    String ALL_STOP = "All Stop";
+    String STOP = "Stop";
+    String NEXT_THROTTLE = "Next Throttle";
+    String FORWARD = "Forward";
+    String REVERSE = "Reverse";
+    String FORWARD_REVERSE_TOGGLE = "Forward/Reverse Toggle";
+    String INCREASE_SPEED = "Increase Speed";
+    String DECREASE_SPEED = "Decrease Speed";
+    String LIMIT_SPEED = "Limit Speed";
+    String PAUSE = "Pause";
+    String SOUNDS_MUTE = "Mute (IPLS)";
+    String SOUNDS_BELL = "Bell (IPLS)";
+    String SOUNDS_HORN = "Horn (IPLS)";
+    String SOUNDS_HORN_SHORT = "Horn Short (IPLS)";
+    String SPEAK_CURRENT_SPEED = "Speak Current Speed";
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/pref_tts_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/pref_tts_type.java
@@ -1,0 +1,26 @@
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package jmri.enginedriver.type;
+
+public interface pref_tts_type {
+    String THROTTLE_RESPONSE_NONE = "None";
+    String THROTTLE_RESPONSE_THROTTLE = "Throttle";
+    String THROTTLE_RESPONSE_LOCO = "Loco";
+    String THROTTLE_RESPONSE_SPEED = "Speed";
+    String THROTTLE_RESPONSE_LOCO_SPEED = "LocoSpeed";
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/sounds_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/sounds_type.java
@@ -1,0 +1,40 @@
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package jmri.enginedriver.type;
+
+public interface sounds_type {
+    int LOCO = 0;
+    int BELL = 1;
+    int HORN = 2;
+    int HORN_SHORT = 3;
+
+    int BUTTON_BELL = 0;
+    int BUTTON_HORN = 1;
+    int BUTTON_HORN_SHORT = 2;
+
+    int BELL_HORN_START = 0;
+    int BELL_HORN_LOOP = 1;
+    int BELL_HORN_END = 2;
+
+    int REPEAT_INFINITE = -1;
+    int REPEAT_NONE = 0;
+
+    int NOTHING_CURRENTLY_PLAYING = -1;
+    int STARTUP_INDEX = 20;
+    int SHUTDOWN_INDEX = 21;
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/tts_msg_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/tts_msg_type.java
@@ -1,0 +1,30 @@
+/* Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package jmri.enginedriver.type;
+
+public interface tts_msg_type {
+    int VOLUME_THROTTLE = 1;
+    int GAMEPAD_THROTTLE = 2;
+    int GAMEPAD_GAMEPAD_TEST = 3;
+    int GAMEPAD_GAMEPAD_TEST_COMPLETE = 4;
+    int GAMEPAD_GAMEPAD_TEST_SKIPPED = 5;
+    int GAMEPAD_GAMEPAD_TEST_RESET = 6;
+    int GAMEPAD_GAMEPAD_TEST_FAIL = 7;
+    int GAMEPAD_GAMEPAD_TEST_KEY_AND_PURPOSE = 8;
+    int GAMEPAD_THROTTLE_SPEED = 9;
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
@@ -1,0 +1,71 @@
+package jmri.enginedriver.util;
+
+import android.content.SharedPreferences;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import android.util.Log;
+import android.widget.ImageView;
+
+import java.io.File;
+
+import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
+
+public class BackgroundImageLoader {
+    private String prefBackgroundImageFileName;
+    private String prefBackgroundImagePosition;
+    private boolean prefBackgroundImage;
+    private SharedPreferences prefs;
+    private ImageView image;
+    private threaded_application mainapp;
+
+    public BackgroundImageLoader(SharedPreferences myPrefs, threaded_application myMainapp, ImageView myImage) {
+        prefs = myPrefs;
+        image = myImage;
+        mainapp = myMainapp;
+        prefBackgroundImage = prefs.getBoolean("prefBackgroundImage", mainapp.getResources().getBoolean(R.bool.prefBackgroundImageDefaultValue));
+        prefBackgroundImageFileName = prefs.getString("prefBackgroundImageFileName", mainapp.getResources().getString(R.string.prefBackgroundImageFileNameDefaultValue));
+        prefBackgroundImagePosition = prefs.getString("prefBackgroundImagePosition", mainapp.getResources().getString(R.string.prefBackgroundImagePositionDefaultValue));
+    }
+
+    public void loadBackgroundImage() {
+        if (prefBackgroundImage) {
+//<!-- needed for API 33 -->
+            if ( ( (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+                    && (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_IMAGES)) )
+                    || ( (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    && (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_IMAGES)) ) ) {
+                loadBackgroundImageImpl();
+            }
+//<!-- needed for API 33 -->
+        }
+    }
+
+    protected void loadBackgroundImageImpl() {
+        try {
+//            File sdcard_path = Environment.getExternalStorageDirectory();
+            File image_file = new File(prefBackgroundImageFileName);
+//            File image_file = new File(getApplicationContext().getExternalFilesDir(null), prefBackgroundImageFileName);
+            image.setImageBitmap(BitmapFactory.decodeFile(image_file.getPath()));
+            switch (prefBackgroundImagePosition){
+                case "FIT_CENTER":
+                    image.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                    break;
+                case "CENTER_CROP":
+                    image.setScaleType(ImageView.ScaleType.CENTER_CROP);
+                    break;
+                case "CENTER":
+                    image.setScaleType(ImageView.ScaleType.CENTER);
+                    break;
+                case "FIT_XY":
+                    image.setScaleType(ImageView.ScaleType.FIT_XY);
+                    break;
+                case "CENTER_INSIDE":
+                    image.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+                    break;
+            }
+        } catch (Exception e) {
+            Log.d("Engine_Driver", "backgroundImageLoader: failed loading background image");
+        }
+    }
+}

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
@@ -30,14 +30,12 @@ public class BackgroundImageLoader {
 
     public void loadBackgroundImage() {
         if (prefBackgroundImage) {
-//<!-- needed for API 33 -->
             if ( ( (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
                     && (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_IMAGES)) )
                     || ( (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                     && (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_IMAGES)) ) ) {
                 loadBackgroundImageImpl();
             }
-//<!-- needed for API 33 -->
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/InPhoneLocoSoundsLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/InPhoneLocoSoundsLoader.java
@@ -23,23 +23,12 @@ import java.util.Locale;
 import jmri.enginedriver.R;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.threaded_application;
+import jmri.enginedriver.type.sounds_type;
 
 public class InPhoneLocoSoundsLoader {
    protected threaded_application mainapp;  // hold pointer to mainapp
    protected SharedPreferences prefs;
    protected Context context;
-
-   private static final int SOUNDS_TYPE_LOCO = 0;
-   private static final int SOUNDS_TYPE_BELL = 1;
-   private static final int SOUNDS_TYPE_HORN = 2;
-   private static final int SOUNDS_TYPE_HORN_SHORT = 3;
-
-   private static final int SOUNDS_BELL_HORN_START = 0;
-   private static final int SOUNDS_BELL_HORN_LOOP = 1;
-   private static final int SOUNDS_BELL_HORN_END = 2;
-
-   private static final int SOUNDS_STARTUP_INDEX = 20;
-   private static final int SOUNDS_SHUTDOWN_INDEX = 21;
 
    // details for the currently being loaded IPLS file
    // these are used for temporary storage of the ipls details
@@ -149,15 +138,15 @@ public class InPhoneLocoSoundsLoader {
             getIplsDetails(mainapp.prefDeviceSounds[throttleIndex]);
             if (!iplsFileName.equals("")) {
                for (int j = 0; j <= 2; j++) {
-                  loadSoundFromFile(SOUNDS_TYPE_BELL, throttleIndex, j, context, iplsBellSoundsFileName[j]);
-                  loadSoundFromFile(SOUNDS_TYPE_HORN, throttleIndex, j, context, iplsHornSoundsFileName[j]);
+                  loadSoundFromFile(sounds_type.BELL, throttleIndex, j, context, iplsBellSoundsFileName[j]);
+                  loadSoundFromFile(sounds_type.HORN, throttleIndex, j, context, iplsHornSoundsFileName[j]);
                }
-               loadSoundFromFile(SOUNDS_TYPE_HORN_SHORT, throttleIndex, 0, context, iplsHornShortSoundsFileName);
+               loadSoundFromFile(sounds_type.HORN_SHORT, throttleIndex, 0, context, iplsHornShortSoundsFileName);
                for (int j = 0; j <= iplsLocoSoundsCount; j++) {
-                  loadSoundFromFile(SOUNDS_TYPE_LOCO, throttleIndex, j, context, iplsLocoSoundsFileName[j]);
+                  loadSoundFromFile(sounds_type.LOCO, throttleIndex, j, context, iplsLocoSoundsFileName[j]);
                }
-               loadSoundFromFile(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_STARTUP_INDEX, context, iplsLocoSoundsFileName[SOUNDS_STARTUP_INDEX]);
-               loadSoundFromFile(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_SHUTDOWN_INDEX, context, iplsLocoSoundsFileName[SOUNDS_SHUTDOWN_INDEX]);
+               loadSoundFromFile(sounds_type.LOCO, throttleIndex, sounds_type.STARTUP_INDEX, context, iplsLocoSoundsFileName[sounds_type.STARTUP_INDEX]);
+               loadSoundFromFile(sounds_type.LOCO, throttleIndex, sounds_type.SHUTDOWN_INDEX, context, iplsLocoSoundsFileName[sounds_type.SHUTDOWN_INDEX]);
                mainapp.prefDeviceSoundsCurrentlyLoaded[throttleIndex] = iplsFileName;
 
             } else { // can't find the file name or some other issue
@@ -176,14 +165,14 @@ public class InPhoneLocoSoundsLoader {
                case "diesel645turbo":
                case "diesel7FDL":
                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.bell_start);
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.bell_loop);
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.bell_end);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.bell_start);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.bell_loop);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.bell_end);
                   break;
                case "steamClass94":
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.bell_br_64_glocke_22_start);
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.bell_br_64_glocke_22_loop);
-                  loadSound(SOUNDS_TYPE_BELL, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.bell_br_64_glocke_22_end);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.bell_br_64_glocke_22_start);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.bell_br_64_glocke_22_loop);
+                  loadSound(sounds_type.BELL, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.bell_br_64_glocke_22_end);
                   break;
             }
 
@@ -191,32 +180,32 @@ public class InPhoneLocoSoundsLoader {
                default:
                case "steam":
                case "steamSlow":
-//                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_start);
-//                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.whistle_loop);
-//                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.whistle_end);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.steam_horn_start3);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.steam_horn_loop3);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.steam_horn_end3);
+//                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_start);
+//                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.whistle_loop);
+//                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.whistle_end);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.steam_horn_start3);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.steam_horn_loop3);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.steam_horn_end3);
                   break;
 
                case "diesel645turbo":
                case "diesel7FDL":
                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.horn_start);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.horn_loop);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.horn_end);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.horn_start);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.horn_loop);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.horn_end);
                   break;
 
                case "steamClass64":
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_class64_long_start);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.whistle_class64_long_mid);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.whistle_class64_long_end);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_class64_long_start);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.whistle_class64_long_mid);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.whistle_class64_long_end);
                   break;
 
                case "steamClass94":
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_start);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_LOOP, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_loop);
-                  loadSound(SOUNDS_TYPE_HORN, throttleIndex, SOUNDS_BELL_HORN_END, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_end);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_start);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_LOOP, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_loop);
+                  loadSound(sounds_type.HORN, throttleIndex, sounds_type.BELL_HORN_END, context, R.raw.whistle_class94_pfiff_941538_b_nf_2_22_end);
                   break;
             }
 
@@ -224,21 +213,21 @@ public class InPhoneLocoSoundsLoader {
                default:
                case "steam":
                case "steamSlow":
-                  loadSound(SOUNDS_TYPE_HORN_SHORT, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_short);
+                  loadSound(sounds_type.HORN_SHORT, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_short);
                   break;
 
                case "diesel645turbo":
                case "diesel7FDL":
                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_HORN_SHORT, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.horn_short);
+                  loadSound(sounds_type.HORN_SHORT, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.horn_short);
                   break;
 
                case "steamClass64":
-                  loadSound(SOUNDS_TYPE_HORN_SHORT, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_class64_short);
+                  loadSound(sounds_type.HORN_SHORT, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_class64_short);
                   break;
 
                case "steamClass94":
-                  loadSound(SOUNDS_TYPE_HORN_SHORT, throttleIndex, SOUNDS_BELL_HORN_START, context, R.raw.whistle_class94_pfiff_2_2);
+                  loadSound(sounds_type.HORN_SHORT, throttleIndex, sounds_type.BELL_HORN_START, context, R.raw.whistle_class94_pfiff_2_2);
                   break;
             }
 
@@ -247,22 +236,22 @@ public class InPhoneLocoSoundsLoader {
                default:
                case "steam":
                case "steamSlow":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.steam_loco_stationary_med);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.steam_piston_stroke3);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.steam_loop_30rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 3, context, R.raw.steam_loop_35rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 4, context, R.raw.steam_loop_40rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 5, context, R.raw.steam_loop_50rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 6, context, R.raw.steam_loop_60rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 7, context, R.raw.steam_loop_75rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 8, context, R.raw.steam_loop_90rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 9, context, R.raw.steam_loop_100rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 10, context, R.raw.steam_loop_125rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 11, context, R.raw.steam_loop_150rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 12, context, R.raw.steam_loop_175rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 13, context, R.raw.steam_loop_200rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 14, context, R.raw.steam_loop_250rpm);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 15, context, R.raw.steam_loop_300rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.steam_loco_stationary_med);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.steam_piston_stroke3);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.steam_loop_30rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 3, context, R.raw.steam_loop_35rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 4, context, R.raw.steam_loop_40rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 5, context, R.raw.steam_loop_50rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 6, context, R.raw.steam_loop_60rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 7, context, R.raw.steam_loop_75rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 8, context, R.raw.steam_loop_90rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 9, context, R.raw.steam_loop_100rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 10, context, R.raw.steam_loop_125rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 11, context, R.raw.steam_loop_150rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 12, context, R.raw.steam_loop_175rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 13, context, R.raw.steam_loop_200rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 14, context, R.raw.steam_loop_250rpm);
+                  loadSound(sounds_type.LOCO, throttleIndex, 15, context, R.raw.steam_loop_300rpm);
                   if (mainapp.prefDeviceSounds[throttleIndex].equals("steam")) {
                      mainapp.soundsLocoSteps[throttleIndex] = 15;
                   } else {
@@ -271,70 +260,70 @@ public class InPhoneLocoSoundsLoader {
                   break;
 
                case "diesel645turbo":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.diesel_645turbo_idle);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.diesel_645turbo_d1k);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.diesel_645turbo_d2);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 3, context, R.raw.diesel_645turbo_d3);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 4, context, R.raw.diesel_645turbo_d4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.diesel_645turbo_idle);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.diesel_645turbo_d1k);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.diesel_645turbo_d2);
+                  loadSound(sounds_type.LOCO, throttleIndex, 3, context, R.raw.diesel_645turbo_d3);
+                  loadSound(sounds_type.LOCO, throttleIndex, 4, context, R.raw.diesel_645turbo_d4);
                   mainapp.soundsLocoSteps[throttleIndex] = 4;
                   break;
 
                case "diesel7FDL":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.diesel_7fdl_idle_1a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.diesel_7fdl_idle_2a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.diesel_7fdl_idle_3a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 3, context, R.raw.diesel_7fdl_idle_4a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 4, context, R.raw.diesel_7fdl_idle_5a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 5, context, R.raw.diesel_7fdl_idle_6a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 6, context, R.raw.diesel_7fdl_idle_7a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 7, context, R.raw.diesel_7fdl_idle_8a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.diesel_7fdl_idle_1a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.diesel_7fdl_idle_2a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.diesel_7fdl_idle_3a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 3, context, R.raw.diesel_7fdl_idle_4a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 4, context, R.raw.diesel_7fdl_idle_5a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 5, context, R.raw.diesel_7fdl_idle_6a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 6, context, R.raw.diesel_7fdl_idle_7a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 7, context, R.raw.diesel_7fdl_idle_8a);
                   mainapp.soundsLocoSteps[throttleIndex] = 7; // fast steam
                   break;
 
                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.diesel_nw7_motor);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.diesel_nw7_motor_2);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.diesel_nw7_motor_1);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.diesel_nw7_motor);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.diesel_nw7_motor_2);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.diesel_nw7_motor_1);
                   mainapp.soundsLocoSteps[throttleIndex] = 2;
                   break;
 
                case "steamClass64":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.steam_class64_idle_sound);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.steam_class64_chuff1_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.steam_class64_chuff2_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 3, context, R.raw.steam_class64_chuff3_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 4, context, R.raw.steam_class64_chuff4_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 5, context, R.raw.steam_class64_chuff5_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 6, context, R.raw.steam_class64_chuff6_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.steam_class64_idle_sound);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.steam_class64_chuff1_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.steam_class64_chuff2_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 3, context, R.raw.steam_class64_chuff3_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 4, context, R.raw.steam_class64_chuff4_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 5, context, R.raw.steam_class64_chuff5_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 6, context, R.raw.steam_class64_chuff6_1_4);
                   mainapp.soundsLocoSteps[throttleIndex] = 6;
                   break;
 
                case "steamClass94":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 0, context, R.raw.steam_class94_idle2a);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 1, context, R.raw.steam_class94_speed0a_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 2, context, R.raw.steam_class94_speed2g_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 3, context, R.raw.steam_class94_speed3g_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 4, context, R.raw.steam_class94_speed4g_1_4);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, 5, context, R.raw.steam_class94_speed5g_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 0, context, R.raw.steam_class94_idle2a);
+                  loadSound(sounds_type.LOCO, throttleIndex, 1, context, R.raw.steam_class94_speed0a_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 2, context, R.raw.steam_class94_speed2g_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 3, context, R.raw.steam_class94_speed3g_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 4, context, R.raw.steam_class94_speed4g_1_4);
+                  loadSound(sounds_type.LOCO, throttleIndex, 5, context, R.raw.steam_class94_speed5g_1_4);
                   mainapp.soundsLocoSteps[throttleIndex] = 5;
                   break;
             }
 
             switch (mainapp.prefDeviceSounds[throttleIndex]) {
                default:
-                  mainapp.soundsLoco[throttleIndex][SOUNDS_STARTUP_INDEX] = 0;
-                  mainapp.soundsLocoDuration[throttleIndex][SOUNDS_STARTUP_INDEX] = 0;
-                  mainapp.soundsLoco[throttleIndex][SOUNDS_SHUTDOWN_INDEX] = 0;
-                  mainapp.soundsLocoDuration[throttleIndex][SOUNDS_SHUTDOWN_INDEX] = 0;
+                  mainapp.soundsLoco[throttleIndex][sounds_type.STARTUP_INDEX] = 0;
+                  mainapp.soundsLocoDuration[throttleIndex][sounds_type.STARTUP_INDEX] = 0;
+                  mainapp.soundsLoco[throttleIndex][sounds_type.SHUTDOWN_INDEX] = 0;
+                  mainapp.soundsLocoDuration[throttleIndex][sounds_type.SHUTDOWN_INDEX] = 0;
                   break;
                case "diesel645turbo":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_STARTUP_INDEX, context, R.raw.diesel_645turbo_start);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_SHUTDOWN_INDEX, context, R.raw.diesel_645turbo_shutdown);
+                  loadSound(sounds_type.LOCO, throttleIndex, sounds_type.STARTUP_INDEX, context, R.raw.diesel_645turbo_start);
+                  loadSound(sounds_type.LOCO, throttleIndex, sounds_type.SHUTDOWN_INDEX, context, R.raw.diesel_645turbo_shutdown);
                   break;
 
                case "dieselNW2":
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_STARTUP_INDEX, context, R.raw.diesel_nw7_start_22050);
-                  loadSound(SOUNDS_TYPE_LOCO, throttleIndex, SOUNDS_SHUTDOWN_INDEX, context, R.raw.diesel_nw7_stop_22050);
+                  loadSound(sounds_type.LOCO, throttleIndex, sounds_type.STARTUP_INDEX, context, R.raw.diesel_nw7_start_22050);
+                  loadSound(sounds_type.LOCO, throttleIndex, sounds_type.SHUTDOWN_INDEX, context, R.raw.diesel_nw7_stop_22050);
                   break;
 
             }
@@ -366,13 +355,13 @@ public class InPhoneLocoSoundsLoader {
       soundsCountOfSoundBeingLoaded ++;
       switch (soundType) {
          default:
-         case SOUNDS_TYPE_LOCO: // loco
+         case sounds_type.LOCO: // loco
             mainapp.soundsLoco[whichThrottle][soundNo] = mainapp.soundPool.load(context, resId, 1);
             mainapp.soundsLocoDuration[whichThrottle][soundNo] = duration;
             break;
-         case SOUNDS_TYPE_BELL: // bell
-         case SOUNDS_TYPE_HORN: // horn
-         case SOUNDS_TYPE_HORN_SHORT: // horn short
+         case sounds_type.BELL: // bell
+         case sounds_type.HORN: // horn
+         case sounds_type.HORN_SHORT: // horn short
             mainapp.soundsExtras[soundType-1][whichThrottle][soundNo] = mainapp.soundPool.load(context, resId, 1);
             mainapp.soundsExtrasDuration[soundType-1][whichThrottle][soundNo] = duration;
             break;
@@ -401,14 +390,14 @@ public class InPhoneLocoSoundsLoader {
 
                switch (soundType) {
                   default:
-                  case SOUNDS_TYPE_LOCO: // loco
+                  case sounds_type.LOCO: // loco
                      mainapp.soundsLoco[whichThrottle][soundNo]
                              = mainapp.soundPool.load(context.getExternalFilesDir(null) + "/" + fileName, 1);
                      mainapp.soundsLocoDuration[whichThrottle][soundNo] = duration;
                      break;
-                  case SOUNDS_TYPE_BELL: // bell
-                  case SOUNDS_TYPE_HORN: // horn
-                  case SOUNDS_TYPE_HORN_SHORT: // horn short
+                  case sounds_type.BELL: // bell
+                  case sounds_type.HORN: // horn
+                  case sounds_type.HORN_SHORT: // horn short
                      mainapp.soundsExtras[soundType - 1][whichThrottle][soundNo]
                              = mainapp.soundPool.load(context.getExternalFilesDir(null) + "/" + fileName, 1);
                      mainapp.soundsExtrasDuration[soundType - 1][whichThrottle][soundNo] = duration;
@@ -425,13 +414,13 @@ public class InPhoneLocoSoundsLoader {
    void loadSoundFromFileFailed(int soundType, int whichThrottle, int soundNo, Context context, String fileName) {
       switch (soundType) {
          default:
-         case SOUNDS_TYPE_LOCO: // loco
+         case sounds_type.LOCO: // loco
             mainapp.soundsLoco[whichThrottle][soundNo] = 0;
             mainapp.soundsLocoDuration[whichThrottle][soundNo] = 0;
             break;
-         case SOUNDS_TYPE_BELL: // bell
-         case SOUNDS_TYPE_HORN: // horn
-         case SOUNDS_TYPE_HORN_SHORT: // horn
+         case sounds_type.BELL: // bell
+         case sounds_type.HORN: // horn
+         case sounds_type.HORN_SHORT: // horn
             mainapp.soundsExtras[soundType-1][whichThrottle][soundNo] = 0;
             mainapp.soundsExtrasDuration[soundType-1][whichThrottle][soundNo] = 0;
             break;
@@ -492,17 +481,17 @@ public class InPhoneLocoSoundsLoader {
                                  num = Integer.decode(line.substring(1, splitPos));
                               } catch (NumberFormatException e) {
                                  if (line.substring(1, splitPos).equals("+")) {  // startup sound
-                                    num = SOUNDS_STARTUP_INDEX;
+                                    num = sounds_type.STARTUP_INDEX;
                                  } else if (line.substring(1, splitPos).equals("-")) { // shutdown sound
-                                    num = SOUNDS_SHUTDOWN_INDEX;
+                                    num = sounds_type.SHUTDOWN_INDEX;
                                  } else {
                                     break;
                                  }
                               }
                            }
-                           if ((num >= 0) && (num <= SOUNDS_SHUTDOWN_INDEX)) {
+                           if ((num >= 0) && (num <= sounds_type.SHUTDOWN_INDEX)) {
                               iplsLocoSoundsFileName[num] = line.substring(splitPos + 1, line.length() - splitPos + 2).trim();
-                              if ( (num > iplsLocoSoundsCount) && (num < SOUNDS_STARTUP_INDEX) ) {  // don't count the Startup and shutdown sounds
+                              if ( (num > iplsLocoSoundsCount) && (num < sounds_type.STARTUP_INDEX) ) {  // don't count the Startup and shutdown sounds
                                  iplsLocoSoundsCount = num;
                               }
                            }
@@ -513,9 +502,9 @@ public class InPhoneLocoSoundsLoader {
                                  num = Integer.decode(line.substring(1, splitPos));
                               } catch (NumberFormatException e) {
                                  if (line.substring(1, splitPos).equals("+")) {  // startup sound
-                                    num = SOUNDS_STARTUP_INDEX;
+                                    num = sounds_type.STARTUP_INDEX;
                                  } else if (line.substring(1, splitPos).equals("-")) { // shutdown sound
-                                    num = SOUNDS_SHUTDOWN_INDEX;
+                                    num = sounds_type.SHUTDOWN_INDEX;
                                  } else {
                                     break;
                                  }

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
@@ -1,6 +1,7 @@
 package jmri.enginedriver.util;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -252,7 +253,7 @@ public class PermissionsHelper {
                     break;
                 case WRITE_SETTINGS:
                     Log.d("Engine_Driver", "Requesting WRITE_SETTINGS permissions");
-                    if (android.os.Build.VERSION.SDK_INT < 23) {
+                    if (Build.VERSION.SDK_INT < 23) {
                         activity.requestPermissions(new String[]{
                                         Manifest.permission.WRITE_SETTINGS},
                                 requestCode);
@@ -272,9 +273,11 @@ public class PermissionsHelper {
 //<!-- needed for API 33 -->
                 case READ_MEDIA_IMAGES:
                     Log.d("Engine_Driver", "Requesting READ_MEDIA_IMAGES permissions");
-                    activity.requestPermissions(new String[]{
-                                    Manifest.permission.READ_MEDIA_IMAGES},
-                            requestCode);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        activity.requestPermissions(new String[]{
+                                        Manifest.permission.READ_MEDIA_IMAGES},
+                                requestCode);
+                    }
                     break;
 //                case NEARBY_WIFI_DEVICES:
 //                    activity.requestPermissions(new String[]{
@@ -283,9 +286,11 @@ public class PermissionsHelper {
 //                    Log.d("Engine_Driver", "Requesting NEARBY_WIFI_DEVICES permissions");
 //                    break;
                 case POST_NOTIFICATIONS:
-                    activity.requestPermissions(new String[]{
-                                    Manifest.permission.POST_NOTIFICATIONS},
-                            requestCode);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        activity.requestPermissions(new String[]{
+                                        Manifest.permission.POST_NOTIFICATIONS},
+                                requestCode);
+                    }
                     Log.d("Engine_Driver", "Requesting POST_NOTIFICATIONS permissions");
                     break;
 //<!-- needed for API 33 -->
@@ -320,7 +325,9 @@ public class PermissionsHelper {
                         if (requestCode != WRITE_SETTINGS) {
                             intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
                         } else {
-                            intent.setAction(Settings.ACTION_MANAGE_WRITE_SETTINGS);
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                intent.setAction(Settings.ACTION_MANAGE_WRITE_SETTINGS);
+                            }
                         }
                         Uri uri = Uri.fromParts("package", context.getApplicationContext().getPackageName(), null);
                         intent.setData(uri);
@@ -381,9 +388,10 @@ public class PermissionsHelper {
      * @return true if permissions granted; false if not
      */
 //    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    @SuppressLint("ObsoleteSdkInt")
     public boolean isPermissionGranted(final Context context, @RequestCodes final int requestCode) {
         //sdk 15 doesn't support some of the codes below, always return success
-        if (android.os.Build.VERSION.SDK_INT < 16) {
+        if (Build.VERSION.SDK_INT < 16) {
             return true;
         }
         // Determine which permissions to check based on request code
@@ -411,7 +419,7 @@ public class PermissionsHelper {
                 return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION ) == PackageManager.PERMISSION_GRANTED;
             case WRITE_SETTINGS:
                 boolean result;
-                if (android.os.Build.VERSION.SDK_INT < 23) {
+                if (Build.VERSION.SDK_INT < 23) {
                     result = ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_SETTINGS) == PackageManager.PERMISSION_GRANTED;
                 } else {
                     result = Settings.System.canWrite(context);
@@ -422,11 +430,15 @@ public class PermissionsHelper {
 
 //<!-- needed for API 33 -->
             case READ_MEDIA_IMAGES:
-                return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED;
+                }
 //            case NEARBY_WIFI_DEVICES :
 //                return ContextCompat.checkSelfPermission(context, Manifest.permission.NEARBY_WIFI_DEVICES ) == PackageManager.PERMISSION_GRANTED;
             case POST_NOTIFICATIONS:
-                return ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS ) == PackageManager.PERMISSION_GRANTED;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    return ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS ) == PackageManager.PERMISSION_GRANTED;
+                }
 //<!-- needed for API 33 -->
 
             default:
@@ -470,11 +482,15 @@ public class PermissionsHelper {
                 return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_SETTINGS);
 
             case READ_MEDIA_IMAGES:
-                return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_IMAGES);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_IMAGES);
+                }
 //            case NEARBY_WIFI_DEVICES:
 //                return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.NEARBY_WIFI_DEVICES);
             case POST_NOTIFICATIONS:
-                return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS);
+                }
 
             default:
                 return false;

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/TransparentListView.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/TransparentListView.java
@@ -18,24 +18,20 @@ import android.widget.ListView;
 public class TransparentListView extends ListView {
 
     private void makeTransparent() {
-        if (Build.VERSION.SDK_INT >= 9) {
+        try {
+            Method overscrollFooterMethod =
+                    TransparentListView.class.getMethod("setOverscrollFooter", Drawable.class);
+            Method overscrollHeaderMethod =
+                    TransparentListView.class.getMethod("setOverscrollHeader", Drawable.class);
+
             try {
-
-                Method overscrollFooterMethod =
-                        TransparentListView.class.getMethod("setOverscrollFooter", Drawable.class);
-                Method overscrollHeaderMethod =
-                        TransparentListView.class.getMethod("setOverscrollHeader", Drawable.class);
-
-
-                try {
-                    overscrollFooterMethod.invoke(this, new Object[]{null});
-                    overscrollHeaderMethod.invoke(this, new Object[]{null});
-                } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            } catch (SecurityException | NoSuchMethodException e) {
+                overscrollFooterMethod.invoke(this, new Object[]{null});
+                overscrollHeaderMethod.invoke(this, new Object[]{null});
+            } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
             }
+        } catch (SecurityException | NoSuchMethodException e) {
+            e.printStackTrace();
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/Tts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/Tts.java
@@ -1,0 +1,204 @@
+package jmri.enginedriver.util;
+
+import android.content.SharedPreferences;
+import android.speech.tts.TextToSpeech;
+import android.widget.ImageView;
+import android.widget.Toast;
+
+import java.util.Locale;
+
+import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
+import jmri.enginedriver.type.pref_tts_type;
+import jmri.enginedriver.type.tts_msg_type;
+
+public class Tts {
+    private static final String PREF_TTS_WHEN_NONE = "None";
+
+    private String lastTts = "none";
+    private String prefTtsWhen = "None";
+    private long lastTtsTime;
+    private int whichLastVolume = -1;
+
+    private TextToSpeech myTts;
+
+    private String prefTtsThrottleResponse;
+    private String prefTtsThrottleSpeed;
+    private boolean prefTtsGamepadTest;
+    private boolean prefTtsGamepadTestComplete;
+    private boolean prefTtsGamepadTestKeys;
+
+    private SharedPreferences prefs;
+    private ImageView image;
+    private threaded_application mainapp;
+
+    public Tts(SharedPreferences myPrefs, threaded_application myMainapp) {
+        prefs = myPrefs;
+        mainapp = myMainapp;
+        loadPrefs();
+
+        if (!prefTtsWhen.equals(mainapp.getResources().getString(R.string.prefTtsWhenDefaultValue))) {
+            if (myTts == null) {
+//                lastTtsTime = new Time();
+//                lastTtsTime.setToNow();
+                lastTtsTime = System.currentTimeMillis();
+
+                myTts = new TextToSpeech(mainapp, new TextToSpeech.OnInitListener() {
+                    @Override
+                    public void onInit(int status) {
+                        if (status != TextToSpeech.ERROR) {
+                            myTts.setLanguage(Locale.getDefault());
+                        } else {
+                            Toast.makeText(mainapp, mainapp.getResources().getString(R.string.toastTtsFailed), Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    public void loadPrefs() {
+        prefTtsWhen = prefs.getString("prefTtsWhen", mainapp.getString(R.string.prefTtsWhenDefaultValue));
+        prefTtsThrottleResponse = prefs.getString("prefTtsThrottleResponse", mainapp.getString(R.string.prefTtsThrottleResponseDefaultValue));
+        prefTtsThrottleSpeed = prefs.getString("prefTtsThrottleSpeed", mainapp.getString(R.string.prefTtsThrottleSpeedDefaultValue));
+        prefTtsGamepadTest = prefs.getBoolean("prefTtsGamepadTest", mainapp.getResources().getBoolean(R.bool.prefTtsGamepadTestDefaultValue));
+        prefTtsGamepadTestComplete = prefs.getBoolean("prefTtsGamepadTestComplete", mainapp.getResources().getBoolean(R.bool.prefTtsGamepadTestCompleteDefaultValue));
+        prefTtsGamepadTestKeys = prefs.getBoolean("prefTtsGamepadTestKeys", mainapp.getResources().getBoolean(R.bool.prefTtsGamepadTestKeysDefaultValue));
+    }
+
+    public void speakWords(int msgNo) {
+        speakWords(msgNo, ' ', false, 0, 0, 0, "");
+    }
+
+    public void speakWords(int msgNo, String argString) {
+        speakWords(msgNo, ' ', false, 0, 0, 0, argString);
+    }
+
+    public void speakWords(int msgNo, int whichThrottle) {
+        speakWords(msgNo, whichThrottle, false, 0, 0, 0, "");
+    }
+
+    public void speakWords(int msgNo, int whichThrottle, boolean force) {
+        speakWords(msgNo, whichThrottle, force, 0, 0, 0, "");
+    }
+
+    public void speakWords(int msgNo, int whichThrottle, boolean force, int argInt1, int argInt2, int argInt3, String argString) {
+        boolean result = false;
+        String speech = "";
+        if (!prefTtsWhen.equals(PREF_TTS_WHEN_NONE)) {
+            if (myTts != null) {
+                switch (msgNo) {
+                    case tts_msg_type.VOLUME_THROTTLE:
+                        if (!prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_NONE)) {
+                            int displaySpeedFromCurrentSliderPosition = argInt1; //getDisplaySpeedFromCurrentSliderPosition(whichThrottle,true)
+                            String consistAddressString = argString; // getConsistAddressString(whichThrottle);
+
+                            if (whichLastVolume != whichThrottle) {
+                                result = true;
+                                whichLastVolume = whichThrottle;
+                                speech = mainapp.getResources().getString(R.string.TtsVolumeThrottle) + " " + (whichThrottle + 1);
+                            }
+                            if ((prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO)) || (prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO_SPEED))) {
+                                speech = speech  + ", " + mainapp.getResources().getString(R.string.TtsLoco) + " " + (consistAddressString);
+                            }
+                            if ((prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_SPEED)) || (prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO_SPEED))) {
+                                speech = speech  + ", " + mainapp.getResources().getString(R.string.TtsSpeed) + " "
+                                        + (displaySpeedFromCurrentSliderPosition);
+                            }
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_THROTTLE:
+                        if (!prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_NONE)) {
+                            int whichLastGamepad1 = argInt1;
+                            int displaySpeedFromCurrentSliderPosition = argInt2; // getDisplaySpeedFromCurrentSliderPosition(whichThrottle,true)
+                            String consistAddressString = argString; // getConsistAddressString(whichThrottle)
+
+                            if ((whichLastGamepad1 != whichThrottle) || (force)) {
+                                result = true;
+                                whichLastGamepad1 = whichThrottle;
+                                speech = mainapp.getResources().getString(R.string.TtsGamepadThrottle) + " " + (whichThrottle + 1);
+                            }
+                            if ((prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO)) || (prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO_SPEED))) {
+                                speech = speech  + ", " + mainapp.getResources().getString(R.string.TtsLoco) + " " + (consistAddressString);
+                            }
+                            if ((prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_SPEED)) || (prefTtsThrottleResponse.equals(pref_tts_type.THROTTLE_RESPONSE_LOCO_SPEED))) {
+                                speech = speech  + ", " + mainapp.getResources().getString(R.string.TtsSpeed) + " "
+                                        + (displaySpeedFromCurrentSliderPosition);
+                            }
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST:
+                        if ((prefTtsGamepadTest)) {
+                            result = true;
+                            speech = mainapp.getResources().getString(R.string.TtsGamepadTest);
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST_COMPLETE:
+                        if ((prefTtsGamepadTestComplete)) {
+                            result = true;
+                            speech = mainapp.getResources().getString(R.string.TtsGamepadTestComplete);
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST_SKIPPED:
+                        if ((prefTtsGamepadTestComplete)) {
+                            result = true;
+                            speech = mainapp.getResources().getString(R.string.TtsGamepadTestSkipped);
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST_FAIL:
+                        if ((prefTtsGamepadTestComplete)) {
+                            result = true;
+                            speech = mainapp.getResources().getString(R.string.TtsGamepadTestFail);
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST_RESET:
+                        if ((prefTtsGamepadTestComplete)) {
+                            result = true;
+                            speech = mainapp.getResources().getString(R.string.TtsGamepadTestReset);
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_GAMEPAD_TEST_KEY_AND_PURPOSE:
+                        if (prefTtsGamepadTestKeys) {
+                            result = true;
+                            speech = argString;
+                        }
+                        break;
+                    case tts_msg_type.GAMEPAD_THROTTLE_SPEED:
+                        if ( (prefTtsThrottleSpeed.equals("Zero + Max")) || (prefTtsThrottleSpeed.equals("Zero + Max + speed")) ) {
+                            int maxSpd = argInt1; // getMaxSpeed(whichThrottle);
+                            int spd = argInt2;    // getSpeedFromCurrentSliderPosition(whichThrottle,false)
+                            int displaySpeedFromCurrentSliderPosition = argInt3;    // getSpeedFromCurrentSliderPosition(whichThrottle,true)
+
+                            if (spd == 0) {
+                                result = true;
+                                speech = mainapp.getResources().getString(R.string.TtsGamepadTestSpeedZero);
+                            } else if (spd == maxSpd) {
+                                result = true;
+                                speech = mainapp.getResources().getString(R.string.TtsGamepadTestSpeedMax);
+                                if ((prefTtsThrottleSpeed.equals("Zero + Max + speed"))) {
+                                    speech = speech + " " + displaySpeedFromCurrentSliderPosition;
+                                }
+                            }
+                        }
+                        break;
+                }
+
+                if (result) {
+//                    Time currentTime = new Time();
+//                    currentTime.setToNow();
+//                    if (((currentTime.toMillis(true) >= (lastTtsTime.toMillis(true) + 1500)) || (!speech.equals(lastTts)))) {
+
+                    // //don't repeat what was last spoken within 1.5 seconds
+                    if (((System.currentTimeMillis() >= (lastTtsTime + 1500)) || (!speech.equals(lastTts)))) {
+                        //myTts.speak(speech, TextToSpeech.QUEUE_FLUSH, null);
+                        myTts.speak(speech, TextToSpeech.QUEUE_ADD, null);
+//                        lastTtsTime = currentTime;
+                        lastTtsTime = System.currentTimeMillis();
+                    }
+                    lastTts = speech;
+                }
+            }
+        }
+    }
+
+}

--- a/EngineDriver/src/main/res/drawable/small_heading_style_colorful.xml
+++ b/EngineDriver/src/main/res/drawable/small_heading_style_colorful.xml
@@ -1,0 +1,10 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="@dimen/buttonCornerRadius_ultra" />
+    <stroke android:width="0px" android:color="@color/transparent" />
+    <gradient
+        android:startColor="@color/buttonFillGradiantDark_colorful"
+        android:endColor="@color/buttonFillGradiantLight_colorful"
+        android:type="linear"
+        />
+    <corners android:radius="2dp" />
+</shape>

--- a/EngineDriver/src/main/res/drawable/small_heading_style_ultra.xml
+++ b/EngineDriver/src/main/res/drawable/small_heading_style_ultra.xml
@@ -2,9 +2,13 @@
     <corners android:radius="@dimen/buttonCornerRadius_ultra" />
     <stroke android:width="0px" android:color="@color/black" />
     <gradient
-        android:startColor="@color/buttonCommonFillGradiantCenter_ultra"
-        android:endColor="@color/buttonCommonFillGradiantVeryLight_ultra"
+        android:centerX="60%"
+        android:startColor="@color/buttonCommonFillGradiantVeryLight_ultra"
+        android:centerColor="@color/buttonCommonFillGradiantLight_ultra"
+        android:endColor="@color/transparent"
         android:type="linear"
         />
     <corners android:radius="1dp" />
 </shape>
+
+<!--        android:endColor="@color/buttonCommonFillGradiantCenter_ultra"-->

--- a/EngineDriver/src/main/res/drawable/spinner_background.xml
+++ b/EngineDriver/src/main/res/drawable/spinner_background.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/spinner_background_original"/>
-    <stroke android:width="2px" android:color="@color/spinner_divider_original" />
+    <stroke android:width="1px" android:color="@color/spinner_divider_original" />
     <corners android:radius="@dimen/spinnerBackgroundCornerRadius_original" />
 </shape>

--- a/EngineDriver/src/main/res/drawable/spinner_background_ultra.xml
+++ b/EngineDriver/src/main/res/drawable/spinner_background_ultra.xml
@@ -1,5 +1,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/spinner_background_ultra"/>
-    <stroke android:width="2px" android:color="@color/spinner_divider_ultra" />
+    <stroke android:width="1px" android:color="@color/spinner_divider_ultra" />
     <corners android:radius="@dimen/spinnerBackgroundCornerRadius_original" />
 </shape>

--- a/EngineDriver/src/main/res/layout/function_settings.xml
+++ b/EngineDriver/src/main/res/layout/function_settings.xml
@@ -177,6 +177,7 @@
                         android:text="@string/fb_column_label"
                         android:textStyle="bold"
                         android:paddingLeft="4dp"
+                        android:layout_marginRight="6dp"
                         style="?android:attr/listSeparatorTextViewStyle"
                         tools:ignore="RtlSymmetry" />
 

--- a/EngineDriver/src/main/res/layout/gamepad_test.xml
+++ b/EngineDriver/src/main/res/layout/gamepad_test.xml
@@ -439,7 +439,8 @@
                 <Button
                     android:id="@+id/gamepad_test_button_skip"
                     style="?attr/ed_normal_button_style"
-                    android:layout_gravity="right"                    android:text="@string/gamepadTestSkip" />
+                    android:layout_gravity="right"                    android:text="@string/gamepadTestSkip"
+                    tools:ignore="RtlHardcoded" />
 <!--            </TableRow>-->
 
 <!--        </TableLayout>-->

--- a/EngineDriver/src/main/res/layout/routes.xml
+++ b/EngineDriver/src/main/res/layout/routes.xml
@@ -66,10 +66,14 @@
                         android:text="@string/set"
                         android:textAppearance="?android:attr/textAppearanceLarge" />
                 </LinearLayout>
+
                 <TextView
                     android:id="@+id/routes_location_label"
                     style="?android:attr/listSeparatorTextViewStyle"
-                    android:text="@string/routes_location_label" />
+                    android:text="@string/routes_location_label"
+                    android:paddingLeft="4dp"
+                    tools:ignore="RtlHardcoded,RtlSymmetry" />
+
                 <LinearLayout
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
@@ -88,7 +92,11 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    android:padding="4dp" >
+                    android:paddingRight="4dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:paddingLeft="0dp"
+                    tools:ignore="RtlHardcoded">
 
                     <TextView
                         android:id="@+id/routes_list_label"
@@ -98,6 +106,7 @@
                         android:layout_toLeftOf="@+id/routes_sort"
                         android:paddingLeft="4dp"
                         android:layout_marginRight="4dp"
+                        android:layout_marginLeft="0dp"
                         android:paddingTop="2dp"
                         android:text="@string/routes_list_label"
                         tools:ignore="RtlHardcoded,RtlSymmetry" />

--- a/EngineDriver/src/main/res/layout/toolbar.xml
+++ b/EngineDriver/src/main/res/layout/toolbar.xml
@@ -31,19 +31,6 @@
             android:orientation="horizontal"
             tools:ignore="RtlHardcoded">
 
-<!--            <TextView-->
-<!--                android:id="@+id/toolbar_icon_title"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_gravity="left"-->
-<!--                android:layout_marginStart="4dp"-->
-<!--                android:layout_marginLeft="4dp"-->
-<!--                android:text="Engine Driver"-->
-<!--                android:textColor="#fff"-->
-<!--                android:textSize="8sp"-->
-<!--                android:textStyle="italic"-->
-<!--                tools:ignore="HardcodedText,RtlHardcoded" />-->
-
             <ImageView
                 android:layout_width="32dp"
                 android:layout_height="32dp"

--- a/EngineDriver/src/main/res/layout/turnouts.xml
+++ b/EngineDriver/src/main/res/layout/turnouts.xml
@@ -176,7 +176,11 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    android:padding="4dp" >
+                    android:paddingRight="4dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:paddingLeft="0dp"
+                    tools:ignore="RtlHardcoded">
 
                     <TextView
                         android:id="@+id/turnouts_list_label"

--- a/EngineDriver/src/main/res/layout/withrottle_cv_programmer.xml
+++ b/EngineDriver/src/main/res/layout/withrottle_cv_programmer.xml
@@ -355,7 +355,7 @@
                     android:layout_alignParentEnd="true"
                     android:layout_alignParentRight="true"
                     android:text="@string/logviewerClose"
-                    tools:ignore="RtlHardcoded" />
+                    tools:ignore="RelativeOverlap,RtlHardcoded" />
 
             </RelativeLayout>
 

--- a/EngineDriver/src/main/res/menu/connection_menu.xml
+++ b/EngineDriver/src/main/res/menu/connection_menu.xml
@@ -10,8 +10,15 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" tools:ignore="AppCompatResource" >
+<menu  xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <item android:id="@+id/flashlight_button"
+        android:title="@string/flashlightAction"
+        android:visible="false"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction"  />
 
     <item android:id="@+id/intro_mnu" android:title="@string/introMenu" />
     <item android:id="@+id/settings_mnu" android:title="@string/preferences" />
@@ -19,7 +26,4 @@
     <item android:id="@+id/logviewer_menu" android:title="@string/logViewer" />
     <item android:id="@+id/exit_mnu" android:title="@string/exit" />
     <item android:id="@+id/about_mnu" android:title="@string/about" />
-    <item android:id="@+id/flashlight_button"
-        android:title="@string/flashlightAction" android:visible="false"
-        android:showAsAction="always" />
 </menu>

--- a/EngineDriver/src/main/res/menu/routes_menu.xml
+++ b/EngineDriver/src/main/res/menu/routes_menu.xml
@@ -30,6 +30,12 @@
         android:title="@string/PowerButtonBar"
         android:visible="false"
         app:showAsAction="always" />
+    <item android:id="@+id/dcc_ex_button"
+        android:icon="?attr/ed_dcc_ex_button"
+        android:title="@string/app_name_dcc_ex"
+        android:visible="false"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
 
     <item android:id="@+id/throttle_mnu" android:title="@string/throttle" />
     <item android:id="@+id/turnouts_mnu" android:title="@string/turnouts" />

--- a/EngineDriver/src/main/res/menu/turnouts_menu.xml
+++ b/EngineDriver/src/main/res/menu/turnouts_menu.xml
@@ -35,6 +35,13 @@
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" />
 
+    <item android:id="@+id/dcc_ex_button"
+        android:icon="?attr/ed_dcc_ex_button"
+        android:title="@string/app_name_dcc_ex"
+        android:visible="false"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
     <item android:id="@+id/throttle_mnu" android:title="@string/throttle" />
     <item android:id="@+id/routes_mnu" android:title="@string/routes" />
     <item android:id="@+id/web_mnu" android:title="@string/web" />

--- a/EngineDriver/src/main/res/values/dimen.xml
+++ b/EngineDriver/src/main/res/values/dimen.xml
@@ -24,7 +24,7 @@
     <dimen name="buttonStopStroke_original">2dip</dimen>
     <dimen name="buttonStopCornerRadius_original">5dip</dimen>
 
-    <dimen name="spinnerBackgroundCornerRadius_original">2dp</dimen>
+    <dimen name="spinnerBackgroundCornerRadius_original">3dp</dimen>
 
     <!-- Black theme -->
 
@@ -44,7 +44,7 @@
     <dimen name="buttonStopStroke_black">2dip</dimen>
     <dimen name="buttonStopCornerRadius_black">5dip</dimen>
 
-    <dimen name="spinnerBackgroundCornerRadius_black">2dp</dimen>
+    <dimen name="spinnerBackgroundCornerRadius_black">3dp</dimen>
 
     <!-- Outline theme -->
 
@@ -71,7 +71,7 @@
     <dimen name="buttonStopStroke_outline">1dip</dimen>
     <dimen name="buttonStopCornerRadius_outline">5dip</dimen>
 
-    <dimen name="spinnerBackgroundCornerRadius_outline">2dp</dimen>
+    <dimen name="spinnerBackgroundCornerRadius_outline">3dp</dimen>
 
     <!-- Ultra Black theme -->
 
@@ -98,7 +98,7 @@
     <dimen name="buttonStopStroke_ultra">1dp</dimen>
     <dimen name="buttonStopCornerRadius_ultra">2dp</dimen>
 
-    <dimen name="spinnerBackgroundCornerRadius_ultra">2dp</dimen>
+    <dimen name="spinnerBackgroundCornerRadius_ultra">3dp</dimen>
 
     <!-- Colorful theme -->
 
@@ -125,6 +125,6 @@
     <dimen name="buttonStopStroke_colorful">1dp</dimen>
     <dimen name="buttonStopCornerRadius_colorful">8dp</dimen>
 
-    <dimen name="spinnerBackgroundCornerRadius_colorful">2dp</dimen>
+    <dimen name="spinnerBackgroundCornerRadius_colorful">3dp</dimen>
 
 </resources>

--- a/EngineDriver/src/main/res/values/styles.xml
+++ b/EngineDriver/src/main/res/values/styles.xml
@@ -15,7 +15,7 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -286,7 +286,10 @@
   </style>
 
   <style name="ActionBarPopup" parent="Widget.AppCompat.PopupMenu">
-    <item name="android:background">@color/spinner_background_original</item>
+    <item name="android:itemBackground">@android:color/transparent</item>
+    <item name="android:actionBarItemBackground">@drawable/spinner_background</item>
+    <item name="android:background">@android:color/transparent</item>
+    <item name="android:popupBackground">@android:color/transparent</item>
   </style>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -389,7 +392,10 @@
   </style>
 
   <style name="ActionBarPopup_black" parent="Widget.AppCompat.PopupMenu">
-    <item name="android:background">@color/spinner_background_ultra</item>
+    <item name="android:itemBackground">@android:color/transparent</item>
+    <item name="android:actionBarItemBackground">@drawable/spinner_background_ultra</item>
+    <item name="android:background">@android:color/transparent</item>
+    <item name="android:popupBackground">@android:color/transparent</item>
   </style>
 
   <style name="windowTitleBackground_black">
@@ -742,7 +748,10 @@
   </style>
 
   <style name="ActionBarPopup_outline" parent="Widget.AppCompat.PopupMenu">
-    <item name="android:background">@color/spinner_background_ultra</item>
+    <item name="android:itemBackground">@android:color/transparent</item>
+    <item name="android:actionBarItemBackground">@drawable/spinner_background_ultra</item>
+    <item name="android:background">@android:color/transparent</item>
+    <item name="android:popupBackground">@android:color/transparent</item>
   </style>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -756,10 +765,10 @@
     <item name="android:background">@drawable/small_heading_style_ultra</item>
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:shadowColor">#00000000</item>
-    <item name="android:shadowDx">0</item>
-    <item name="android:shadowDy">0</item>
-    <item name="android:shadowRadius">0</item>
+    <item name="android:shadowColor">@color/black</item>
+    <item name="android:shadowDx">1</item>
+    <item name="android:shadowDy">1</item>
+    <item name="android:shadowRadius">3</item>
     <item name="android:padding">2dp</item>
   </style>
 
@@ -903,7 +912,10 @@
   </style>
 
   <style name="ActionBarPopup_ultra" parent="Widget.AppCompat.PopupMenu">
-    <item name="android:background">@color/spinner_background_ultra</item>
+    <item name="android:itemBackground">@android:color/transparent</item>
+    <item name="android:actionBarItemBackground">@drawable/spinner_background_ultra</item>
+    <item name="android:background">@android:color/transparent</item>
+    <item name="android:popupBackground">@android:color/transparent</item>
   </style>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -941,7 +953,8 @@
 
   <style name="small_heading_style_colorful" parent="@android:style/Widget.TextView">
     <item name="android:textColor">@color/primary_colorful</item>
-    <item name="android:background">@color/heading_colorful</item>
+<!--    <item name="android:background">@color/heading_colorful</item>-->
+    <item name="android:background">@drawable/small_heading_style_colorful</item>
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:shadowColor">@color/shadow_colorful</item>
@@ -1225,12 +1238,21 @@
   <style name="OverflowMenuButton_colorful" parent="Widget.AppCompat.ActionButton.Overflow">
     <item name="android:tint">@color/solidWhite</item>
   </style>
-  <style name="OverflowMenu_colorful" parent="Widget.AppCompat.PopupMenu.Overflow">
-    <item name="android:popupBackground">@color/windowBackground_colorful</item>
-  </style>
+<!--  <style name="OverflowMenu_colorful" parent="Widget.AppCompat.PopupMenu.Overflow">-->
+<!--    <item name="android:popupBackground">@color/windowBackground_colorful</item>-->
+<!--  </style>-->
   <style name="ActionBarPopup_colorful" parent="Widget.AppCompat.PopupMenu">
-<!--    <item name="android:background">@drawable/spinner_background_colorful</item>-->
-    <item name="android:background">@color/spinner_background_colorful</item>
+    <item name="android:itemBackground">@android:color/transparent</item>
+    <item name="android:actionBarItemBackground">@drawable/spinner_background_colorful</item>
+    <item name="android:background">@android:color/transparent</item>
+    <item name="android:popupBackground">@android:color/transparent</item>
+  </style>
+
+  <style name="ActionBarPopup_colorful.MenuTextStyle">
+    <item name="android:textColor">@color/solidWhite</item>
+    <item name="android:textStyle">bold</item>
+    <item name="android:actionMenuTextColor">@color/solidWhite</item>
+    <item name="actionMenuTextColor">@color/solidWhite</item>
   </style>
   <style name="ItemTextAppearance_colorful">
     <item name="android:textColor">@color/primary_colorful</item>

--- a/EngineDriver/src/main/res/values/themes.xml
+++ b/EngineDriver/src/main/res/values/themes.xml
@@ -398,7 +398,7 @@
         <item name="android:itemBackground">@color/transparent</item>
 
         <item name="actionOverflowButtonStyle">@style/OverflowMenuButton_colorful</item>
-        <item name="actionOverflowMenuStyle">@style/OverflowMenu_colorful</item>
+<!--        <item name="actionOverflowMenuStyle">@style/OverflowMenu_colorful</item>-->
         <item name="android:itemTextAppearance">@style/ItemTextAppearance_colorful</item>
 
         <!--        <item name="android:textColor">@color/solidBlack</item> -->

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -19,6 +19,7 @@
  - split the TTS code and types into their own classes
  - Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
  - General cleanup and linting of the dcc_ex code
+ - Improve maintaining of unique IDs for devices (needed for WitThrottle) as a byproduct of not beong allowed to access the real Device IDs anymore
 **Version 2.37.182
  * Add intro/setup wizard page for DCC-EX
  * New WiThrottle CV PoM page

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -16,6 +16,9 @@
  * Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
  * General cleanup and linting of the dcc_ex code
  * Visual improvements to the 'about' message on the About screen and log
+ - split the TTS code and types into their own classes
+ - Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
+ - General cleanup and linting of the dcc_ex code
 **Version 2.37.182
  * Add intro/setup wizard page for DCC-EX
  * New WiThrottle CV PoM page

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -11,7 +11,10 @@
  * New button to download the roster list to the Recents list
  * Selecting a loco from Recent Loco that was originally selected from a roster will now attempt to reload the original function buttons, regardless to the server. Note with WiThrottle it cannot know the latching characteristics
  * UI and performance improvements to the Consist Functions Edit screen
- * general cleanup and linting of the select_loco code
+ * General cleanup and linting of the select_loco code
+ * Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
+ * General cleanup and linting of the dcc_ex code
+ * Visual improvements to the 'about' message on the About screen and log
 **Version 2.37.182
  * Add intro/setup wizard page for DCC-EX
  * New WiThrottle CV PoM page


### PR DESCRIPTION
- Force getting a new ID when the intro is run (which is also run on a reset)
- Save the current ID and restore it when import the preferences 
- up the limit for the deviceID to 999999

- split the TTS code and types into their own classes
- Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
- General cleanup and linting of the dcc_ex code
- Visual improvements to the 'about' message on the About screen and log