### PR TITLE
deal with longInt being sent by the devel versions of DCC-EX

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="186"
-    android:versionName="2.37.186" android:installLocation="auto">
+    android:versionName="2.37.186e" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />

--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="186"
-    android:versionName="2.37.186e" android:installLocation="auto">
+    android:versionName="2.37.186" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -1583,7 +1583,8 @@ public class comm_thread extends Thread {
                         int fnState;
                         for (int i = 0; i < threaded_application.MAX_FUNCTIONS; i++) {
                             try {
-                                fnState = mainapp.bitExtracted(Integer.parseInt(args[4]), 1, i + 1);
+//                                fnState = mainapp.bitExtracted(Integer.parseInt(args[4]), 1, i + 1);
+                                fnState = mainapp.bitExtracted(Long.parseLong(args[4]), 1, i + 1);
                                 if (i==0) Log.d("Engine_Driver", "processDccexLocos(): function:" + i + " state: " + fnState);
                                 processFunctionState(whichThrottle, i, (fnState != 0));
                                 responseStr = "M" + mainapp.throttleIntToString(whichThrottle) + "A" + addr_str + "<;>F" + fnState + (i);

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2926,9 +2926,13 @@ public class threaded_application extends Application {
 
     // Function to extract k bits from p position and returns the extracted value as integer
     // from: https://www.geeksforgeeks.org/extract-k-bits-given-position-number/
-    public int bitExtracted(int number, int k, int p)
-    {
+    public int bitExtracted(int number, int k, int p) {
         return (((1 << k) - 1) & (number >> (p - 1)));
+    }
+    public int bitExtracted(long number, int k, int p) {
+        final long rightShifted = number >>> p;
+        final long mask = (1L << k) - 1L;
+        return Math.toIntExact(rightShifted & mask);
     }
 
     public int toggleBit(int n, int k) {

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2930,7 +2930,7 @@ public class threaded_application extends Application {
         return (((1 << k) - 1) & (number >> (p - 1)));
     }
     public int bitExtracted(long number, int k, int p) {
-        final long rightShifted = number >>> p;
+        final long rightShifted = number >>> (p-1);
         final long mask = (1L << k) - 1L;
         return Math.toIntExact(rightShifted & mask);
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -6409,11 +6409,19 @@ protected class SelectFunctionButtonTouchListener implements View.OnClickListene
                                 String bt = function_labels_temp.get(func);
                                 functionButtonTouchListener = new FunctionButtonTouchListener(func, whichThrottle, bt);
                                 b.setOnTouchListener(functionButtonTouchListener);
-                                bt = (bt + "                      ").trim();  // pad with spaces, and limit to 20 characters
+//                                bt = (bt + "                      ").trim();  // pad with spaces, and limit to 20 characters
                                 b.setText(bt);
                                 b.setVisibility(View.VISIBLE);
                                 // if there is a long first word or the total length is long, reduce the font size
-                                if ((bt.indexOf(" ")>8) || (bt.length()>16)) b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+                                if ((bt.indexOf(" ")>8) || (bt.length()>16)) {
+                                    b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+                                    if ((bt.indexOf(" ")>10) || (bt.length()>20)) {
+                                        b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
+                                        if ((bt.indexOf(" ")>12) || (bt.length()>24)) {
+                                            b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
+                                        }
+                                    }
+                                }
                                 b.setEnabled(false); // start out with everything disabled
                             } else {
                                 b.setVisibility(View.GONE);

--- a/EngineDriver/src/main/res/values/colors.xml
+++ b/EngineDriver/src/main/res/values/colors.xml
@@ -31,7 +31,7 @@
 
     <color name="primary_text">#ffffffff</color>
     <color name="secondary_text">#D8D8D8</color>
-    <color name="tertiary_text">#ffffffff</color>
+    <color name="tertiary_text">#A0A0A0</color>
     <color name="hint_text">#747474</color>
     <color name="primaryDisabled">#ff888888</color>
     <color name="secondaryDisabled">#ff888888</color>


### PR DESCRIPTION

- automatically reduce the font size of buttons if the first word is long or the total text length is long
- more code cleanup
- up the limit for the deviceID to 999999
- Force getting a new ID when the intro is run (which is also run on a reset)
- Save the current ID and restore it when import the preferences
- split the TTS code and types into their own classes
- Added the DCC-EX toolbar button the the Routes and Turnouts/Points screens
- General cleanup and linting of the dcc_ex code
- Visual improvements to the 'about' message on the About screen and log