### PR TITLE
If the loco does not come from the roster, it now saves the default Function labels against the loco in the recents list.

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -2380,7 +2380,12 @@ public class threaded_application extends Application {
             locoSource = source_type.ROSTER;
         }
         String keepFunctions = "";
-        String functionLabels = mainapp.packFunctionLabels(functionLabelsMap);
+        String functionLabels;
+        if (locoSource == source_type.ROSTER) {
+            functionLabels = mainapp.packFunctionLabels(functionLabelsMap);
+        } else {
+            functionLabels = mainapp.packFunctionLabels(mainapp.function_labels_default);
+        }
         for (int i = 0; i < importExportPreferences.recent_loco_address_list.size(); i++) {
             if (locoAddress.equals(importExportPreferences.recent_loco_address_list.get(i))
                     && address_size.equals(importExportPreferences.recent_loco_address_size_list.get(i))
@@ -2402,7 +2407,7 @@ public class threaded_application extends Application {
         importExportPreferences.recent_loco_name_list.add(0, loco_name);
         importExportPreferences.recent_loco_source_list.add(0, locoSource);
         if (functionLabels.length()>0) {
-            keepFunctions =functionLabels;
+            keepFunctions = functionLabels;
         }
         importExportPreferences.recent_loco_functions_list.add(0, keepFunctions);  // restore from the previous value
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -6421,11 +6421,13 @@ protected class SelectFunctionButtonTouchListener implements View.OnClickListene
                                             b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
                                             if (((bt + " ").indexOf(" ")>14) || (bt.length()>24)) {
                                                 b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
+                                                b.setMaxLines(3);
                                             }
                                         }
                                     }
                                 } else {
                                     b.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
+                                    b.setMaxLines(2);
                                 }
                                 b.setEnabled(false); // start out with everything disabled
                             } else {

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -827,7 +827,6 @@
  *   TODO: respect "Max Throttle %" from roster entry
  *   TODO: option to show the turnout view instead of the webview, including option for Recents
  *   TODO: option to use 'f' function commands for WiThrottle
- *   TODO: option to save and re-request selected locos, (6-throttle layout with the same locos)
  *   TODO: option/button to support DPU "unfenced" mode, relatively adjusting 2nd throttle from first
  *   TODO: retrieve and show icons for function buttons (if set)
  *   TODO: if nS is lead of ED consist, MT-nS loses track of "other" loco (test with a "partial steal")
@@ -853,10 +852,13 @@
  *   TODO: edit/save/auto-restore 'local' function definitions for individual locos
  *   TODO: allow downloading of filtered roster list
  *   TODO: download the images when you download the full roster
- *   TODO: add preference for automatically loading locos on connection into multiple throttles
+ *   TODO: a) option to save and re-request selected locos, (6-throttle layout with the same locos)
+ *   TODO: b) add preference for automatically loading locos on connection into multiple throttles
  * consist edit:
  *   TODO: add swipe action or other action to change the lights and remove the Consist Lights edit page entirely
  *   TODO: let user explicitly choose the loco to pull function labels from
+ * DCC-EX screen
+ *   TODO: the number of tracks/outputs is not refreshed when the app is closed, opened again, and connected to a CS that has a different number of outputs
  * preferences:
  *   TODO: simplify accessing exported preferences file. Link?
  * log_viewer:


### PR DESCRIPTION

By product of this is that you can sort-of edit the labels of the non-roster recent locos