### PR TITLE
Various fixes and changes

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="188"
-    android:versionName="2.38.188" android:installLocation="auto">
+    android:versionName="2.38.188ad" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
@@ -167,7 +167,7 @@
         <activity
             android:name=".turnouts"
             android:alwaysRetainTaskState="true"
-            android:label="@string/app_name_turnouts_long"
+            android:label="@string/app_name_turnouts"
             android:launchMode="singleTop"
             android:configChanges="orientation|screenSize"
             android:theme="@style/app_theme_black" >

--- a/EngineDriver/src/main/assets/about_page-cs.html
+++ b/EngineDriver/src/main/assets/about_page-cs.html
@@ -38,7 +38,7 @@
     na <a href="http://www.modelrectifier.com/category-s/332.htm" target="_blank">MRC Prodigy WiFi</a>,
     nebo na a <a href="http://www.digitrax.com/products/wireless/lnwi/" target="_blank">Digitrax LnWi</a>,
     a &#345;&iacute;dit va&scaron;e lokomotivy a cel&eacute; koleji&scaron;t&#283;.
-    Rychlost, sm&#283;r a a&#382; 29 DCC funkc&iacute; je podporov&aacute;no pro jednu a&#382; &scaron;est lokomotiv nebo souprav.
+    Rychlost, sm&#283;r a a&#382; 32 DCC funkc&iacute; je podporov&aacute;no pro jednu a&#382; &scaron;est lokomotiv nebo souprav.
     M&#367;&#382;ete ovl&aacute;dat nap&aacute;jen&iacute; koleji&scaron;t&#283;, v&yacute;hybky a cesty, zobrazovat panely a dal&scaron;&iacute; JMRI okna s pou&#382;it&iacute;m
     zobrazen&iacute; webu.
     M&#367;&#382;ete tak&eacute; vytv&aacute;&#345;et a upravovat soupravy (softwarov&#283; definovan&eacute;).

--- a/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
+++ b/EngineDriver/src/main/assets/about_page-de-rAT-CH-LI.html
@@ -38,7 +38,7 @@
     mit einem <a href="http://www.modelrectifier.com/category-s/332.htm" target="_blank">MRC Prodigy WiFi</a>,
     oder mit einem <a href="http://www.digitrax.com/products/wireless/lnwi/" target="_blank">Digitrax LnWi</a>,
     und ermöglicht darüber die Steuerung von Lokomotiven und der gesamten Modelleisenbahn. Für eine bis sechs
-    Lokomotiven oder Lokverbünde werden Geschwindigkeit, Fahrrichtung und bis zu 29 DCC Funktionen unterstützt.
+    Lokomotiven oder Lokverbünde werden Geschwindigkeit, Fahrrichtung und bis zu 32 DCC Funktionen unterstützt.
     Zudem können der Anlagenstrom, Weichen und Fahrstrassen, sowie unter Verwendung der Webansicht auch
     Anzeigetafeln und andere JMRI Fenster gesteuert werden. Lokverbünde können erstellt und bearbeitet
     werden (Software-definiert).</p>

--- a/EngineDriver/src/main/assets/about_page-de.html
+++ b/EngineDriver/src/main/assets/about_page-de.html
@@ -38,7 +38,7 @@
     mit einem <a href="http://www.modelrectifier.com/category-s/332.htm" target="_blank">MRC Prodigy WiFi</a>,
     oder mit einem <a href="http://www.digitrax.com/products/wireless/lnwi/" target="_blank">Digitrax LnWi</a>,
     und ermöglicht darüber die Steuerung von Lokomotiven und der gesamten Modelleisenbahn. Für eine bis sechs
-    Lokomotiven oder Lokverbünde werden Geschwindigkeit, Fahrrichtung und bis zu 29 DCC Funktionen unterstützt.
+    Lokomotiven oder Lokverbünde werden Geschwindigkeit, Fahrrichtung und bis zu 32 DCC Funktionen unterstützt.
     Zudem können der Anlagenstrom, Weichen und Fahrstraßen, sowie unter Verwendung der Webansicht auch
     Anzeigetafeln und andere JMRI Fenster gesteuert werden. Lokverbünde können erstellt und bearbeitet
     werden (Software-definiert).</p>

--- a/EngineDriver/src/main/assets/about_page-es.html
+++ b/EngineDriver/src/main/assets/about_page-es.html
@@ -38,7 +38,7 @@
     al <a href="http://www.modelrectifier.com/category-s/332.htm" target="_blank">MRC Prodigy WiFi</a>,
     o al <a href="http://www.digitrax.com/products/wireless/lnwi/" target="_blank">Digitrax LnWi</a>,
     y coger el control de tus locomotoras y todo tu modelo de ferrocarril. Velocidad, dirección,
-    y hasta 29 funciones DCC estan soportadas para una o seis locomotoras o tracciones múltiples.
+    y hasta 32 funciones DCC estan soportadas para una o seis locomotoras o tracciones múltiples.
     Puedes controlar la energía del circuito, desvíos y rutas, y mostrar paneles y otras ventanas
     del JMRI usando las vistas web. También puedes crear y editar tracciones múltiples (definidas por software).</p>
 <p>Para mas detalles, visite <a href="https://enginedriver.mstevetodd.com" target="_blank">[la página de EngineDriver]</a>.

--- a/EngineDriver/src/main/assets/about_page-fr.html
+++ b/EngineDriver/src/main/assets/about_page-fr.html
@@ -37,7 +37,7 @@
             target="_blank">WiThrottle JMRI</a> tournant sur un ordinateur, à une station
     <a href="http://www.modelrectifier.com/category-s/332.htm" target="_blank">MRC Prodigy WiFI</a>, ou à un
     <a href="http://www.digitrax.com/products/wireless/lnwi/" target="_blank">Digitrax LnWi</a>. En retour elle
-    contrôle vos locomotives et l'ensemble de votre réseau. Vitesse, direction et jusqu a 29 fonctions DCC sont
+    contrôle vos locomotives et l'ensemble de votre réseau. Vitesse, direction et jusqu a 32 fonctions DCC sont
     supportées, avec d'une à 6 locomotives ou UM (unité multiple) par commande. Vous pouvez controler l
     alimentation, les aiguilles, les itinéraires, et afficher les panels et autres fenêtres JMRI via les vues Web.
     Vous pouvez aussi créer et éditer des UM locales depuis cette application.</p>

--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -29,7 +29,10 @@
     <li>New Semi-Realistic Throttle screen layout</li>
     <li>Added abiltiy to override the WiThrottle default Latching</li>
     <li>Additional Google translations</li>
+    <li>French Canadian translations by Yvéric Patry</li>
     <li>Support for new gamepad type - Auvisio Android-B</li>
+    <li>Return missing label on the Select Button</li>
+    <li>Improvement to the roster sorting options</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"
@@ -47,7 +50,7 @@
         NCE)</a> and <a
             href="https://myiott.org/index.php/iott-stick/communication-modules/whthrottle-server"
             target="_blank">IoTT&nbsp;Stick</a>. Once connected, you can control your locomotives
-    and your entire model railroad. Speed, direction, and up to 29 DCC functions are supported for
+    and your entire model railroad. Speed, direction, and up to 32 DCC functions are supported for
     one to six locomotives or consists. You can create and edit consists (software-defined). You can
     also control layout power, turnouts, routes, and access <a
             href="http://jmri.org/help/en/html/web/">JMRI web</a> panels and windows.</p>

--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -1351,6 +1351,9 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                         parentActivity.mainapp.prefAlwaysUseFunctionsFromServer = sharedPreferences.getBoolean("prefAlwaysUseFunctionsFromServer",
                                 getResources().getBoolean(R.bool.prefAlwaysUseFunctionsFromServerDefaultValue));
                         break;
+                    case "prefSortOrderRoster":
+                        parentActivity.mainapp.getDefaultSortOrderRoster();
+                        break;
 
                 }
             }

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
@@ -287,6 +287,16 @@ public class comm_handler extends Handler {
             break;
          }
 
+         case message_type.DCCEX_JOIN_TRACKS: { // DCC-EX only
+            comm_thread.joinTracks();
+            break;
+         }
+
+         case message_type.DCCEX_UNJOIN_TRACKS: { // DCC-EX only
+            comm_thread.joinTracks(false);
+            break;
+         }
+
          case message_type.WRITE_TRACK_POWER: { // DCC-EX only
             String [] args = msg.obj.toString().split(" ");
             comm_thread.sendTrackPower(args[0], msg.arg1);

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -652,6 +652,18 @@ public class comm_thread extends Thread {
         }
     }
 
+    protected static void joinTracks() {
+        joinTracks(true);
+    }
+    protected static void joinTracks(boolean join) {
+        if (join) {
+            wifiSend("<1 JOIN>");
+        } else {
+            wifiSend("<0 PROG>");
+            wifiSend("<1 PROG>");
+        }
+    }
+
     protected void sendTurnout(String cmd) {
 //        Log.d("Engine_Driver", "comm_thread.sendTurnout: cmd=" + cmd);
         char action = cmd.charAt(0); //first char is action (C=close,T=throw,2=toggle)

--- a/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
@@ -45,7 +45,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
+//import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -118,13 +118,14 @@ public class dcc_ex extends AppCompatActivity {
     Button previousCommandButton;
     Button nextCommandButton;
     Button writeTracksButton;
+    Button joinTracksButton;
     //    Button hideSendsButton;
     Button clearCommandsButton;
 
     private LinearLayout dexcProgrammingCommonCvsLayout;
     private LinearLayout dexcProgrammingAddressLayout;
     private LinearLayout dexcProgrammingCvLayout;
-    private final LinearLayout[] dexcDccexTracklayout = {null, null, null, null, null, null, null, null};
+//    private final LinearLayout[] dexcDccexTracklayout = {null, null, null, null, null, null, null, null};
     private LinearLayout dexcDccexTrackLinearLayout;
     Spinner dccexCommonCvsSpinner;
     Spinner dccexCommonCommandsSpinner;
@@ -448,7 +449,7 @@ public class dcc_ex extends AppCompatActivity {
 
                     if (TRACK_TYPES_SELECTABLE[typeIndex]) {
                         if (!TRACK_TYPES_NEED_ID[typeIndex]) {
-                            if (type=="AUTO") { // needs to be set to main first if AUTO is selected
+                            if (type.equals("AUTO")) { // needs to be set to main first if AUTO is selected
                                 mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_TRACK, trackLetter + " MAIN", 0);
                             }
                             mainapp.sendMsg(mainapp.comm_msg_handler, message_type.WRITE_TRACK, trackLetter + " " + type, 0);
@@ -481,6 +482,23 @@ public class dcc_ex extends AppCompatActivity {
             dccexSendsStr = "";
             refreshDccexView();
         }
+    }
+
+    public class JoinTracksButtonListener implements View.OnClickListener {
+        public void onClick(View v) {
+            if (!mainapp.dccexJoined) {
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DCCEX_JOIN_TRACKS, "");
+                activateJoinedButton(true);
+            } else {
+                mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DCCEX_UNJOIN_TRACKS, "");
+                activateJoinedButton(false);
+            }
+        }
+    }
+
+    void activateJoinedButton(boolean joined) {
+        mainapp.dccexJoined = joined;
+        joinTracksButton.setSelected(joined);
     }
 
 //    public class hide_sends_button_listener implements View.OnClickListener {
@@ -945,8 +963,12 @@ public class dcc_ex extends AppCompatActivity {
         WriteTracksButtonListener writeTracksButtonListener = new WriteTracksButtonListener();
         writeTracksButton.setOnClickListener(writeTracksButtonListener);
 
-        ScrollView dccexResponsesScrollView = findViewById(R.id.dexc_DccexResponsesScrollView);
-        ScrollView dccexSendsScrollView = findViewById(R.id.dexc_DccexSendsScrollView);
+        joinTracksButton = findViewById(R.id.dexc_DccexJoinTracksButton);
+        JoinTracksButtonListener joinTracksButtonListener = new JoinTracksButtonListener();
+        joinTracksButton.setOnClickListener(joinTracksButtonListener);
+
+//        ScrollView dccexResponsesScrollView = findViewById(R.id.dexc_DccexResponsesScrollView);
+//        ScrollView dccexSendsScrollView = findViewById(R.id.dexc_DccexSendsScrollView);
 
         clearCommandsButton = findViewById(R.id.dexc_DCCEXclearCommandsButton);
         ClearCommandsButtonListener clearCommandsButtonListener = new ClearCommandsButtonListener();
@@ -983,6 +1005,7 @@ public class dcc_ex extends AppCompatActivity {
             return;
         }
         mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
+        activateJoinedButton(mainapp.dccexJoined);
 
         if (menu != null) {
             mainapp.displayEStop(menu);

--- a/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
@@ -41,6 +41,7 @@ import java.util.List;
 import jmri.enginedriver.R;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.threaded_application;
+import jmri.enginedriver.util.LocaleHelper;
 import jmri.enginedriver.util.PermissionsHelper;
 import jmri.enginedriver.util.PermissionsHelper.RequestCodes;
 
@@ -111,7 +112,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 
         LinearLayout screenNameLine = findViewById(R.id.screen_name_line);
         Toolbar toolbar = findViewById(R.id.toolbar);
-        LinearLayout statusLine = (LinearLayout) findViewById(R.id.status_line);
+        LinearLayout statusLine = findViewById(R.id.status_line);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
             getSupportActionBar().setDisplayShowTitleEnabled(false);
@@ -127,6 +128,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
         }
 
         Log.d("Engine_Driver", mainapp.getAboutInfo());
+        Log.d("Engine_Driver", mainapp.getAboutInfo(false));
 
     } // end onCreate
 
@@ -194,6 +196,11 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
         super.onDestroy();
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(LocaleHelper.onAttach(base));
+    }
+
     public class close_button_listener implements View.OnClickListener {
         public void onClick(View v) {
             mainapp.buttonVibration();
@@ -246,12 +253,13 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 
         try {
             Process process = Runtime.getRuntime().exec("logcat -c");
-            process = Runtime.getRuntime().exec("logcat -f " + logFile);
+            Runtime.getRuntime().exec("logcat -f " + logFile);
             Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastSaveLogFile, logFile.toString()), Toast.LENGTH_LONG).show();
             mainapp.logSaveFilename = logFile.toString();
             showHideSaveButton();
             Log.d("Engine_Driver", "Logging started to: " + logFile);
             Log.d("Engine_Driver", mainapp.getAboutInfo());
+            Log.d("Engine_Driver", mainapp.getAboutInfo(false));
         } catch ( IOException e ) {
             e.printStackTrace();
         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -217,6 +217,8 @@ public class select_loco extends AppCompatActivity {
                 Log.w("Engine_Driver", "select_loco: refreshRosterList(): xml roster not available");
             }
 
+            int position = -1;
+
             //put roster entries into screen list
             if (mainapp.roster_entries != null) {
                 ArrayList<String> rns = new ArrayList<>(mainapp.roster_entries.keySet());  //copy from synchronized map to avoid holding it while iterating
@@ -242,6 +244,9 @@ public class select_loco extends AppCompatActivity {
                         }
                     }
                     hm.put("roster_owner", owner);
+                    position++;
+                    hm.put("roster_position", String.format("%04d",position));
+
 
                     boolean includeInList = false;
                     if ((prefRosterFilter.isEmpty()) && (rosterOwnersFilterIndex==0) ) {
@@ -292,6 +297,8 @@ public class select_loco extends AppCompatActivity {
                     hm.put("roster_address", consist_addr);
                     hm.put("roster_entry_type", "consist");
                     hm.put("roster_owner", "");
+                    position++;
+                    hm.put("roster_position", String.format("%04d",position));
 
                     // add temp hashmap to list which view is hooked to
                     rosterList.add(hm);
@@ -305,12 +312,20 @@ public class select_loco extends AppCompatActivity {
                     int rslt;
                     String s0;
                     String s1;
-                    if (mainapp.rosterOrder == sort_type.NAME) {
-                        s0 = arg0.get("roster_name").replaceAll("_", " ").toLowerCase();
-                        s1 = arg1.get("roster_name").replaceAll("_", " ").toLowerCase();
-                    } else {
-                        s0 = threaded_application.formatNumberInName(arg0.get("roster_address"));
-                        s1 = threaded_application.formatNumberInName(arg1.get("roster_address"));
+                    switch (mainapp.rosterOrder) {
+                        case sort_type.NAME:
+                        default:
+                            s0 = arg0.get("roster_name").replaceAll("_", " ").toLowerCase();
+                            s1 = arg1.get("roster_name").replaceAll("_", " ").toLowerCase();
+                            break;
+                        case sort_type.ID:
+                            s0 = threaded_application.formatNumberInName(arg0.get("roster_address"));
+                            s1 = threaded_application.formatNumberInName(arg1.get("roster_address"));
+                            break;
+                        case sort_type.POSITION:
+                            s0 = threaded_application.formatNumberInName(arg0.get("roster_position"));
+                            s1 = threaded_application.formatNumberInName(arg1.get("roster_position"));
+                            break;
                     }
                     rslt = s0.compareTo(s1);
                     return rslt;
@@ -1168,10 +1183,16 @@ public class select_loco extends AppCompatActivity {
         SortRosterButtonListener() {}
 
         public void onClick(View v) {
-            if (mainapp.rosterOrder==sort_type.NAME) {
-                mainapp.rosterOrder=sort_type.ID;
-            } else {
-                mainapp.rosterOrder=sort_type.NAME;
+            switch (mainapp.rosterOrder) {
+                case sort_type.NAME:
+                    mainapp.rosterOrder = sort_type.ID;
+                    break;
+                case sort_type.ID:
+                    mainapp.rosterOrder = sort_type.POSITION;
+                    break;
+                case sort_type.POSITION:
+                default:
+                    mainapp.rosterOrder = sort_type.NAME;
             }
             refreshRosterList();
             mainapp.toastSortType(mainapp.rosterOrder);
@@ -1484,7 +1505,7 @@ public class select_loco extends AppCompatActivity {
         // put pointer to this activity's handler in main app's shared variable
         mainapp.select_loco_msg_handler = new SelectLocoHandler(Looper.getMainLooper());
 
-        getDefaultSortOrderRoster();
+//        getDefaultSortOrderRoster();
         prefRosterFilter = prefs.getString("prefRosterFilter", this.getResources().getString(R.string.prefRosterFilterDefaultValue));
         prefRosterRecentLocoNames = prefs.getBoolean("prefRosterRecentLocoNames",
                 getResources().getBoolean(R.bool.prefRosterRecentLocoNamesDefaultValue));
@@ -2536,22 +2557,6 @@ public class select_loco extends AppCompatActivity {
         }
         @Override
         public void onNothingSelected(AdapterView<?> parent) {
-        }
-    }
-
-    void getDefaultSortOrderRoster() {
-        String prefSortOrderRoster = prefs.getString("prefSortOrderRoster", this.getResources().getString(R.string.prefSortOrderRosterDefaultValue));
-        switch (prefSortOrderRoster) {
-            default:
-            case "name":
-                mainapp.rosterOrder = sort_type.NAME;
-                break;
-            case "id":
-                mainapp.rosterOrder = sort_type.ID;
-                break;
-            case "position":
-                mainapp.rosterOrder = sort_type.POSITION;
-                break;
         }
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -163,6 +163,7 @@ import jmri.enginedriver.type.direction_button;
 import jmri.enginedriver.type.function_button;
 
 import jmri.enginedriver.type.screen_swipe_index_type;
+import jmri.enginedriver.type.sort_type;
 import jmri.enginedriver.type.sounds_type;
 import jmri.enginedriver.type.speed_button_type;
 import jmri.enginedriver.type.throttle_screen_type;
@@ -5784,7 +5785,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         setContentView(mainapp.throttleLayoutViewId);
 
         getCommonPrefs(true); // get all the common preferences
-
+        mainapp.getDefaultSortOrderRoster();
         setThrottleNumLimits();
 
         getDirectionButtonPrefs();
@@ -6386,7 +6387,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         getCommonPrefs(false);
         getDirectionButtonPrefs();
+
         setThrottleNumLimits();
+
 
         clearVolumeAndGamepadAdditionalIndicators();
 
@@ -8432,6 +8435,5 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 gamepadRepeatUpdateHandler.postDelayed(new SemiRealisticGamepadRptUpdater(whichThrottle, stepMultiplier), REP_DELAY);
             }
         }
-
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/message_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/message_type.java
@@ -96,4 +96,6 @@ public interface message_type {
     int WRITE_DIRECT_DCC_COMMAND = 74;
     int WRITE_DIRECT_DCC_COMMAND_ECHO = 75;
     int FORCE_THROTTLE_RELOAD = 76;
+    int DCCEX_JOIN_TRACKS = 77;
+    int DCCEX_UNJOIN_TRACKS = 78;
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/LocaleHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/LocaleHelper.java
@@ -85,7 +85,13 @@ public class LocaleHelper {
     @TargetApi(17)
     private static Context updateResources(Context context, String language) {
 
-        Locale locale = new Locale(language);
+        String [] languageAndCountry = language.split("_");
+        Locale locale;
+        if (languageAndCountry.length==1) {
+            locale = new Locale(language);
+        } else {
+            locale = new Locale(languageAndCountry[0], languageAndCountry[1]);
+        }
         Locale.setDefault(locale);
 
         Configuration configuration = context.getResources().getConfiguration();

--- a/EngineDriver/src/main/res/layout/consist.xml
+++ b/EngineDriver/src/main/res/layout/consist.xml
@@ -67,13 +67,13 @@
             style="?attr/EDListView"
             android:layout_width="fill_parent"
             android:layout_height="0dp"
-            android:layout_marginBottom="20dp"
-            android:layout_weight="0.85" />
+            android:layout_marginBottom="10dp"
+            android:layout_weight="0.8" />
 
         <RelativeLayout
             android:layout_width="fill_parent"
             android:layout_height="0dp"
-            android:layout_weight=".15"
+            android:layout_weight=".2"
             android:gravity="bottom"
             android:paddingLeft="6dp"
             android:paddingRight="6dp" >
@@ -81,8 +81,11 @@
             <TextView
                 android:id="@+id/consist_help"
                 style="?attr/floating_text_style"
+                android:textColor="?android:attr/textColorSecondary"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingTop="3dp"
+                android:paddingBottom="3dp"
                 android:gravity="bottom"
                 android:layout_alignParentBottom="true"
                 android:layout_marginTop="0dp"
@@ -97,7 +100,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
-                android:layout_marginLeft="20dp"
+                android:layout_marginLeft="10dp"
                 android:layout_marginTop="0dp"
                 android:layout_alignParentRight="true"
                 android:layout_alignParentBottom="true"

--- a/EngineDriver/src/main/res/layout/consist_item.xml
+++ b/EngineDriver/src/main/res/layout/consist_item.xml
@@ -3,7 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal" >
+    android:orientation="horizontal"
+    android:paddingLeft="5dp"
+    android:paddingRight="5dp" >
 
     <TextView
         android:id="@+id/con_loco_name"
@@ -32,6 +34,7 @@
         <TextView
             android:id="@+id/con_lead_label"
             style="?attr/list_id_style"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="lead"
@@ -40,6 +43,7 @@
         <TextView
             android:id="@+id/con_trail_label"
             style="?attr/list_id_style"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="trail"
@@ -66,6 +70,7 @@
         <TextView
             android:id="@+id/con_facing_label"
             style="?attr/list_id_style"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/editConsistLocoFacingLabel" />

--- a/EngineDriver/src/main/res/layout/consist_lights.xml
+++ b/EngineDriver/src/main/res/layout/consist_lights.xml
@@ -11,13 +11,19 @@
     <include layout="@layout/toolbar" />
     <include layout="@layout/toolbar_status_line" />
 
+    <TextView
+        style="?android:attr/listSeparatorTextViewStyle"
+        android:text="@string/app_name_ConsistLightsEdit"
+        android:paddingLeft="4dp"
+        tools:ignore="RtlHardcoded,RtlSymmetry" />
+
     <ListView
         android:id="@+id/consist_lights_list"
         style="?attr/EDListView"
         android:layout_width="fill_parent"
         android:layout_height="0dp"
-        android:layout_marginBottom="20dp"
-        android:layout_weight="9" />
+        android:layout_marginBottom="10dp"
+        android:layout_weight="8.8" />
 
     <RelativeLayout
         android:layout_width="fill_parent"
@@ -30,6 +36,7 @@
         <TextView
             android:id="@+id/consistLights_help"
             style="?attr/floating_text_style"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="bottom"

--- a/EngineDriver/src/main/res/layout/consist_lights_item.xml
+++ b/EngineDriver/src/main/res/layout/consist_lights_item.xml
@@ -3,7 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal" >
+    android:orientation="horizontal"
+    android:paddingLeft="5dp"
+    android:paddingRight="5dp" >
 
     <TextView
         android:id="@+id/con_loco_name"

--- a/EngineDriver/src/main/res/layout/dcc_ex.xml
+++ b/EngineDriver/src/main/res/layout/dcc_ex.xml
@@ -147,10 +147,10 @@
                         style="?attr/floating_text_style"
                         android:layout_width="47dp"
                         android:layout_height="wrap_content"
+                        android:layout_gravity="center"
                         android:paddingLeft="5dp"
                         android:paddingRight="0dp"
                         android:text="@string/DCCEXbuttonDefaultFunctions"
-                        android:layout_gravity="center"
                         android:textSize="10sp"
                         tools:ignore="SmallSp" />
                 </LinearLayout>
@@ -394,6 +394,7 @@
                 android:layout_width="fill_parent"
                 android:layout_height="120sp"
                 android:layout_margin="0sp"
+                android:baselineAligned="false"
                 android:orientation="horizontal"
                 android:padding="5sp"
                 android:weightSum="1"
@@ -403,7 +404,7 @@
                     android:id="@+id/dexc_DccexTrackScrollView"
                     android:layout_width="0sp"
                     android:layout_height="fill_parent"
-                    android:layout_weight=".85"
+                    android:layout_weight=".83"
                     android:orientation="vertical">
 
                     <LinearLayout
@@ -906,21 +907,50 @@
 
                 </ScrollView>
 
-                <Button
-                    android:id="@+id/dexc_DccexWriteTracksButton"
-                    style="?attr/ed_small_button_style"
-                    android:layout_width="0sp"
+                <LinearLayout
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight=".15"
-                    android:autoSizeMaxTextSize="20sp"
-                    android:autoSizeMinTextSize="8sp"
-                    android:autoSizeStepGranularity="1sp"
-                    android:padding="0sp"
-                    android:text="@string/DCCEXsetTrackButtonLabel"
-                    tools:ignore="UnusedAttribute" />
+                    android:layout_weight=".17"
+                    android:layout_marginTop="8sp"
+                    android:background="#00000000"
+                    android:orientation="vertical"
+                    android:weightSum="1">
 
+                    <Button
+                        android:id="@+id/dexc_DccexWriteTracksButton"
+                        style="?attr/ed_small_button_style"
+                        android:layout_width="match_parent"
+                        android:layout_height="40sp"
+                        android:autoSizeMaxTextSize="18sp"
+                        android:autoSizeMinTextSize="8sp"
+                        android:autoSizeStepGranularity="1sp"
+                        android:padding="0dp"
+                        android:text="@string/DCCEXsetTrackButtonLabel"
+                        tools:ignore="UnusedAttribute" />
+
+                    <Button
+                        android:id="@+id/dexc_DccexJoinTracksButton"
+                        style="?attr/ed_small_button_style"
+                        android:layout_width="match_parent"
+                        android:layout_height="32sp"
+                        android:autoSizeMaxTextSize="18sp"
+                        android:autoSizeMinTextSize="8sp"
+                        android:autoSizeStepGranularity="1sp"
+                        android:layout_marginTop="10dp"
+                        android:padding="0sp"
+                        android:text="@string/DCCEXJoinTrackButtonLabel"
+                        tools:ignore="UnusedAttribute" />
+
+                </LinearLayout>
 
             </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="2dp"
+                android:layout_marginTop="6sp"
+                android:background="#888888"
+                android:orientation="vertical" />
 
             <LinearLayout
                 android:layout_width="fill_parent"
@@ -985,7 +1015,7 @@
                             android:id="@+id/dexc_DccexPreviousCommandButton"
                             style="?attr/ed_small_button_style"
                             android:layout_width="fill_parent"
-                            android:layout_height="22sp"
+                            android:layout_height="26dp"
                             android:layout_weight=".5"
                             android:padding="2sp"
                             android:text="@string/DccexPreviousCommandButtonLabel" />
@@ -997,7 +1027,7 @@
                             android:id="@+id/dexc_DccexNextCommandButton"
                             style="?attr/ed_small_button_style"
                             android:layout_width="fill_parent"
-                            android:layout_height="22sp"
+                            android:layout_height="22dp"
                             android:layout_weight=".5"
                             android:padding="2sp"
                             android:text="@string/DccexNextCommandButtonLabel" />
@@ -1023,7 +1053,7 @@
                     android:layout_weight=".3"
                     android:gravity="end"
                     android:padding="2sp"
-                    android:text="@string/DCCEXcommonCommnadsLabel"
+                    android:text="@string/DCCEXcommonCommandsLabel"
                     android:textAlignment="viewEnd"
                     android:textColor="?android:attr/textColorSecondary"
                     android:textSize="12sp" />

--- a/EngineDriver/src/main/res/layout/function_consist_settings.xml
+++ b/EngineDriver/src/main/res/layout/function_consist_settings.xml
@@ -69,6 +69,10 @@
                 android:layout_centerHorizontal="true"
                 android:layout_marginTop="40dp"
                 android:layout_marginBottom="4dp"
+                android:paddingLeft="4dp"
+                android:paddingStart="4dp"
+                android:paddingRight="4dp"
+                android:paddingEnd="4dp"
                 android:text="@string/logviewerClose"
                 tools:ignore="RtlHardcoded" />
 

--- a/EngineDriver/src/main/res/layout/function_settings.xml
+++ b/EngineDriver/src/main/res/layout/function_settings.xml
@@ -46,7 +46,11 @@
                 style="?attr/ed_small_button_style"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/copy_function_labels" />
+                android:text="@string/copy_function_labels"
+                android:paddingLeft="4dp"
+                android:paddingStart="4dp"
+                android:paddingRight="4dp"
+                android:paddingEnd="4dp" />
 
             <RelativeLayout
                 android:layout_width="fill_parent"
@@ -177,7 +181,11 @@
                 style="?attr/ed_small_button_style"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/fbResetFunctionLabels" />
+                android:text="@string/fbResetFunctionLabels"
+                android:paddingLeft="4dp"
+                android:paddingStart="4dp"
+                android:paddingRight="4dp"
+                android:paddingEnd="4dp" />
 
             <Button
                 android:id="@+id/fb_button_close"

--- a/EngineDriver/src/main/res/layout/log_main.xml
+++ b/EngineDriver/src/main/res/layout/log_main.xml
@@ -45,6 +45,7 @@
                 android:layout_height="40dp"
                 android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
+                android:layout_alignParentBottom="true"
                 android:text="@string/logviewerClose"
                 tools:ignore="RtlHardcoded" />
 
@@ -55,7 +56,12 @@
                 android:layout_height="40dp"
                 android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
+                android:layout_alignParentBottom="true"
                 android:layout_gravity="right"
+                android:paddingLeft="6dp"
+                android:paddingStart="6dp"
+                android:paddingRight="6dp"
+                android:paddingEnd="6dp"
                 android:text="@string/logviewerSave"
                 tools:ignore="RelativeOverlap,RtlHardcoded" />
 

--- a/EngineDriver/src/main/res/layout/routes_item.xml
+++ b/EngineDriver/src/main/res/layout/routes_item.xml
@@ -52,7 +52,7 @@
         android:layout_weight="0.25"
         android:autoSizeTextType="uniform"
         android:autoSizeMinTextSize="10sp"
-        android:autoSizeMaxTextSize="24sp"
+        android:autoSizeMaxTextSize="18sp"
         android:autoSizeStepGranularity="1sp"
         android:text="testing"
         tools:ignore="HardcodedText,UnusedAttribute" />

--- a/EngineDriver/src/main/res/layout/throttle.xml
+++ b/EngineDriver/src/main/res/layout/throttle.xml
@@ -101,10 +101,11 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
                                     android:text="@string/loco"
+                                    android:translationZ="90dp"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>
 
@@ -567,10 +568,11 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
                                     android:text="@string/loco"
+                                    android:translationZ="90dp"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>
 
@@ -1028,9 +1030,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>

--- a/EngineDriver/src/main/res/layout/throttle_big_buttons_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_big_buttons_left.xml
@@ -112,9 +112,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_big_buttons_right.xml
+++ b/EngineDriver/src/main/res/layout/throttle_big_buttons_right.xml
@@ -113,9 +113,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_semi_realistic_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_semi_realistic_left.xml
@@ -113,9 +113,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_simple.xml
+++ b/EngineDriver/src/main/res/layout/throttle_simple.xml
@@ -109,9 +109,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>
@@ -667,9 +668,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>
@@ -1219,9 +1221,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>
@@ -1739,9 +1742,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>
@@ -2259,9 +2263,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>
@@ -2779,9 +2784,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RtlHardcoded" />
                             </RelativeLayout>

--- a/EngineDriver/src/main/res/layout/throttle_switching.xml
+++ b/EngineDriver/src/main/res/layout/throttle_switching.xml
@@ -105,6 +105,7 @@
                                         android:text="@string/none"
                                         android:layout_marginLeft="5dp"
                                         android:layout_marginRight="2dp"
+                                        android:paddingBottom="0dp"
                                         tools:ignore="TooDeepLayout" />
 
                                     <TextView
@@ -112,9 +113,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
-                                        android:paddingTop="2dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
+                                        android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -856,6 +858,7 @@
                                         android:layout_width="fill_parent"
                                         android:layout_marginLeft="2dp"
                                         android:layout_marginRight="5dp"
+                                        android:paddingBottom="0dp"
                                         android:text="@string/none" />
 
                                     <TextView
@@ -863,9 +866,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
-                                        android:paddingTop="2dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
+                                        android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_switching_horizontal.xml
+++ b/EngineDriver/src/main/res/layout/throttle_switching_horizontal.xml
@@ -101,9 +101,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>
@@ -604,9 +605,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>
@@ -1104,9 +1106,10 @@
                                     style="?attr/ed_loco_label_style"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:paddingLeft="6dp"
+                                    android:paddingLeft="8dp"
                                     android:paddingRight="0dp"
                                     android:paddingTop="2dp"
+                                    android:translationZ="90dp"
                                     android:text="@string/loco"
                                     tools:ignore="RelativeOverlap,RtlHardcoded" />
                             </RelativeLayout>

--- a/EngineDriver/src/main/res/layout/throttle_switching_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_switching_left.xml
@@ -206,9 +206,10 @@
                                             style="?attr/ed_loco_label_style"
                                             android:layout_width="wrap_content"
                                             android:layout_height="wrap_content"
-                                            android:paddingLeft="6dp"
+                                            android:paddingLeft="8dp"
                                             android:paddingTop="2dp"
                                             android:paddingRight="0dp"
+                                            android:translationZ="90dp"
                                             android:text="@string/loco" />
                                     </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_switching_right.xml
+++ b/EngineDriver/src/main/res/layout/throttle_switching_right.xml
@@ -131,9 +131,10 @@
                                             style="?attr/ed_loco_label_style"
                                             android:layout_width="wrap_content"
                                             android:layout_height="wrap_content"
-                                            android:paddingLeft="6dp"
+                                            android:paddingLeft="8dp"
                                             android:paddingTop="2dp"
                                             android:paddingRight="0dp"
+                                            android:translationZ="90dp"
                                             android:text="@string/loco" />
                                     </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_switching_tablet_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_switching_tablet_left.xml
@@ -111,9 +111,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -862,9 +863,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -1611,9 +1613,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -2332,9 +2335,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -3053,9 +3057,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -3774,9 +3779,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_vertical.xml
+++ b/EngineDriver/src/main/res/layout/throttle_vertical.xml
@@ -112,9 +112,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -664,9 +665,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_vertical_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_vertical_left.xml
@@ -112,9 +112,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_vertical_right.xml
+++ b/EngineDriver/src/main/res/layout/throttle_vertical_right.xml
@@ -112,9 +112,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingTop="2dp"
                                         android:paddingRight="0dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/layout/throttle_vertical_tablet_left.xml
+++ b/EngineDriver/src/main/res/layout/throttle_vertical_tablet_left.xml
@@ -110,9 +110,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -661,9 +662,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -1210,9 +1212,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -1727,9 +1730,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -2244,9 +2248,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 
@@ -2761,9 +2766,10 @@
                                         style="?attr/ed_loco_label_style"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:paddingLeft="6dp"
+                                        android:paddingLeft="8dp"
                                         android:paddingRight="0dp"
                                         android:paddingTop="2dp"
+                                        android:translationZ="90dp"
                                         android:text="@string/loco" />
                                 </RelativeLayout>
 

--- a/EngineDriver/src/main/res/values-ca/arrays.xml
+++ b/EngineDriver/src/main/res/values-ca/arrays.xml
@@ -57,20 +57,20 @@
         <item>Sis</item>
     </string-array>
     <string-array name="prefThrottleScreenTypeEntries">  <!-- display version -->
-        <item>Original &#8211; telèfon o tablet (1&#8211;3 controladors)</item>
-        <item>Vertical &#8211; telèfon o tableta (2 controladors)</item>
-        <item>Botons grans &#8211; esquerra (1 controlador)</item>
-        <item>Botons grans &#8211; dreta (1 controlador)</item>
-        <item>Vertical &#8211; esquerra (1 controlador)</item>
-        <item>Vertical &#8211; dreta (1 controlador)</item>
-        <item>Switching &#8211; (2 controladors)</item>
-        <item>Switching &#8211; esquerra (1 controlador)</item>
-        <item>Switching &#8211; dreta (1 controlador)</item>
-        <item>Switching &#8211; Horizontal (3 controlador)</item>
-        <item tools:ignore="TypographyDashes">Simple - tablet recomanat (1-6 controladors)</item>
+        <item>Original &#8211; telèfon o tablet (1&#8211;3)</item>
+        <item>Vertical &#8211; telèfon o tableta (2)</item>
+        <item>Botons grans &#8211; esquerra (1)</item>
+        <item>Botons grans &#8211; dreta (1)</item>
+        <item>Vertical &#8211; esquerra (1)</item>
+        <item>Vertical &#8211; dreta (1)</item>
+        <item>Switching &#8211; (2)</item>
+        <item>Switching &#8211; esquerra (1)</item>
+        <item>Switching &#8211; dreta (1)</item>
+        <item>Switching &#8211; Horizontal (3)</item>
+        <item tools:ignore="TypographyDashes">Simple - tablet recomanat (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Switching esquerra (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Vertical esquerra (1-6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Esquerra semirealista (1)</item>
     </string-array>
     <string-array name="DisplayClockEntries">
         <item>Cap</item>
@@ -84,7 +84,7 @@
         <item >2</item>
     </string-array>
     -->
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Atura-ho tot</item>
         <item>Atura</item>
         <item>Endavant</item>
@@ -132,11 +132,11 @@
         <item>Banya (IPLS)</item>
         <item>Banya Curta (IPLS)</item>
         <item >Parla la velocitat actual</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutre</item>
+        <item>Augmentar el fre</item>
+        <item>Disminueix el fre</item>
+        <item>Augmenta la càrrega</item>
+        <item>Disminueix la càrrega</item>
     </string-array>
     <string-array name="prefAutoImportExportEntries">
         <item>Cap</item>
@@ -184,12 +184,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Utilitzar els paràmetres globals del telèfon</item>
         <item>Anglès (USA) - Engine Driver\'s per defecte</item>
+        <item>Anglès (Austràlia)</item>
+        <item>Anglès (Canadà)</item>
+        <item>Anglès (Nova Zelanda)</item>
+        <item>Anglès (Regne Unit)</item>
         <item>Italià</item>
         <item>Portuguès</item>
         <item>Alemany</item>
         <item>Espanyol</item>
         <item>Català</item>
         <item>Francès</item>
+        <item>Francès (Canadà)</item>
         <item>Txec</item>
     </string-array>
 
@@ -198,7 +203,7 @@
         <item>Text complex coincident - Locomotora capdavantera sempre acticada, Trail segueix les regles següents</item>
         <item>Especial exacta - Capdavantera i tota la resta activat si coincideixen exactament les etiquetes de funció</item>
         <item>Especial Parcial - Capdavantera i tota la resta activat si coincideixen parcialment les etiquetes de funció</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Només conté parcials especials: s\'activa si l\'etiqueta de funció conté l\'etiqueta predeterminada</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Locomotora capdavantera - Coincidència parcial</item>

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -24,7 +24,7 @@
 <!--    <string name="function_buttons">botons_de_funcions</string>-->
     <string name="introMenu">Introducció</string>
 
-    <string name="app_description">Engine Driver - Un Controlador per al teu telèfon Android. Aquesta aplicació permet connectar a servidors Withrottle com el JMRI, MRC o Digitrax, i tripular les teves Locomotores. La velocitat, la direcció, i més de 29 funcions DCC estan suportades per a una o dues Locomotores</string>
+    <string name="app_description">Engine Driver - Un Controlador per al teu telèfon Android. Aquesta aplicació permet connectar a servidors Withrottle com el JMRI, DCC-EX, MRC o Digitrax, i tripular les teves Locomotores. La velocitat, la direcció, i més de 32 funcions DCC estan suportades per a una o dues Locomotores</string>
     <string name="app_name_intro">Introducció</string>
     <string name="app_name_connect">Connectar al servidor</string>
     <string name="app_name_throttle">Controlador</string>
@@ -35,8 +35,7 @@
     <string name="app_name_routes">Rutes</string>
     <string name="app_name_routes_long">Engine Driver - Rutes</string>
     <string name="app_name_routes_short">Rutes</string>
-    <string name="app_name_turnouts">Agulles</string>
-    <string name="app_name_turnouts_long">Engine Driver - Agulles</string>
+    <string name="app_name_turnouts">Engine Driver - Agulles</string>
     <string name="app_name_turnouts_short">Agulles</string>
     <string name="app_name_about">Quant a</string>
     <string name="app_name_functions">Paràmetres de funcions per defecte</string>
@@ -59,7 +58,7 @@
     <string name="select_loco">Entra l\'adreça de la Locomotora</string>
     <string name="select_loco_address">Adreça</string>
     <string name="acquire_button">Adquirir</string>
-    <string name="roster_list">Selecciona des de la flota/Tracció Múltiple</string>
+    <string name="roster_list">Selecciona des de la flota / Tracció Múltiple</string>
     <string name="recent_engines">Selecciona des de Lomotores recents</string>
 <!--    <string name="direction">Adelante</string>-->
 <!--    <string name="speed">Velocitat:</string>-->
@@ -78,14 +77,13 @@
 
     <string name="consist_help">Prèmer una Locomotora per a canviar la direcció vers la de la Tracció Múltiple. Mantenir premut per eliminar una Locomotora de la Tracció Múltiple. Prèmer enrere par a finalitzar</string>
     <string name="about">Quant a</string>
-    <string name="web">Web</string>
     <string name="about_page_url">file:///android_asset/about_page-ca.html</string>
 
     <string name="mrc_settings">Paràmetres MRC</string>
     <string name="dccesp_settings">Configuració DCC ESP</string>
     <string name="loco">Locomotora:</string>
-    <string name="loco_direction_left_extra">"\u00B7E\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7E\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Seleccionar</string>
     <string name="powerWillNotWorkTitle">No funcionarà!</string>
     <string name="powerWillNotWork">JMRI té el control d\'alimentació WiThrottle apagat.\nEliminarà la tecla de corrent de via.\nEs mostrarà de nou quan s\'activi en el JMRI</string>
@@ -129,6 +127,7 @@
     <string name="disabled">Deshabilitat</string>
     <string name="yes">Si</string>
     <string name="no">No</string>
+    <string name="cancel">Cancel·la</string>
     <string name="exit_text">Sortir de l\'Engine Driver?</string>
     <string name="exit_title">Sortir</string>
     <string name="steal_text">Agafa l\'adreça %1$s?</string>
@@ -140,7 +139,7 @@
     <string name="prefSwipeUpDownSummary">Opcions per fer lliscar el dit amunt-avall a la pantalla del Controlador</string>
     <string name="prefThrottleNameTitle">Nom del Controlador</string>
 
-    <string name="prefThrottleNameSummary">Estableix el nom d\'aquest dispositiu (es mostra en la finestra del WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Estableix el nom d\'aquest dispositiu (es mostra en la finestra del JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">Orientació de la pantalla</string>
 
     <string name="prefThrottleOrientationSummary">Orientació de la pantalla (excepte Web)</string>
@@ -183,7 +182,7 @@
     <string name="prefGamePadTypeSummary">Trieu l\'opció que millor admeti el vostre gamepad</string>
 <!--    <string name="prefGamePadStartButtonTitle">Acció de la tecla d\'inici de gamepad</string>-->
 <!--    <string name="prefGamePadStartButtonSummary">Trieu l\'acció quan premeu la tecla inici</string>-->
-    <string name="prefGamePadFeedbackVolumeTitle">\% del clic de la tecla del gamepad </string>
+    <string name="prefGamePadFeedbackVolumeTitle">\% del clic de la tecla del gamepad</string>
     <string name="prefGamePadFeedbackVolumeSummary">Estableix el percentatge de volum per als clics de la tecla del gamepad</string>
 
     <string name="prefGamePadSpeedButtonsRepeatTitle">Retard de repetició de la tecla de velocitat</string>
@@ -237,14 +236,14 @@
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Mostra les etiquetes de funció predeterminades en lloc de les etiquetes de les entrades de la flota</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Anul·lació del bloqueig de la funció de l\'accelerador</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Utilitzeu el bloqueig predeterminat del controlador del motor per a blocs que no són de la llista, en lloc dels valors predeterminats proporcionats per WiThrottle</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Mostra les etiquetes de funció predeterminades en lloc de les etiquetes de les entrades de la llista.                                                               \\nAixò HA d\'estar activat per utilitzar els estils de regles de seguiment \\\'Especials\\\'.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Mostra les etiquetes de funció predeterminades en lloc de les etiquetes de les entrades de la llista.\nAixò HA d\'estar activat per utilitzar els estils de regles de seguiment \'Especials\'.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Disminueix l\'Alçada del número de Locomotora?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Utilitza tecles mes petits per al número de Locomotora, velocitat i tecles de direcció</string>
     <string name="prefNumOfThrottles">Número de Controladors</string>
     <string name="prefNumOfThrottlesSummary">Trieu quants Controladors voleu mostrar</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipus de pantalla del Controlador</string>
-    <string name="prefThrottleScreenTypeSummary">Quin tipus de pantalla utilitzarà el Controlador</string>
+    <string name="prefThrottleScreenTypeSummary">Quin tipus de pantalla utilitzarà el Controlador\n(El número entre parèntesis després del nom és el nombre d\'acceleradores que pot suportar el disseny.)</string>
 
     <string name="prefMaximumThrottleTitle">Percentatge màxim del Controlador</string>
 
@@ -256,7 +255,7 @@
     <string name="prefWebViewSummary">Opcions per a l\'aspecte de la visualització web</string>
     <string name="prefInitialThrotWebPageTitle">Pàgina web inicial del Controlador</string>
 
-    <string name="prefInitialThrotWebPageSummary">Pàgina web inicial dels Controladors (com ara \'/panell/\')</string>
+    <string name="prefInitialThrotWebPageSummary">Pàgina web inicial dels Controladors (com ara \'/panel/\')</string>
     <string name="prefWebViewLocationTitle">Vista web del Controlador?</string>
 
     <string name="prefWebViewLocationSummary">Inclou una visualització web al panell del Controlador</string>
@@ -290,7 +289,7 @@
     <string name="prefDefaultAddressLengthTitle">Direccions per defecte (curtes/llargues)</string>
 
     <string name="prefDefaultAddressLengthSummary">Longitud predeterminada de l\'adreça de la Locomotora, (Auto s\'establirà en funció de # de dígits)</string>
-    <string name="prefWebTitle">Preferències web</string>
+    <string name="prefWebTitle">Preferències Web</string>
     <string name="prefDisplaySpeedUnitsTitle">Unitats de velocitats</string>
 
     <string name="prefDisplaySpeedUnitsSummary">Mostra la velocitat de la pantalla com a percentatge o per passos de velocitat?</string>
@@ -299,7 +298,7 @@
     <string name="prefWebOrientationSummary">Orientació de la pantalla web</string>
     <string name="prefInitialWebPageTitle">Pàgina web original</string>
 
-    <string name="prefInitialWebPageSummary">Pàgina web inicial (com ara \'/panell/\')</string>
+    <string name="prefInitialWebPageSummary">Pàgina web inicial (com ara \'/panel/\')</string>
     <string name="prefConnectTitle">Preferències de connexió</string>
     <string name="prefMaximumRecentConnectionsTitle">Màxim de connexions recents</string>
 
@@ -314,7 +313,7 @@
 
     <string name="prefDelimiterSummary">Estableix el caràcter per a marcar el final d\'una localització d\'una agulla i nom de rutes</string>
     <string name="prefScreenBrightnessDimTitle">Canvia \% la brillantor de la pantalla</string>
-    <string name="prefScreenBrightnessDimSummary">Paràmetres de la brillantor a utilizar quan la canviem en la pantalla (0%-99%). Deshabilita automàticament Brillantor-automàtic, adapta brillantor si es possible. </string>
+    <string name="prefScreenBrightnessDimSummary">Paràmetres de la brillantor a utilizar quan la canviem en la pantalla (0%-99%). Deshabilita automàticament Brillantor-automàtic, adapta brillantor si es possible.</string>
 
     <string name="logViewer">Veure Log</string>
     <string name="clearLocoList">Neteja la llista</string>
@@ -341,7 +340,7 @@
     <string name="prefSelectedLocoIndicatorSummary">Punt de referència addicional de la tecla selecciona Locomotora basat en el mètode de selecció</string>
 
     <string name="prefDisableVolumeKeysTitle">Deshabilita les tecles de volum</string>
-    <string name="prefDisableVolumeKeysSummary">Deshabilita les tecles físiques de volum del telèfon/tablet per a el control de velocitat. Nota: si es selecciona sobreescriu \'Indicador de Locomotora addicional seleccionada\' . </string>
+    <string name="prefDisableVolumeKeysSummary">Deshabilita les tecles físiques de volum del telèfon/tablet per a el control de velocitat. Nota: si es selecciona sobreescriu \'Indicador de Locomotora addicional seleccionada\'.</string>
     <string name="prefVolumeKeysFollowLastTouchedThrottleTitle">Tecles de volum segueixen el Toc</string>
     <string name="prefVolumeKeysFollowLastTouchedThrottleSummary">Las tecles de Volum per al control de velocitat han de seguir l\'últim Controlador tocat</string>
     <string name="prefSpeedButtonsRepeatTitle">Retard de repetició de la tecla de velocitat</string>
@@ -375,7 +374,7 @@
 <!--    <string name="prefImportServerManualSummary">Fitxer del servidor a \'Importar\' un conjunt de preferències del servidor actualment connectat.\nEl fitxer ha d\'estar al \'/\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\' del servidor i el servidor web ha d\'estar executat.\nObjectiu: la importació començarà immediatament a desar aquesta preferència</string>-->
 
     <string name="prefImportServerAutoTitle">Importació automàtica de tots els servidors</string>
-    <string name="prefImportServerAutoSummary">Importa automàticament les preferències dels servidors a la connexió.\n(Si el fitxer \'\\engine_driver\' folder to \'[jmri railroad base folder]\\prefs\\engine_driver\\auto_preferences.ed\' està al servidor i si és més recent que s\'hagi verificat l\'última vegada.)</string>
+    <string name="prefImportServerAutoSummary">Importa automàticament les preferències dels servidors a la connexió.\n(Si el fitxer \'[jmri railroad base folder]\\prefs\\engine_driver\\auto_preferences.ed\' folder to \'[jmri railroad base folder]\\prefs\\engine_driver\\auto_preferences.ed\' està al servidor i si és més recent que s\'hagi verificat l\'última vegada.)</string>
 
     <string name="importServerAutoDialog">S\'ha trobat un nou fitxer de preferències en aquest servidor (%1$s).\nVols importar-lo?\n\nAdvertència!\n\'Complet\' - Totes les vostres preferències seran sobreescriure.\n\n\'Parcial\' - totes les preferències, excepte el tema i algunes preferències de tipus de pàgina, seran sobreescriuen</string>
     <string name="importServerAutoDialogPositiveButton">Complet</string>
@@ -396,6 +395,9 @@
     <string name="prefGamepadTestEnforceTestingTitle">Força la prova del gamepad</string>
     <string name="prefGamepadTestEnforceTestingSummary">Prova el gamepad cada vegada que sigui conectat</string>
 
+    <string name="prefHeartbeatResponseFactorTitle">Factor de resposta al batec del cor</string>
+    <string name="prefHeartbeatResponseFactorSummary">Percentatge del període de batec del cor per quan enviar el batec (50%-90%). Tindrà efecte a la propera connexió.</string>
+    <string name="server">Servidor</string>
     <string name="prefGamepadTestEnforceTestingSimpleTitle">Utilitza la prova simple</string>
     <string name="prefGamepadTestEnforceTestingSimpleSummary">Tant sols prueba que puedas reducir la velocidad</string>
 
@@ -417,13 +419,12 @@
 
     <string name="prefThemeTitle">Tema/Estil</string>
 
-    <string name="prefThemeSummary">Tema de l\'App.\nRequereix Android Honeycomb o posterior</string>
+    <string name="prefThemeSummary">Tema de l\'App.</string>
 
     <string name="prefHideDemoServerTitle">Amaga la demo del servidor</string>
     <string name="prefHideDemoServerSummary">Amaga la demo del servidor\'jmri.mstevetodd.com\' en la llista de connexions</string>
 <!--    <string name="prefDirectionButtonsTitle">Etiquetes de les tecles de direcció</string>-->
 <!--    <string name="prefDirectionButtonsSummary">Etiquetes per a totes les tecles de direcció</string>-->
-
 
     <string name="prefAccelerometerTitle">Preferencies de l\'acceleròmetre</string>
     <string name="prefAccelerometerSummary">Opcions per al moviment del dispositiu a la pàgina del Controlador</string>
@@ -462,19 +463,19 @@
     <string name="gamepadTestCompleteLabel">Prova d\'estat:</string>
     <string name="gamepadTestHelp">Desplaceu-vos cap avall per veure les instruccions completes&#8230;\n\nPrémer TOTS Dpad I les quatre tecles principals del gamepad NO FUNCIONARÀ.\n\nSi no pots activar totes les tecles, canvia el mode del gamepad (mira les instruccions que venen amb el teu gamepad) o prova un altre tipus de gamepad (amunt).\n\n\'ENRERE \' o \'CANCEL·LA\' sortirà de la prova però el gamepad NO FUNCIONARÀ.\n\'OMET\', o prement la tecla \'Reduir velocitat\' del gamepad tres vegades, forçarà el pas de la prova, encara que el gamepad no funcioni correctament.\n\'REINICIA\' farà que ED pensi que encara no s\'han utilitzat gamepads.\nSi selecciona la prova \'simple\', al prèmer un sola tecla \'Reduir velocitat\' s\'ometrà la prova.\n\nUtilitza les opcions del menú \'Prova de gamepad n\' per a tornar a aquesta pàgina</string>
     <string name="gamepadTestHelpNonForced">Si no pots activar tote les tecles, canvia el mode del gamepad (mira les instruccions que venen amb el teu dispositiu) o prova un tipus de gamepad diferent (adalt).\nÉs possible que hagiss de tornar a provar el gamepad quan l\'utilitzis per primera vegada en la pantalla del Controlador</string>
-    <string name="gamepadTestIncomplete">"Prova incompleta"</string>
-    <string name="gamepadTestComplete">"Prova completada"</string>
-    <string name="gamepadTestCompleteToast">"Prova gamepad completada satisfactoriament"</string>
-    <string name="gamepadTestInvalidKeycode">"Codi de tecla no vàlid para aquest mode"</string>
-    <string name="gamepadTestReset">"Reinicia"</string>
-    <string name="gamepadTestCancel">"Cancel·la"</string>
-    <string name="gamepadTestCancelNonForced">"Tanca"</string>
-    <string name="gamepadTestSkip">"Omet"</string>
+    <string name="gamepadTestIncomplete">Prova incompleta</string>
+    <string name="gamepadTestComplete">Prova completada</string>
+    <string name="gamepadTestCompleteToast">Prova gamepad completada satisfactoriament</string>
+    <string name="gamepadTestInvalidKeycode">Codi de tecla no vàlid para aquest mode</string>
+    <string name="gamepadTestReset">Reinicia</string>
+    <string name="gamepadTestCancel">Cancel·la</string>
+    <string name="gamepadTestCancelNonForced">Tanca</string>
+    <string name="gamepadTestSkip">Omet</string>
 
-    <string name="gamepadTestKeyCodesUpCode">"Am"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Av"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Es"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Dr"</string>
+    <string name="gamepadTestKeyCodesUpCode">Am</string>
+    <string name="gamepadTestKeyCodesDownCode">Av</string>
+    <string name="gamepadTestKeyCodesLeftCode">Es</string>
+    <string name="gamepadTestKeyCodesRightCode">Dr</string>
 
     <string name="prefGamepadTestNowTitle">Prova de configuració del gamepad ara!</string>
     <string name="prefGamepadTestNowSummary">Permet confirmar que la configuració seleccionada funciona correctament.\nLa pàgina de prova s\'iniciarà IMMEDIATAMENT en seleccionar-la</string>
@@ -521,9 +522,9 @@
     <string name="toastConnectErrorReadingRecentConnections">Error llegint la lista de connexions recents:</string>
     <string name="toastConnectErrorSavingRecentConnection">Error desant la connexió recent:</string>
     <string name="toastConnectRemoveDemoHostError">El servidor de "demo" només es pot eliminar mitjançant la modificació de les preferències</string>
-    <string name="toastConnectRemoved">Servidor esborrat de la llista</string>
+    <string name="toastConnectRemoved">Servidor eliminat de la llista.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Comanda enviada per establir la ruta"</string>-->
+<!--    <string name="toastRoutesCommandSent">Comanda enviada per establir la ruta</string>-->
     <string name="toastImportExportExportSucceeded">L\'exportació de preferències a \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\' folder to \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha tingut èxit</string>
     <string name="toastImportExportImportSucceeded">L\'importació de preferències des de \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\' folder to \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha tingut èxit</string>
     <string name="toastImportExportExportFailed">L\'exportació de preferències a  \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\' folder to \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha fallat!</string>
@@ -614,6 +615,8 @@
 <!--    <string name="FilterRosterList">Filtre</string>-->
     <string name="FilterRosterListHint">Conté&#8230;</string>
 
+    <string name="prefDoubleBackButtonToExitTitle">Doble botó Enrere per sortir?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Si premeu el botó \"Enrere\" d\'Android dues vegades en 3 segons a la pantalla \"Acelerador\" o \"Connexió\", sortirà del controlador del motor</string>
     <string name="prefRosterOwnersFilterShowOptionTitle">Filtra per propietari de la llista</string>
     <string name="prefRosterOwnersFilterShowOptionSummary">Mostra una opció per filtrar la llista per propietari</string>
     <string name="prefRosterOwnersFilterDefaultOwner">Tots</string>
@@ -621,6 +624,7 @@
     <string name="LocoSelectMethodRoster">JMRI flota</string>
     <string name="LocoSelectMethodRecent">Recent</string>
     <string name="LocoSelectMethodHelp">Entra adalt l\'adreça DCC de la Locomotora i fes clic en \'Adquereix\'.\n\nAlternativament, pots seleccionar una Locomotora de la  \'Flota\' del JMRI o selecciona entre les Locomotores utilitzades \'Recents\' fent clic en una de les opcions que apareixen adalt</string>
+    <string name="toastAddressExceedsMax">L\'adreça %1$s\' supera el màxim admès (\'%2$s\')</string>
     <string name="flashlightAction">Llum Flash</string>
     <string name="flashlightStateOn">La llum flash està encesa</string>
     <string name="flashlightStateOff">La llum flash està apagada</string>
@@ -630,7 +634,9 @@
     <string name="prefConnectTimeoutMsTitle">Temps d\'espera per connexió inicial</string>
     <string name="prefConnectTimeoutMsSummary">Estableix el temps d\'espera de connexió inicial en mil·lisegons</string>
     <string name="prefSocketTimeoutMsTitle">Temps d\'espera del socket</string>
-    <string name="prefSocketTimeoutMsSummary">Estableix el temps d\'espera en mil·lisegons per al socket </string>
+    <string name="prefSocketTimeoutMsSummary">Estableix el temps d\'espera en mil·lisegons per al socket</string>
+    <string name="toastWaitingForConnection">Temps d\'espera pendent del missatge \'VN\' de WiThrottle de %1$s:%2$s. Desconnectant</string>
+    <string name="toastWaitingForConnectionDccEx">S\'espera el temps d\'espera del missatge DCC-EX \'iDCCEX...\' de %1$s:%2$s. Desconnectant</string>
     <string name="toastThreadedAppNoLocalIp">No s\'ha trobat l\'adreça IP.\nVerifica la connexió WIFI</string>
     <string name="toastThreadedAppErrorCreatingWiThrottle">Error creant el client zeroconf del withrottle: Excepció IO:\n%1$s</string>
     <string name="toastThreadedAppWiThrottleNotSupported">Versió de WiThrottle %1$s no suportada</string>
@@ -668,8 +674,6 @@
 
     <string name="prefConsistFollowString1DefaultValue">LLUM</string>
     <string name="prefConsistFollowString2DefaultValue">XIULET,BOTZINA,CAMPANA</string>
-    <string name="prefConsistFollowStringOtherDefaultValue" />
-    <string name="prefConsistFollowActionOtherDefaultValue">lead</string>
 
     <string name="prefConsistFollowDefaultActionTitle">Si fallen Tots els partits Acció</string>
     <string name="prefConsistFollowDefaultActionSummary">Quines Locomotores de la Tracció Múltiple han de reaccionar a les tecles de funció si no s\'acompleix cap de les regles següents</string>
@@ -706,6 +710,12 @@
     <string name="prefKidsTimerTitle">Durada limitada</string>
     <string name="prefKidsTimerSummary">Restringiu el temps que circularà una Locomotora. Per exemple, cada nen tindrà una quantitat igual de temps</string>
 
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Canvi de direcció a la parada final</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Deixeu que la direcció de la locomotora canviï quan el botó de control estigui en la posició de parada final en sentit contrari a les agulles del rellotge.</string>
+    <string name="prefEsuMc2KnobButtonTitle">Mostra el botó de desactivació del botó</string>
+    <string name="prefEsuMc2KnobButtonSummary">Permet que el botó de control es desactivi mitjançant un botó d\'acció a la pantalla de l\'accelerador.</string>
+    <string name="EsuMc2KnobAction">Activa/desactiva el botó</string>
+    <string name="toastThreadedAppNotWIFI">L\'ús de la xarxa %1$s, no Wi-Fi.\\nComprovi la configuració de Wi-Fi.\n</string>
     <string name="prefKidsTimerRestartPasswordTitle">Reinicia contrasenya</string>
     <string name="prefKidsTimerRestartPasswordSummary">Contrasenya per reiniciar els paràmetres actuals del temporitzador</string>
 
@@ -717,6 +727,7 @@
     <string name="app_name_throttle_kids_enabled">Temporitzador preparat</string>
     <string name="app_name_throttle_kids_ended">Temporitzador finalitzat</string>
 
+    <string name="prefEsuMc2StopButtonShortPressTitle">Activa Premsa curta</string>
     <string name="kidsTimer">Temporitzador</string>
     <string name="timerDialogTitle">Contrasenya del temporitzador</string>
     <string name="timerDialogMessage">Contrasenya :</string>
@@ -768,7 +779,7 @@
     <string name="introButtonsSliderAndButtons">Control lliscant i tecles\n(no és possible amb \'Botons grans\')</string>
     <string name="introButtonsNoSlider">Només tecles de velocitat</string>
 
-    <string name="introDccexTitle">Opcions de l\\\'EX-CommandStation</string>
+    <string name="introDccexTitle">Opcions de l\'EX-CommandStation</string>
     <string name="introDccexSummary">El controlador del motor pot proporcionar funcionalitats addicionals, inclosa la programació de CV, si utilitzeu directament una DCC-EX EX-CommandStation. (No mitjançant JMRI)\n\nSi responeu \'Sí\' a continuació, el controlador del motor utilitzarà per defecte les ordres natives de DCC-EX en comptes de WiThrottle si el nom del servidor conté \'DCC-EX\' o \'DCCEX\' .</string>
     <string name="introDccexQuestionYes">Sí, faré servir una EX-CommandStation</string>
     <string name="introDccexQuestionNo">No, NO faré servir una EX-CommandStation</string>
@@ -799,8 +810,10 @@
     <string name="prefLimitSpeedButtonSummary">Opció per mostrar una tecla que limita la velocitat màxima d\'una Locomotora</string>
     <string name="prefLimitSpeedButtonTitle">Mostra la tecla de \'Límit de velocitat\'</string>
     <string name="prefLimitSpeedPercentSummary">Ajusta el \% de velocitat del regulador que es limitarà temporalment</string>
+    <string name="prefPauseAlternateButtonTitle">Botó alternatiu \'Pausa\'</string>
+    <string name="prefPauseAlternateButtonSummary">Mostra el botó \'Pausa\' alternatiu a prop del botó \'Atura\'. (només dissenys verticals)</string>
     <string name="prefLimitSpeedPercentTitle">\'Límit de velocitat\' a \%</string>
-    <string name="rosterDetailsDialogTitle">"Detalls de la flota per "</string>
+    <string name="rosterDetailsDialogTitle">Detalls de la flota per</string>
     <string name="toastRecentCleared">Locomotora eliminada de la llista</string>
     <string name="toastRecentConsistCleared">Tracció múltiple eliminada de la llista</string>
     <string name="editConsistButtonLabel">Edita l\'ordre i el frontal</string>
@@ -901,7 +914,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Quant de temps entre es repeteix el pas de velocitat d\'acceleració (en mil·lisegons). Més petit és més ràpid.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Retard de repetició de pas de velocitat de desacceleració</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Quant de temps entre es repeteix el pas de velocitat de desacceleració (en mil·lisegons). Més petit és més ràpid.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Pas de velocitat "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Pas de velocitat</string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Quant salta la velocitat real cada pas a la velocitat objectiu.  Més gran és més ràpid.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Osques de l\'accelerador</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Ajusteu l\'accelerador com a percentatge o per un nombre específic de passos/osques</string>
@@ -909,7 +922,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Ajusteu el nombre de passos al control lliscant de fre</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Valoreu el refresc dels frens d\'aire</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Ajusteu la velocitat amb què els frens d\'aire s\'actualitzaran/ompliran (en mil·lisegons). Més petit és més ràpid.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Nombre de càrrega "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Nombre de càrrega </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Ajusteu el nombre de passos al control lliscant de càrrega</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Multiplicador de percentatge de càrrega</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Ajusteu l\'efecte del control lliscant de càrrega sobre els canvis de velocitat. &gt;100% = més càrrega</string>
@@ -965,6 +978,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Retard (impuls) per canvi de pas en mil·lisegons (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">En el moment del telèfon</string>
     <string name="deviceSoundsMuteButton">Muda</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 i F2 també activen IPLS Bell i Horn</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 i F2 activen Bell i Horn?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Amaga el botó de silenci IPLS als acceleradors</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Amaga el botó de silenci</string>
     <string name="prefDeviceSoundsButtonSummary">Mostra un botó d\'acció de barra per canviar les opcions del telèfon de Loco sona</string>
     <string name="prefDeviceSoundsButtonTitle">Al botó de sons del telèfon</string>
     <string name="deviceSoundsMenu">Loco sona</string>
@@ -978,7 +995,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botó de campana és momentània. (Bloqueig si no està marcat.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bouth Button Botó / momentània</string>
 <!--    <string name="permissionsReadLegacyFiles">El controlador de motor necessita permisos d\'emmagatzematge per carregar la configuració del llegat (ubicació antiga).</string>-->
-    <string name="permissionsReadPhoneState">El controlador del motor necessita permisos de telèfon per aturar les operacions en una trucada.</string>
+    <string name="permissionsReadPhoneState">Engine Driver necessita permisos de telèfon per aturar les operacions en una trucada.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferències addicionals</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Addicionals al telèfon Loco sona les preferències</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Els sons de pas de loco jugaran fins al final en canviar de pas. La quantitat d\'impuls (a dalt) només es converteix en un temps mínim.</string>
@@ -1005,7 +1022,7 @@
     <string name="prefWebViewButtonSummary">Zobrazit tlačítko Ukázat/Skrýt zobrazit Web v panelu akcí? (vyžaduje v předvolbách povoleno \'Ovladač zobrazení Web\')</string>
     <string name="prefWebViewButtonTitle">Ukázat/Skrýt tlačítko zobrazit Web?</string>
     <string name="FilterRosterListDownloadLabel">descarregar</string>
-    <string name="rosterEmpty">No es pot trobar cap ingrés a la llista de JMRI. Utilitzeu l\'opció \'Adreça DCC\' o \'recent\'.</string>
+    <string name="rosterEmpty">No s\'ha pogut trobar cap entitat a la llista del servidor WiThrottle. Utilitzeu l\'opció "Adreça DCC" o "Recent".</string>
     <string name="statusThreadedAppNotConnected">No està connectat a una xarxa. Comproveu la configuració de Wi-Fi. \n\nReintentant</string>
     <string name="toastNumThrottles">El tipus de pantalla de l\'acceleració escollit no admet tants acceleradors. Reduint al %1$s.</string>
     <string name="TtsGamepadTestSpeedMax">Màxim</string>
@@ -1022,10 +1039,10 @@
     <string name="usingProtocolDCCEX">Utilitzant el protocol DCC-EX. \nDesmarqueu \"Utilitzeu les ordres natives DCC-EX\" preferir per utilitzar el protocol amb WithRottle.</string>
     <string name="prefDccexConnectionOptionSummary">Mostra l\'opció de canviar entre protocols amb WithRottle i DCC-EX a la pantalla de connexió.</string>
     <string name="prefDccexConnectionOptionTitle">Mostra l\'opció de protocol</string>
-    <string name="prefActionBarShowDccExButtonSummary">Mostra el botó a la barra d’acció per accedir a la pantalla ECC-EX. (Només per a connexions natives DCC-EX.)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Mostra el botó a la barra d’acció per accedir a la pantalla DCC-EX. (Només per a connexions natives DCC-EX.)</string>
     <string name="prefActionBarShowDccExButtonTitle">Botó DCC-EX?</string>
     <string name="DCCEXactionTypeLabel">Acció</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(exclou \'&lt;\' i \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(exclou \'&lt;\' i \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Clar</string>
     <string name="DccexConnectionOptionTitle">Protocol de connexió</string>
     <string name="DccexFailed">L\'acció ha fallat</string>
@@ -1037,10 +1054,10 @@
     <string name="DccexSendCommandButtonLabel">Enviar</string>
     <string name="witActionTypeLabel">Acció</string>
     <string name="witWriteAddressLabel">Adreça DCC</string>
-    <string name="witPomWarning">Notes: - Això no funcionarà en alguns sistemes DCC. - S\'ha impedit el canvi d\'adreça de lloc - CV 1, 17 &amp; 18 i el bit 5 de CV 29. \\n\\nFeu servir amb precaució.</string>
+    <string name="witPomWarning">Notes: - Això no funcionarà en alguns sistemes DCC. - S\'ha impedit el canvi d\'adreça de lloc - CV 1, 17 &amp; 18 i el bit 5 de CV 29. \n\nFeu servir amb precaució.</string>
     <string name="witPomMaxValueWarning">El valor \'%1$s\' supera el màxim admès (\'%2$s\')</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">CMD comuns</string>
+    <string name="DCCEXcommonCommandsLabel">CMD comuns</string>
     <string name="DCCEXsetTrackButtonLabel">Conjunt</string>
     <string name="DccexSucceeded">L\'acció va tenir èxit</string>
     <string name="DCCEXturnoutClosed">Tancada</string>
@@ -1083,4 +1100,22 @@
     <string name="order">Ordena</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Mostrar sempre Llançar/Tancar?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Mostra sempre els botons Llançar i Tancar per als desviaments, mai el botó Commuta.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Uneix-te</string>
+
+    <string name="air_reservoir">Dipòsit d\'aire</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Tipus de fre del descodificador</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Activeu les funcions de fre al descodificador</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Número de funció baix de l\'ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU: quina funció de descodificador s\'ha d\'activar a un valor de fre baix</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Número de funció mitjana ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU: quina funció de descodificador s\'ha d\'activar al valor mitjà de frenada</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">Número d\'alta funció de l\'ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU: quina funció de descodificador s\'ha d\'activar a un valor de fre alt</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Valor de fre baix d\'ESU (percentatge)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU - Quin percentatge de fre per activar el número de funció baixa</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">ESU Mid Brake alu (percentatge)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU - Quin percentatge de fre per activar el número de funció mitjana</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Valor de fre alt ESU (percentatge)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU - Quin percentatge de fre per activar el número de funció alta</string>
+
 </resources>

--- a/EngineDriver/src/main/res/values-cs/arrays.xml
+++ b/EngineDriver/src/main/res/values-cs/arrays.xml
@@ -82,7 +82,7 @@
         <item tools:ignore="TypographyDashes">Jednoduchý - Tablet doporučeno (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Switching Vlevo (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Vertical Vlevo (1-6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Polorealistická levá (1)</item>
     </string-array>
 
     <string-array name="DisplayClockEntries">  <!-- display version -->
@@ -101,58 +101,58 @@
     </string-array>
 
     <string-array name="prefGamePadKeyEntries">  <!-- display version -->
-        <item >Vše Zastavit</item>
-        <item >Zastavit</item>
-        <item >Vpřed</item>
-        <item >Vzad</item>
-        <item >Přepnout Vpřed/Vzad</item>
-        <item >Zvýšit rychlost</item>
-        <item >Snížit rychlost</item>
-        <item >Nejvyšší dovolená rychlost</item>
-        <item >Pause</item>
-        <item >Další ovladač</item>
-        <item >Funkce 00/Světla</item>
-        <item >Funkce 01/Zvon</item>
-        <item >Funkce 02/Houkačka</item>
-        <item >Funkce 03</item>
-        <item >Funkce 04</item>
-        <item >Funkce 05</item>
-        <item >Funkce 06</item>
-        <item >Funkce 07</item>
-        <item >Funkce 08</item>
-        <item >Funkce 09</item>
-        <item >Funkce 10</item>
-        <item >Funkce 11</item>
-        <item >Funkce 12</item>
-        <item >Funkce 13</item>
-        <item >Funkce 14</item>
-        <item >Funkce 15</item>
-        <item >Funkce 16</item>
-        <item >Funkce 17</item>
-        <item >Funkce 18</item>
-        <item >Funkce 19</item>
-        <item >Funkce 20</item>
-        <item >Funkce 21</item>
-        <item >Funkce 22</item>
-        <item >Funkce 23</item>
-        <item >Funkce 24</item>
-        <item >Funkce 25</item>
-        <item >Funkce 26</item>
-        <item >Funkce 27</item>
-        <item >Funkce 28</item>
-        <item >Funkce 29</item>
-        <item >Funkce 30</item>
-        <item >Funkce 31</item>
-        <item >Ztlumit (IPLS)</item>
-        <item >Zvonek (IPLS)</item>
-        <item >Roh (IPLS)</item>
-        <item >Roh krátký (IPLS)</item>
-        <item >Mluvit aktuální rychlostí</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Vše Zastavit</item>
+        <item>Zastavit</item>
+        <item>Vpřed</item>
+        <item>Vzad</item>
+        <item>Přepnout Vpřed/Vzad</item>
+        <item>Zvýšit rychlost</item>
+        <item>Snížit rychlost</item>
+        <item>Nejvyšší dovolená rychlost</item>
+        <item>Pause</item>
+        <item>Další ovladač</item>
+        <item>Funkce 00/Světla</item>
+        <item>Funkce 01/Zvon</item>
+        <item>Funkce 02/Houkačka</item>
+        <item>Funkce 03</item>
+        <item>Funkce 04</item>
+        <item>Funkce 05</item>
+        <item>Funkce 06</item>
+        <item>Funkce 07</item>
+        <item>Funkce 08</item>
+        <item>Funkce 09</item>
+        <item>Funkce 10</item>
+        <item>Funkce 11</item>
+        <item>Funkce 12</item>
+        <item>Funkce 13</item>
+        <item>Funkce 14</item>
+        <item>Funkce 15</item>
+        <item>Funkce 16</item>
+        <item>Funkce 17</item>
+        <item>Funkce 18</item>
+        <item>Funkce 19</item>
+        <item>Funkce 20</item>
+        <item>Funkce 21</item>
+        <item>Funkce 22</item>
+        <item>Funkce 23</item>
+        <item>Funkce 24</item>
+        <item>Funkce 25</item>
+        <item>Funkce 26</item>
+        <item>Funkce 27</item>
+        <item>Funkce 28</item>
+        <item>Funkce 29</item>
+        <item>Funkce 30</item>
+        <item>Funkce 31</item>
+        <item>Ztlumit (IPLS)</item>
+        <item>zvonek (IPLS)</item>
+        <item>Klakson (IPLS)</item>
+        <item>Horn Short (IPLS)</item>
+        <item>Aktuální rychlost mluvení (IPLS)</item>
+        <item>Neutrální</item>
+        <item>Zvyšte brzdu</item>
+        <item>Snížit brzdu</item>
+        <item>Zvýšit zatížení</item>
+        <item>Snížit zatížení</item>
     </string-array>
 
     <string-array name="prefGamePadFlydigiWee2Labels">
@@ -323,7 +323,7 @@
         <item>Nic</item>
         <item>Exportovat</item>
         <item>Importovat</item>
-        <item>Reset</item>
+        <item>Resetovat</item>
     </string-array>
 
     <string-array name="prefAutoImportExportEntries">  <!-- display version -->
@@ -386,12 +386,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Použít nastavení telefonu</item>
         <item>Anglicky (US) - Engine Driver výchozí</item>
+        <item>Anglicky (Austrálie)</item>
+        <item>Anglicky (Kanada)</item>
+        <item>Anglicky (Nový Zéland)</item>
+        <item>Anglicky (Spojené království)</item>
         <item>Italsky</item>
         <item>Portugalsky</item>
         <item>Německy</item>
         <item>Španělsky</item>
         <item>Katalánksy</item>
         <item>Francouzsky</item>
+        <item>Francouzsky (Kanada)</item>
         <item>Česky</item>
     </string-array>
 
@@ -400,7 +405,7 @@
         <item>Komplex textu shoda - Lead loco aktivován vždy, Trail řídí pravidly níže</item>
         <item>Speciální Exact - Olovo a All Trail aktivován v případě, že přesně shodovat s popisky funkčních</item>
         <item>Zvláštní Částečné - Olovo a All Trail aktivován v případě, že částečně odpovídat štítkům funkce</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Speciální částečné obsahuje pouze - Aktivuje se, pokud štítek funkce obsahuje výchozí štítek</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -26,7 +26,7 @@
 <!--    <string name="function_buttons">Funkce tlačítko</string>-->
     <string name="introMenu">Úvodní/Nastavení Průvodce</string>
 
-    <string name="app_description">Engine Driver – Ovladač pro váš telefon Android. Tato aplikace se může připojit k JMRI, MRC nabo DigiTrax WiThrottle serveru a může řídit vaše lokomotivy. Rychlost, směr a až 29 DCC funkcí je podporováno pro jednu až šest lokomotiv.</string>
+    <string name="app_description">Engine Driver – Ovladač pro váš telefon Android. Tato aplikace se může připojit k JMRI, DCC-EX, MRC nabo DigiTrax WiThrottle serveru a může řídit vaše lokomotivy. Rychlost, směr a až 32 DCC funkcí je podporováno pro jednu až šest lokomotiv.</string>
     <string name="app_name_intro">Úvod – Engine Driver</string>
     <string name="app_name_connect">Připojet se na server – Engine Driver</string>
     <string name="app_name_throttle">Ovladač</string>
@@ -37,8 +37,7 @@
     <string name="app_name_routes">Trasy</string>
     <string name="app_name_routes_long">Engine Driver - Trasy</string>
     <string name="app_name_routes_short">Trasy</string>
-    <string name="app_name_turnouts">Výhybky</string>
-    <string name="app_name_turnouts_long">Engine Driver - Výhybky</string>
+    <string name="app_name_turnouts">Engine Driver - Výhybky</string>
     <string name="app_name_turnouts_short">Výhybky</string>
     <string name="app_name_about">O aplikaci</string>
     <string name="app_name_functions">Výchozí nastavení funkcí</string>
@@ -48,9 +47,9 @@
     <string name="app_name_ConsistLightsEdit">Souprava světla</string>
     <string name="app_name_gamepad_test">Gamepad Test</string>
     <string name="gamepad_test_menu">\≡ Gamepad Test</string>
-    <string name="gamepad1_test">Gamepad 1 Test</string>
-    <string name="gamepad2_test">Gamepad 2 Test</string>
-    <string name="gamepad3_test">Gamepad 3 Test</string>
+    <string name="gamepad1_test">Test gamepadu 1</string>
+    <string name="gamepad2_test">Test gamepadu 2</string>
+    <string name="gamepad3_test">Test gamepadu 3</string>
     <string name="notification_title">Engine Driver běží</string>
     <string name="notification_text">Klepnutím znovu otevřete Engine Driver</string>
     <string name="host_ip">Host Name nebo Adresa</string>
@@ -62,8 +61,8 @@
     <string name="select_loco">Zadejte adresu pro získání lokomotivy</string>
     <string name="select_loco_address">Adresa</string>
     <string name="acquire_button">Získat</string>
-    <string name="roster_list">Vybrat ze záznamů evidence/soupravy</string>
-    <string name="rosterDetailsDialogTitle">"Podrobnosti evidence pro "</string>
+    <string name="roster_list">Vybrat ze záznamů evidence / soupravy</string>
+    <string name="rosterDetailsDialogTitle">Podrobnosti evidence pro</string>
     <string name="recent_engines">Vybrat z Nedávných lokomotiv</string>
     <string name="recent_consists">Vybrat z Nedávných souprav</string>
 <!--    <string name="direction">Vpřed</string>-->
@@ -88,10 +87,8 @@
     <string name="prefNumberOfDefaultFunctionLabelsForRosterTitle">Výchozí počet funkcí pro evidenci</string>
     <string name="prefNumberOfDefaultFunctionLabelsForRosterSummary">Omezení štítků funkcí zobrazené ze záznamů evidence JMRI bez štítku funkce.</string>
 
-
     <string name="consist_help">Klikněte na lokomotivu pro změnu směru s ohledem na maximální rychlost soupravy. Dlouhým stiskem na lokomotivě vyjmete tuto ze soupravy. Pokud máte hotovo tak stiskněte tlačítko Zpět.</string>
     <string name="about">O aplikaci</string>
-    <string name="web">Web</string>
 
     <string name="about_page_url">file:///android_asset/about_page-cs.html</string>
     <string name="blank_page_url">file:///android_asset/blank_page-cs.html</string>
@@ -102,8 +99,8 @@
     <string name="mrc_settings">MRC nastavení</string>
     <string name="dccesp_settings">Nastavení DCC ESP</string>
     <string name="loco">Lokomotiva:</string>
-    <string name="loco_direction_left_extra">"\u00B7F\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7F\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Vybrat</string>
     <string name="powerWillNotWorkTitle">Nebude fungovat!</string>
     <string name="powerWillNotWork">JMRI má vypnuto ovládání napájení přes WiThrottle.\nIkona napájení bude odstraněna.\nPokud bude v nastavení JMRI zapnuto ovládání napájení, tak se znovu zobrazí.</string>
@@ -117,7 +114,7 @@
     <string name="turnouts_location_label">Filtrovat podle umístění</string>
     <string name="turnouts_list_label">Výhybky (klikem na stav přepnete)</string>
     <string name="turnouts_turnout">Výhybka</string>
-    <string name="location_all">Všechna umístění</string>
+    <string name="location_all">VŠECHNA UMÍSTĚNÍ</string>
     <string name="routes">Trasy</string>
 <!--    <string name="routes_label">Ovládání tras</string>-->
     <string name="routes_direct_entry_label">Zadejte systémový název trasy</string>
@@ -147,8 +144,8 @@
     <string name="disabled">Zakázáno</string>
     <string name="yes">Ano</string>
     <string name="no">Ne</string>
-    <string name="ok">"Ok"</string>
-    <string name="cancel">"Zrušit"</string>
+    <string name="ok">Ok</string>
+    <string name="cancel">Zrušit</string>
     <string name="exit_text">Ukončit Engine Driver?</string>
     <string name="exit_title">Konec</string>
     <string name="steal_text">Adresa k ukradení %1$s?</string>
@@ -169,7 +166,7 @@
     <string name="prefSwipeUpDownSummary">Volby pro tažení prstem na obrazovce ovladače.</string>
     <string name="prefThrottleNameTitle">Název ovladače</string>
 
-    <string name="prefThrottleNameSummary">Zadejte název pro toto zařízení (bude zobrazeno v okně WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Zadejte název pro toto zařízení (bude zobrazeno v okně JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">Orientace obrazovky</string>
 
     <string name="prefThrottleOrientationSummary">Orientace obrazovky (s výjimkou Webu)</string>
@@ -216,7 +213,6 @@
     <string name="prefVolumeSpeedButtonsSpeedStepTitle">Tlačítko rychlosti velikost změny</string>
     <string name="prefVolumeSpeedButtonsSpeedStepSummary">Jak moc tlačítko hlasitosti posune rychlost ovladače.</string>
 
-
     <!--     Gamepad preferences  -->
     <string name="prefGamePadTitle">Předvolby Gamepad\/USB</string>
     <string name="prefGamePadSummary">Zvolte typ Gamepad\/USB a ostatní volby</string>
@@ -228,14 +224,11 @@
     <string name="prefGamePadFeedbackVolumeTitle">Gamepad klik na tlačítko hlasitost \%</string>
     <string name="prefGamePadFeedbackVolumeSummary">Nastavete procento hlasitost při kliku na tlačítko Gamepad.</string>
 
-
     <string name="prefGamePadSpeedButtonsRepeatTitle">Zpoždění opakování tlačítka rychlosti</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">Jak dlouho bude mezi opakováním tlačítka rychlosti na Gamepad. Menší je rychlejší.</string>
 
-
     <string name="prefGamePadSpeedButtonsSpeedStepTitle">Velikost změny tlačítka rychlosti</string>
     <string name="prefGamePadSpeedButtonsSpeedStepSummary">Jak moc poskočí rychlost ovladače na tlačítko Gamepad.</string>
-
 
     <!--    Gamepad button preferences   -->
     <string name="prefGamePadButton1Title">Gamepad akce tlačítka</string> <!-- X     -->
@@ -249,19 +242,6 @@
     <string name="prefGamePadButtonDownTitle">Gamepad DPAD Dolů akce</string>
     <string name="prefGamePadButtonLeftTitle">Gamepad DPAD Vlavo akce</string>
     <string name="prefGamePadButtonSummary">Vyberte akci která nastane při stisku tlačítka.</string>
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
 
     <!--    Gamepad button preferences   -->
 
@@ -315,17 +295,15 @@
 
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Překonání blokování funkce WiThrottle</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Použijte výchozí blokování ovladače motoru pro lokace bez rozpisu, spíše než výchozí nastavení poskytované WiThrottle</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Zobrazte výchozí popisky funkcí namísto popisků z položek seznamu.                                                               \\nToto MUSÍ být povoleno, chcete-li používat \\\'Speciální\\\' Styly podle pravidel.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Zobrazte výchozí popisky funkcí namísto popisků z položek seznamu.\nToto MUSÍ být povoleno, chcete-li používat \'Speciální\' Styly podle pravidel.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Změnšit výšku lokomotivy č.?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Použít menší tlačítko pro lokomotivu číslo, tlačítka rychlosti a směru.</string>
     <string name="prefNumOfThrottles">Počet ovladačů</string>
     <string name="prefNumOfThrottlesSummary">Zvolte kolik ovladačů chcete zobrazit.</string>
 
-    
     <string name="prefThrottleScreenTypeTitle">Typ obrazovky ovladače</string>
-    <string name="prefThrottleScreenTypeSummary">Vyberte typ obrazovky ovladače.</string>
+    <string name="prefThrottleScreenTypeSummary">Vyberte typ obrazovky ovladače.\n(Číslo v závorkách za názvem představuje počet omezení, které může rozložení podporovat.)</string>
 
-    
     <string name="prefMaximumThrottleTitle">Maximum ovladače procento</string>
 
     <string name="prefMaximumThrottleSummary">Dovolené maximum posuvníku ovladače, hodnota v %</string>
@@ -374,6 +352,8 @@
     <string name="rosterEmpty">Nemohu najít žádné záznamy v evidenci JMRI. Místo toho použijte volbu \'DCC adresa\' nebo \'Nedávné\'.</string>
 
 <!--    <string name="LocoSelectMethodQuestion">Metoda: </string>-->
+    <string name="prefDoubleBackButtonToExitTitle">Dvojité tlačítko Zpět pro ukončení?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Stisknutím tlačítka Android \'Back\' dvakrát během 3 sekund na obrazovce \'Throttle\' nebo \'Connection\' ukončíte Engine Driver</string>
     <string name="prefRosterOwnersFilterShowOptionTitle">Filtr podle vlastníka seznamu</string>
     <string name="prefRosterOwnersFilterShowOptionSummary">Zobrazit možnost filtrovat seznam podle vlastníka</string>
     <string name="prefRosterOwnersFilterDefaultOwner">Všechno</string>
@@ -409,7 +389,6 @@
     <string name="prefSocketTimeoutMsTitle">Timeout Socket</string>
     <string name="prefSocketTimeoutMsSummary">Nastavit Timeout pro čtení socket v milisekundách</string>
 
-
     <string name="prefTurnoutsTitle">Předvolby Výhybky a Trasy</string>
 <!--    <string name="prefHardwareSystemTitle">Výhybky systém připojení</string>-->
 
@@ -422,7 +401,6 @@
 
     <string name="prefScreenBrightnessDimTitle">Stmívání obrazovky hodnota v \%</string>
     <string name="prefScreenBrightnessDimSummary">Nastavení jasu pro použití stmívání obrazovky (0%-99%). Zakáže automatický nebo adaptivní jas pokud je nastaven.</string>
-
 
     <string name="logViewer">Zobrazit protokol</string>
     <string name="clearLocoList">Vymazat seznam</string>
@@ -449,7 +427,6 @@
     <string name="prefSelectedLocoIndicatorTitle">Doplňkový vybraný indikátor lokomotivy</string>
     <string name="prefSelectedLocoIndicatorSummary">Doplňkové zvýraznění tlačítko výběru lokomotivy na základě metody výběru.</string>
 
-
     <string name="prefDisableVolumeKeysTitle">Zakázat klávesy hlasitost</string>
     <string name="prefDisableVolumeKeysSummary">Zakáže hardwarové klávesy hlasitost na telefonu/tabletu které jinak mohou řídit rychlost. Poznámka: Pokud je vybráno přepíše \'Doplňkový vybraný indikátor lokomotivy\'.</string>
 
@@ -459,22 +436,12 @@
     <string name="prefSpeedButtonsRepeatTitle">Zpoždění opakování tlačítka rychlosti</string>
     <string name="prefSpeedButtonsRepeatSummary">Jak dlouho bude mezi opakováním tlačítka rychlosti. Menší je rychlejší. Nezahrnuje tlačítka Gamepad. (Viz samostatné nastavení Gamepad.)</string>
 
-
     <string name="prefSpeedButtonsSpeedStepTitle">Velikost změny tlačítka rychlosti</string>
     <string name="prefSpeedButtonsSpeedStepSummary">Jak moc poskočí rychlost ovladače na tlačítko šipka.</string>
 
-
-    
-    
-    
-    
     <string name="server_address">Adresa serveru</string>
     <string name="routes_route">Systémový název trasy</string>
-    
-    
-    
-    
-    
+
     <string name="throttle_name">Název ovladače: %1$s</string>
 
     <string name="prefShowAdvancedPreferencesTitle">Zobrazit rozšířené předvolby?</string>
@@ -490,27 +457,23 @@
     <string name="prefImportExportTitle">Import, Export nebo Reset</string>
     <string name="prefImportExportSummary">Předvolby \'Import\' nebo \'Export\' do složky \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\\\' nebo \'Reset\'.\nObjeví se bezprostředně při výběru volby.\nVarování! S \'Reset\' a \'Import\' se bude Engine Driver restartovat!\n(Můžete přenést předvolby na jiný telefon kopírováním souboru.)</string>
 
-
     <string name="prefImportExportLocoListTitle">Zahrnout seznam Nedávné lokomotivy</string>
     <string name="prefImportExportLocoListSummary">Zahrne lokomotivy ze seznamu Nedávné lokomotivy v \'Importu\' a \'Exportu\'.</string>
 
     <string name="prefAutoImportExportTitle">Automatický import/export na určitý host</string>
     <string name="prefAutoImportExportSummary">Při každém připojení na host automaticky \'Importuje\' předvolby pro tohoto host a volitelně je \'Exportuje\' při odpojení.\n(Pro stálé zpětné nastavení do známého stavu nastavte \'Automatický import pouze při připojení\' po prvním připojení nebo po ručním uložení (níže).)</string>
 
-
     <string name="prefHostImportExportTitle">Ruční import/export na určitý host</string>
     <string name="prefHostImportExportSummary">\'Import\' nebo \'Export\' vašich předvoleb pro určitého hosta do složky \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\\\'. Host musí být v seznamu Nedávných připojení.\nObjeví se bezprostředně při výběru volby.\n(Je k dispozici pouze když nejste aktuálně připojen.)</string>
 
-
     <string name="prefImportExportOverwite">Soubor \'%1$s\' již existuije. Přepsat?</string>
     <string name="prefImportExportErrorReadingList">Chyba při čtení seznamu Nedávných připojení:</string>
-    <string name="prefImportExportErrorReadingFrom">"Dovoz \'\\Android\\data\\jmri.enginedriver\\files\\ %1$s\' selhal! Zřejmě jste ještě neuložili předvolby pro tento host.</string>
+    <string name="prefImportExportErrorReadingFrom">Dovoz \'\\Android\\data\\jmri.enginedriver\\files\\ %1$s\' selhal! Zřejmě jste ještě neuložili předvolby pro tento host.</string>
     <string name="prefImportExportErrorNotConnected">Není připojení na tento host.</string>
 
 <!--    <string name="prefImportServerManualTitle">Import z aktuálního Serveru (Ručně)</string>-->
 <!--    <string name="prefImportServerManualSummary">Soubor Serveru pro \'Import\' nastaví předvolby z aktuálně připojeného serveru.\nSoubor musí být v adresáři \'\\Android\\data\\jmri.enginedriver\\files\\\' serveru a Web Server musí být spuštěn.\nVarování: Import se spustí okamžitě při ukládání těchto předvoleb.</string>-->
 
-    
     <string name="prefImportServerAutoTitle">Automaticky importovat ze všech serverů</string>
     <string name="prefImportServerAutoSummary">Automaticky importuje předvolby ze všech připojených serverů.\nPokud je soubor \'[jmri railroad base folder]\\prefs\\engine_driver\\auto_preferences.ed\' na serveru a pokud je novější než poslední kontrola.)</string>
 
@@ -530,6 +493,9 @@
     <string name="prefGamepadTestEnforceTestingTitle">Vynucení testování Gamepad</string>
     <string name="prefGamepadTestEnforceTestingSummary">Otestovat každý Gamepad pokaždé když je připojen.</string>
 
+    <string name="prefHeartbeatResponseFactorTitle">Faktor odezvy srdečního tepu</string>
+    <string name="prefHeartbeatResponseFactorSummary">Procento periody srdečního tepu, kdy se má srdeční tep odeslat (50 %–90 %). Vstoupí v platnost při příštím připojení.</string>
+    <string name="server">Server</string>
     <string name="prefGamepadTestEnforceTestingSimpleTitle">Použít jednoduchý Test</string>
     <string name="prefGamepadTestEnforceTestingSimpleSummary">Pouze test že můžete snížit rychlost.</string>
 
@@ -553,8 +519,7 @@
     <string name="prefTickMarksOnSlidersSummary">Zobrazit nebo skrýt zašktnuté značky na pozadí posuvníků rychlosti.</string>
 
     <string name="prefThemeTitle">Téma/Styl</string>
-    <string name="prefThemeSummary">Téma aplikace. Varování! Engine Driver se ihned restartuje!</string>
-
+    <string name="prefThemeSummary">Téma aplikace.</string>
 
     <string name="prefHideDemoServerTitle">Skrýt Demo Server</string>
     <string name="prefHideDemoServerSummary">Skryje Demo Server \'jmri.mstevetodd.com\' v seznamu připojení.</string>
@@ -562,87 +527,49 @@
 <!--    <string name="prefDirectionButtonsTitle">Štítka tlačítka směru</string>-->
 <!--    <string name="prefDirectionButtonsSummary">Štítky pro všechna tlačítka směru.</string>-->
 
-
     <string name="prefDirectionButtonLongPressDelayTitle">Směrová tlačítka zpoždení dlouhého stisknutí</string>
     <string name="prefDirectionButtonLongPressDelaySummary">Kolik milisekund představuje dlouhé stisknutí směrového tlačítka.</string>
-
 
     <string name="prefAccelerometerTitle">Předvolby akcelerometru</string>
     <string name="prefAccelerometerSummary">Volby pro pohyb zařízení na stránce ovladače</string>
     <string name="prefAccelerometerShakeTitle">Akce třepání</string>
     <string name="prefAccelerometerShakeSummary">Volby pro třepání zařízením.</string>
 
-
     <string name="prefAccelerometerShakeThresholdTitle">Práh třepání</string>
     <string name="prefAccelerometerShakeThresholdSummary">Práh při kterém se bude třepání registrovat. (1,5&#8211;3,5) Nižší hodnota bude reagovat na jemnější akci.\nVyžaduje restart Engine Driver po změně, aby se změny projevily.</string>
 
-
     <string name="prefLocaleTitle">Lokalizace</string>
     <string name="prefLocaleSummary">Vyberte jazyk který chcete použít pro tuto aplikaci.</string>
-
 
     <string name="prefLimitSpeedButtonPreferencesTitle">Předvolby tlačítka \'Omezení rychlosti\'</string>
     <string name="prefLimitSpeedButtonTitle">Zobrazit tlačítko \'Omezení rychlosti\'</string>
     <string name="prefLimitSpeedButtonSummary">Zobrazit tlačítko pro dočasné omezení maximální rychlosti na jednotlivém Ovladači.</string>
 
+    <string name="prefPauseAlternateButtonTitle">Alternativní tlačítko \'Pozastavit\'</string>
+    <string name="prefPauseAlternateButtonSummary">Zobrazit alternativní tlačítko \'Pozastavit\' poblíž tlačítka \'Stop\'. (Pouze vertikální rozvržení)</string>
     <string name="prefLimitSpeedPercentTitle">Tlačítko \'Omezení rychlosti\' \%</string>
     <string name="prefLimitSpeedPercentSummary">Nastavit \% Ovladače, na které bude dočasně omezena rychlost.</string>
-    
 
     <string name="prefSwitchingThrottleSliderDeadZoneTitle">Přepínání mrtvé zóny Ovladače</string>
     <string name="prefSwitchingThrottleSliderDeadZoneSummary">Nastavit velikost mrtvé zóny na posuvníku přepínání Ovladače obrazovky</string>
 
-    
     <string name="limitSpeedButtonLabel">Omezení rychlosti</string>
 
     <string name="functionButton00DefaultValue">Světlo</string>
     <string name="functionButton01DefaultValue">Zvon</string>
     <string name="functionButton02DefaultValue">Houkačka</string>
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     <!--    Gamepad test page -->
     <string name="gamepadTestButtonLabelDpadUp">Nahoru</string>
     <string name="gamepadTestButtonLabelDpadDown">Dolů</string>
     <string name="gamepadTestButtonLabelDpadLeft">Vlavo</string>
     <string name="gamepadTestButtonLabelDpadRight">Vpravo</string>
     <string name="gamepadTestButtonLabelButtonX">C | X [iOS]</string>
-    <string name="gamepadTestButtonLabelButtonY">D | Y [Triangle]</string>
-    <string name="gamepadTestButtonLabelButtonA">A [Cross]</string>
+    <string name="gamepadTestButtonLabelButtonY">D | Y [trojúhelník]</string>
+    <string name="gamepadTestButtonLabelButtonA">A [kříž]</string>
     <string name="gamepadTestButtonLabelButtonB">B [@]</string>
-    <string name="gamepadTestButtonLabelButtonStart">Start | Enter</string>
-    <string name="gamepadTestButtonLabelButtonEnter">Select | Enter</string>
+    <string name="gamepadTestButtonLabelButtonStart">Start | Vstupte</string>
+    <string name="gamepadTestButtonLabelButtonEnter">Vyberte | Vstupte</string>
     <string name="gamepadTestButtonLabelButtonLeftShoulder">Levé rameno</string>
     <string name="gamepadTestButtonLabelButtonRightShoulder">Pravé rameno</string>
     <string name="gamepadTestButtonLabelButtonLeftTrigger">Levý spouštěč</string>
@@ -659,21 +586,21 @@
 <!--    <string name="gamepadTestDeviceName">BT:</string>-->
     <string name="gamepadTestHelp">Srolujte dolů abyste viděli úplné pokyny…\n\nStiskněte VŠECHNY Dpad A čtyři primární tlačítka nebo Gamepad NEBUDE PRACOVAT.\n\nPokud nemůžete aktivovat všechny tlačítka, změňte režim Gamepad (přečtěte si pokyny k vašemu Gamepad) nebo zkuste jiný typ Gamepad (výše uvedené).\n\n\'ZPĚT\' nebo \'ZRUŠIT\' ukončí test ale Gamepad NEBUDE PRACOVAT.\n\'PŘESKOČIT\' nebo třikrát stisk tlačítka Gamepad \'Snížit rychlost\' vynutí přeskočení testu, i když Gamepad nepracuje správně.\n\'RESET\' přinutí EngineDriver se domnívat že žádný Gamepad dosud nebyl použit.\nJestliže je vybrán \'jednoduchý\' test tak jeden stisk tlačítka \'Snížit rychlost\' přeskočí test.\nPoužijte \'Test Gamepad\' volbu nabídky pro návrat na tuto stránku.</string>
     <string name="gamepadTestHelpNonForced">Pokud nemůžete aktivovat všechny tlačítka změňte režim Gamepad (přečtěte si pokyny k vašemu Gamepad) nebo zkuste jiný typ Gamepad (výše uvedené).\nZ obrazovky ovladače můžete být požádán o opakování testu Gamepad pokud ho použijete poprvé.</string>
-    <string name="gamepadTestIncomplete">"Test nedokončen"</string>
-    <string name="gamepadTestComplete">"Test dokončen"</string>
-    <string name="gamepadTestCompleteToast">"Gamepad test dokončen úspěšně"</string>
-    <string name="gamepadTestInvalidKeycode">"Neplatný kód klávesy pro tento režim"</string>
+    <string name="gamepadTestIncomplete">Test nedokončen</string>
+    <string name="gamepadTestComplete">Test dokončen</string>
+    <string name="gamepadTestCompleteToast">Gamepad test dokončen úspěšně</string>
+    <string name="gamepadTestInvalidKeycode">Neplatný kód klávesy pro tento režim</string>
 
-    <string name="gamepadTestReset">"Reset"</string>
-    <string name="gamepadTestCancel">"Zrušit"</string>
-    <string name="gamepadTestCancelNonForced">"Uzavřít"</string>
-    <string name="gamepadTestSkip">"Přeskočit"</string>
+    <string name="gamepadTestReset">Reset</string>
+    <string name="gamepadTestCancel">Zrušit</string>
+    <string name="gamepadTestCancelNonForced">Uzavřít</string>
+    <string name="gamepadTestSkip">Přeskočit</string>
 
 
-    <string name="gamepadTestKeyCodesUpCode">"Up"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Dn"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Lf"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Rt"</string>
+    <string name="gamepadTestKeyCodesUpCode">Up</string>
+    <string name="gamepadTestKeyCodesDownCode">Dn</string>
+    <string name="gamepadTestKeyCodesLeftCode">Lf</string>
+    <string name="gamepadTestKeyCodesRightCode">Rt</string>
 
     <!--    Gamepad test page -->
 
@@ -681,6 +608,8 @@
     <string name="prefGamepadTestNowSummary">Umožňuje potvrdit, že zvolené nastavení pracuje správně.\nTestovací stránka se při výběru OKAMŽITĚ spustí.</string>
 
     <!--    Toast messages for the ThreadedApplication -->
+    <string name="toastWaitingForConnection">Časový limit čekání na zprávu WiThrottle \'VN\' od %1$s:%2$s. Odpojování</string>
+    <string name="toastWaitingForConnectionDccEx">Časový limit čekání na zprávu DCC-EX \'iDCCEX...\' od %1$s:%2$s. Odpojování</string>
     <string name="toastThreadedAppNoLocalIp">Nebyla nalezena žádná lokální IP adresa.\nZkontrolujte WiFi připojení.</string>
     <string name="toastThreadedAppErrorCreatingWiThrottle">Chyba při vytváření WiThrottle posluchače zeroconf: IOException:\n%1$s</string>
     <string name="toastThreadedAppWiThrottleNotSupported">WiThrottle verze %1$s není podporovaná.</string>
@@ -746,7 +675,7 @@
     <string name="toastPreferencesImportServerAutoSucceeded">Automatický Import předvoleb ze serveru byl úspěšný. (%1$s)</string>
 
     <!--    Toast messages for the Routes Activity -->
-<!--    <string name="toastRoutesCommandSent">"Příkaz odeslaný k nastavení trasy "</string>-->
+<!--    <string name="toastRoutesCommandSent">Příkaz odeslaný k nastavení trasy </string>-->
 
     <!--    Toast messages for the Import/Export -->
     <string name="toastImportExportExportSucceeded">Export předvolby do \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' byl úspěšný.</string>
@@ -798,10 +727,8 @@
     <string name="prefTtsWhenTitle">Hlasová odpověď</string>
     <string name="prefTtsWhenSummary">Kdy má událost klávesy a akce být řečena pomocí převodu Textu na řeč (TTS).</string>
 
-
     <string name="prefTtsThrottleResponseTitle">Gamepad změna ovladače</string>
     <string name="prefTtsThrottleResponseSummary">Když vyberete na Gamepad jiný ovladač.</string>
-
 
     <string name="prefTtsGamepadTestTitle">Test Gamepad</string>
     <string name="prefTtsGamepadTestSummary">Když je spuštěna testovací stránka Gamepad.</string>
@@ -814,7 +741,7 @@
     <string name="TtsLoco">Lokomotiva</string>
     <string name="TtsSpeed">Rychlost</string>
     <string name="TtsTargetSpeed">Cílová rychlost</string>
-    <string name="TtsGamepadTest">Gamepad test</string>
+    <string name="TtsGamepadTest">Test gamepadu</string>
     <string name="TtsGamepadTestComplete">Test hotový</string>
     <string name="TtsGamepadTestSkipped">Test přeskočen</string>
     <string name="TtsGamepadTestFail">Test zrušen</string>
@@ -843,6 +770,7 @@
     <string name="functionButtonLookForRear">ZADNÍ</string>
 
     <string name="throttleSwitchAction">Přepnout rozložení obrazovky Ovladače</string>
+    <string name="toastAddressExceedsMax">Adresa \'%1$s\' překračuje maximální podporovanou hodnotu (\'%2$s\')</string>
     <string name="flashlightAction">Svítilna</string>
     <string name="flashlightStateOn">Svítilna Zapnuta</string>
     <string name="flashlightStateOff">Svítilna Vypnuta</string>
@@ -865,21 +793,14 @@
     <string name="prefConsistFollowRuleStyleTitle">Funkce soupravy – následování pravidel stylu</string>
     <string name="prefConsistFollowRuleStyleSummary">Který styl pravidel bude následován v soupravě pokud je stisknuté tlačítko.</string>
 
-
     <string name="prefConsistFollowTitle">Funkce soupravy Následování předvoleb</string>
     <string name="prefConsistFollowSummary">Volby pro to jak se budou chovat funkce v soupravě.</string>
 
     <string name="prefConsistFollowString1DefaultValue">SVĚTLA</string>
     <string name="prefConsistFollowString2DefaultValue">PÍŠŤALA,HOUKAČKA,ZVON</string>
-    <string name="prefConsistFollowStringOtherDefaultValue" />
-    
-    
-    <string name="prefConsistFollowActionOtherDefaultValue">přípřež</string>
 
     <string name="prefConsistFollowDefaultActionTitle">Jsou-li všechny zápasy Fail akce</string>
     <string name="prefConsistFollowDefaultActionSummary">Která z lokomotiv by měla reagovat na tlačítko funkce pokud žádné z níže uvedených pravidel není splněno.</string>
-
-
 
     <string name="prefConsistFollowString1Title">Světlomety konkrétní řetězec 1</string>
     <string name="prefConsistFollowString1Summary">Čárkou oddělený řetězec(ce) pro vyhledání mezi štítky funkcí lokomotiv v soupravě, které obsahují funkci \'Světla\' (obvykle F0).</string>
@@ -913,10 +834,8 @@
     <string name="prefKidsTimerTitle">Časově omezený provoz</string>
     <string name="prefKidsTimerSummary">Omezte dobu, po kterou poběží lokomotiva, např. každé dítě dostane stejné množství času.</string>
 
-
     <string name="prefKidsTimerRestartPasswordTitle">Heslo pro obnovu</string>
     <string name="prefKidsTimerRestartPasswordSummary">Heslo, které obnoví časovač se současnými nastaveními.</string>
-
 
     <string name="prefKidsTimerResetPasswordTitle">Heslo pro obnovu/zákaz</string>
     <string name="prefKidsTimerResetPasswordSummary">Heslo pro obnovu/zákaz nastavení časovače.</string>
@@ -953,7 +872,6 @@
     <string name="permissionsRetryButton">Opakovat</string>
     <string name="permissionsRequestTitle">Oprávnění vyžadováno</string>
     <string name="permissionsRetryTitle">Oprávnění odmítnuta</string>
-
 
     <!-- Introduction / Setup Wizard -->
 
@@ -1036,7 +954,6 @@
     <string name="prefBackgroundImagePositionTitle">Pozice obrázku pozadí</string>
     <string name="prefBackgroundImagePositionSummary">Vyberte jak bude obrázek pozadí umístěn na obrazovce.</string>
 
-    
     <string name="prefThrottleSwitchButtonPreferencesTitle">Předvolby tlačítka přepínání rozvržení</string>
     <string name="prefThrottleSwitchButtonTitle">Tlačíto přepínání rozvržení</string>
     <string name="prefThrottleSwitchButtonSummary">Zobrazit tlačítko přepínání rozvržení ovladače na obrazovce ovladače a umožnit tak rychlou změnu rozvržení ovladače.</string>
@@ -1044,10 +961,8 @@
     <string name="prefThrottleSwitchOption1Title"> Přepínač rozvržení Rozvržení první obrazovky</string>
     <string name="prefThrottleSwitchOption1Summary">Tlačítko přepínání rozvržení přepne mezi tímto rozvržením ovladače a dalším předvoleným.</string>
 
-    
     <string name="prefThrottleSwitchOption2Title">Přepínač rozvržení Rozvržení druhé obrazovky</string>
     <string name="prefThrottleSwitchOption2Summary">Tlačítko přepínání rozvržení přepne mezi předchozím předvoleným a tímto.</string>
-
 
     <string name="prefSemiRealisticThrottleTitle">Polorealistické předvolby plynu</string>
     <string name="prefSemiRealisticThrottleSummary">Předvolby specifické pro obrazovku Semi-Realistic Throttle</string>
@@ -1055,7 +970,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Jak dlouho mezi opakováním kroku rychlosti zrychlení (v milisekundách). Menší je rychlejší.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Deceleration Speed ​​Step Repeat Delay</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Jak dlouho mezi opakováním kroku rychlosti zpomalení (v milisekundách). Menší je rychlejší.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Rychlostní krok "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Rychlostní krok </string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Jak moc skutečná rychlost vyskočí každým krokem na cílovou rychlost.  Větší je rychlejší.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Zářezy plynu</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Nastavte plyn v procentech nebo o určitý počet kroků/zářezů</string>
@@ -1063,7 +978,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Upravte počet kroků na jezdci brzdy</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Ohodnoťte osvěžení vzduchových brzd</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Upravte rychlost, jakou se budou vzduchové brzdy obnovovat/doplňovat (v milisekundách). Menší je rychlejší.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Počet zatížení "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Počet zatížení </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Upravte počet kroků na posuvníku zatížení</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Násobitel procenta zatížení</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Upravte účinek jezdce zatížení na změny rychlosti. >100 % = větší zatížení</string>
@@ -1090,13 +1005,13 @@
     <string name="functionConsistSettings">Skládat nastavení funkcí</string>
     <string name="functionConsistColumnLabel">Označení</string>
     <string name="functionConsistColumnLocos">Lokomotiv (y)</string>
-    <string name="functionConsistColumnLatching">latching</string>
+    <string name="functionConsistColumnLatching">Západka</string>
     <string name="prefFunctionConsistLatchingDefaultValue">žádný</string>
     <string name="prefFunctionConsistLatchingLightBellDefaultValue">aretací</string>
     <string name="prefFunctionConsistLocosDefaultValue">Vést</string>
     <string name="functionConsistHelpText">Používá se pouze pro \'Speciální\\‘ skládat volby funkce následující + DCC-EX. Zvolit, jak bude text každé funkce hledali v popisky funkčních pro každou lokomotivu v sestavě.</string>
     <string name="functionConsistHeader">Skládat Funkce Akce</string>
-    <string name="app_name_consist_functions">Skládat nastavení funkcí - strojvedoucí</string>
+    <string name="app_name_consist_functions">Skládat nastavení funkcí</string>
     <string name="prefShowTimeOnLogEntryTitle">Zobrazovat časová razítka na Log</string>
     <string name="prefShowTimeOnLogEntrySummary">Ukázat Datum Čas pro každou položku na obrazovce protokolu.</string>
     <string name="prefVerticalStopButtonMarginTitle">Tlačítko Stop vertikální okraje</string>
@@ -1131,6 +1046,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Možnosti ohání ke změně obrazovek</string>
     <string name="prefHapticFeedbackDurationTitle">Hmatová odezva Trvání</string>
     <string name="prefHapticFeedbackDurationSummary">Trvání každého vibrací (v milisekundách).</string>
+    <string name="prefHapticFeedbackButtonsTitle">Hmatová zpětná vazba při stisknutí tlačítka</string>
+    <string name="prefHapticFeedbackButtonsSummary">Haptická zpětná vazba (vibrace) při stisku tlačítka.</string>
     <string name="LocoSelectMethodIDNGo">Vyžádat Loco ID</string>
     <string name="idngo_label">Vyžádat Loco ID</string>
     <string name="idngo_button">Vyžádat Loco ID</string>
@@ -1161,6 +1078,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Zpoždění (hybnost) za krok Změna milisekund (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">V telefonu hybnosti</string>
     <string name="deviceSoundsMuteButton">Ztlumit</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 a F2 také aktivují zvonek a klakson IPLS</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 a F2 aktivují zvonek a klakson?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Skryjte tlačítko ztlumení IPLS na plynech</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Tlačítko skrýt ztlumení</string>
     <string name="prefDeviceSoundsButtonSummary">Zobrazte tlačítko ACCE BUNKU pro změnu možností v telefonu Loco Sounds</string>
     <string name="prefDeviceSoundsButtonTitle">V telefonu zvuky</string>
     <string name="deviceSoundsMenu">Loco Sounds</string>
@@ -1175,7 +1096,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Tlačítko Bell je momentální. (Zabezpečení, pokud není zaškrtnuto.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bell Tlačítko Latching / Momentary</string>
 <!--    <string name="permissionsReadLegacyFiles">Ovladač motoru potřebuje oprávnění pro ukládání dat pro nastavení starší (staré umístění).</string>-->
-    <string name="permissionsReadPhoneState">Ovladač motoru potřebuje telefonní oprávnění k pozastavení operací při volání.</string>
+    <string name="permissionsReadPhoneState">Engine Driver potřebuje oprávnění PHONE pro pozastavení provozu během hovoru.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Další preference</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Další v telefonu Loco Sounds Preferences</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Zuny Loco Step bude hrát až do jejich konce při změně kroku. Částka hybnosti (výše) se stává minimálním časem.</string>
@@ -1207,10 +1128,10 @@
     <string name="usingProtocolDCCEX">Pomocí protokolu DCC-Ex. \nZrušte zaškrtnutí zaškrtnutí „Nativní příkazy DCC-EX“ preference k použití protokolu Withrottle.</string>
     <string name="prefDccexConnectionOptionSummary">Zobrazit možnost přepínat mezi protokoly Withrottle a DCC-EX-Ex-na obrazovce připojení.</string>
     <string name="prefDccexConnectionOptionTitle">Zobrazit možnost protokolu</string>
-    <string name="prefActionBarShowDccExButtonSummary">Zobrazit tlačítko v akčním panelu pro přístup na obrazovku ECC-EX. (Pouze pro nativní připojení DCC-EX.)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Zobrazit tlačítko v akčním panelu pro přístup na obrazovku DCC-EX. (Pouze pro nativní připojení DCC-EX.)</string>
     <string name="prefActionBarShowDccExButtonTitle">Tlačítko DCC-EX?</string>
     <string name="DCCEXactionTypeLabel">Akce</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(vyloučit \'&lt;\' a \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(vyloučit \'&lt;\' a \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Průhledná</string>
     <string name="DccexConnectionOptionTitle">Protokol připojení</string>
     <string name="DccexFailed">Akce selhala</string>
@@ -1222,10 +1143,10 @@
     <string name="DccexSendCommandButtonLabel">Poslat</string>
     <string name="witActionTypeLabel">Akce</string>
     <string name="witWriteAddressLabel">Adresa DCC</string>
-    <string name="witPomWarning">Poznámky: - Toto nebude fungovat na některých systémech DCC. - Změna adresy lokomotivy je zabráněna - CV 1, 17 &amp; 18 a bit 5 CV 29. \\n\\nPoužívejte opatrně.</string>
+    <string name="witPomWarning">Poznámky: - Toto nebude fungovat na některých systémech DCC. - Změna adresy lokomotivy je zabráněna - CV 1, 17 &amp; 18 a bit 5 CV 29. \n\nPoužívejte opatrně.</string>
     <string name="witPomMaxValueWarning">Hodnota \'%1$s\' překračuje maximální podporovanou hodnotu (\'%2$s\')</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">Běžné CMD</string>
+    <string name="DCCEXcommonCommandsLabel">Běžné CMD</string>
     <string name="DCCEXsetTrackButtonLabel">Soubor</string>
     <string name="DccexSucceeded">Akce uspěla</string>
     <string name="DCCEXturnoutClosed">ZAVŘENO</string>
@@ -1265,5 +1186,22 @@
     <string name="order">Seřadit</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Vždy zobrazovat Hodit/Zavřít?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">U výhybek vždy zobrazujte tlačítka Hod i Zavřít, nikdy ne tlačítko Přepnout.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Připojte se</string>
+
+    <string name="air_reservoir">Vzduchová nádrž</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Typ dekodérové ​​brzdy</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Aktivujte brzdové funkce na dekodéru</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Nízké funkční číslo ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU – kterou funkci dekodéru aktivovat při nízké hodnotě brzdění</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Číslo střední funkce ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU – kterou funkci dekodéru aktivovat při střední hodnotě brzdění</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">ESU vysoké funkční číslo</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU – kterou funkci dekodéru aktivovat při vysoké hodnotě brzdění</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Nízká hodnota brzdění ESU (procenta)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU - Jaká procentuální brzda pro aktivaci nízkého čísla funkce</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">ESU střední hodnota brzdy (procenta)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU - Jaká procentuální brzda pro aktivaci středního čísla funkce</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Vysoká hodnota brzd ESU (procenta)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU - Jaká procentuální brzda pro aktivaci vysokého funkčního čísla</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-de-rAT/strings.xml
+++ b/EngineDriver/src/main/res/values-de-rAT/strings.xml
@@ -25,7 +25,6 @@
     <string name="routes">Fahrstrassen</string>
 <!--    <string name="routes_label">Fahrstrassen steuern</string>-->
     <string name="routes_direct_entry_label">Systemname für Fahrstrasse eingeben</string>
-
     <string name="routes_list_label">Fahrstrasse (anklicken zum Aktivieren)</string>
 
     <string name="prefThrottleOrientationSummary" tools:ignore="Typos">Bildschirmorientierung (ausser Web)</string>
@@ -37,12 +36,10 @@
 
     <string name="prefGamePadFeedbackVolumeTitle">Klickausmass in \% für Gamepad Knopf</string>
     <string name="prefGamePadFeedbackVolumeSummary">Setze das Prozentausmass für Klicks mit dem Gamepad Knopf</string>
-
     <string name="prefGamePadSpeedButtonsSpeedStepTitle" tools:ignore="Typos">Ausmass der Veränderung durch Geschwindigkeitsknöpfe</string>
 
     <string name="prefSwipeThroughRoutesTitle">Wischen durch Fahrstrassen?</string>
     <string name="prefSwipeThroughRoutesSummary" tools:ignore="Typos">Fahrstrassenanzeige einschliessen beim Wischen zwischen Anzeigen.</string>
-
     <string name="prefSwipeThroughTurnoutsSummary" tools:ignore="Typos">Weichenanzeige einschliessen beim Wischen zwischen Anzeigen.</string>
 
     <string name="prefHideIfNoUserNameSummary">Weiche/Fahrstrasse aus Liste weglassen wenn der Benutzername leer ist.</string>
@@ -61,19 +58,18 @@
     <string name="prefHostImportExportSummary">\'Import\' oder \'Export\' deiner Voreinstellungen für einen spezifischen Host in das \'\\engine_driver\' folder to \'\\Android\\data\\jmri.enginedriver\\files\' Verzeichnis. Der Host muss in deiner Liste Letzte Verbindungen sein.\nWird SOFORT nach Auswahl der Option ausgeführt.\n(Nur verfügbar wenn momentan nicht verbunden.)</string>
 
     <string name="gamepadTestHelp">Nach unten rollen um eine vollständige Anleitung zu sehen…\n\nDrücke ALLE Dpad UND vier primäre Knöpfe oder das Gamepad WIRD NICHT FUNKTIONIEREN.\n\nWenn nicht alle Knöpfe aktiviert werden können, dann wechsle den Gamepad Modus (siehe Anleitung zu deinem Gamepad) oder versuche ein anderer Gamepad Typ (oben).\n\n\'ZURÜCK\' oder \'ABBRECHEN\' wird den Test beenden, aber das Gamepad WIRD NICHT FUNKTIONIEREN.\n\'ÜBERSPRINGEN\', oder dreimaliges Drücken des Gamepad Knopfes \'Geschwindigkeit verringern\' erzwingt einen guten Test, selbst wenn das Gamepad nicht einwandfrei funktioniert.\n\'ZURÜCKSETZEN\' lässt ED annehmen, dass bisher keine Gamepads benutzt wurden.\nWenn für den Test \'einfach\' gewählt wurde, wird einmaliges Drücken des Knopfes \'Geschwindigkeit verringern\' den Test überspringen.\n\nVerwende die \'Gamepad Test n\' Menüoptionen, um zu dieser Seite zurück zu kommen.</string>
-
-    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">"Schliessen"</string>
-
+    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">Schliessen</string>
     <string name="prefGamepadTestNowSummary">Erlaubt dir zu bestätigen, dass die gewählte Einstellung korrekt funktioniert.\nTest Seite wird SOFORT bei Auswahl gestartet.</string>
 
     <string name="toastShakeWebViewUnavailable">Web Anzeige muss zuerst in den Voreinstellungen ermöglicht werden.</string>
 
     <string name="toastPreferencesOutsideLimits" tools:ignore="Typos">Eingegebener Wert liegt ausserhalb der Grenzen (%1$s-%2$s). Zurücksetzen auf %3$s.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Befehl geschickt zum Stellen der Fahrstrasse "</string>-->
+<!--    <string name="toastRoutesCommandSent">Befehl geschickt zum Stellen der Fahrstrasse </string>-->
 
     <string name="prefFlashlightSummary">Zeige Knopf für Taschenlampe in Fahrregler-, Weichen- und Fahrstrassenanzeigen?</string>
 
     <string name="logviewerClose" tools:ignore="Typos">Schliessen</string>
+    <string name="air_reservoir">Luftreservoir</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-de-rCH/strings.xml
+++ b/EngineDriver/src/main/res/values-de-rCH/strings.xml
@@ -61,16 +61,14 @@
     <string name="prefHostImportExportSummary">\'Import\' oder \'Export\' deiner Voreinstellungen für einen spezifischen Host in das \'\\Android\\data\\jmri.enginedriver\\files\\\' Verzeichnis. Der Host muss in deiner Liste Letzte Verbindungen sein.\nWird SOFORT nach Auswahl der Option ausgeführt.\n(Nur verfügbar wenn momentan nicht verbunden.)</string>
 
     <string name="gamepadTestHelp">Nach unten rollen um eine vollständige Anleitung zu sehen…\n\nDrücke ALLE Dpad UND vier primäre Knöpfe oder das Gamepad WIRD NICHT FUNKTIONIEREN.\n\nWenn nicht alle Knöpfe aktiviert werden können, dann wechsle den Gamepad Modus (siehe Anleitung zu deinem Gamepad) oder versuche ein anderer Gamepad Typ (oben).\n\n\'ZURÜCK\' oder \'ABBRECHEN\' wird den Test beenden, aber das Gamepad WIRD NICHT FUNKTIONIEREN.\n\'ÜBERSPRINGEN\', oder dreimaliges Drücken des Gamepad Knopfes \'Geschwindigkeit verringern\' erzwingt einen guten Test, selbst wenn das Gamepad nicht einwandfrei funktioniert.\n\'ZURÜCKSETZEN\' lässt ED annehmen, dass bisher keine Gamepads benutzt wurden.\nWenn für den Test \'einfach\' gewählt wurde, wird einmaliges Drücken des Knopfes \'Geschwindigkeit verringern\' den Test überspringen.\n\nVerwende die \'Gamepad Test n\' Menüoptionen, um zu dieser Seite zurück zu kommen.</string>
-
-    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">"Schliessen"</string>
-
+    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">Schliessen</string>
     <string name="prefGamepadTestNowSummary">Erlaubt dir zu bestätigen, dass die gewählte Einstellung korrekt funktioniert.\nTest Seite wird SOFORT bei Auswahl gestartet.</string>
 
     <string name="toastShakeWebViewUnavailable">Web Anzeige muss zuerst in den Voreinstellungen ermöglicht werden.</string>
 
     <string name="toastPreferencesOutsideLimits" tools:ignore="Typos">Eingegebener Wert liegt ausserhalb der Grenzen (%1$s-%2$s). Zurücksetzen auf %3$s.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Befehl geschickt zum Stellen der Fahrstrasse "</string>-->
+<!--    <string name="toastRoutesCommandSent">Befehl geschickt zum Stellen der Fahrstrasse </string>-->
 
     <string name="prefFlashlightSummary">Zeige Knopf für Taschenlampe in Fahrregler-, Weichen- und Fahrstrassenanzeigen?</string>
 

--- a/EngineDriver/src/main/res/values-de-rLI/strings.xml
+++ b/EngineDriver/src/main/res/values-de-rLI/strings.xml
@@ -37,12 +37,10 @@
 
     <string name="prefGamePadFeedbackVolumeTitle">Klickausmass in \% für Gamepad Knopf</string>
     <string name="prefGamePadFeedbackVolumeSummary">Setze das Prozentausmass für Klicks mit dem Gamepad Knopf</string>
-
     <string name="prefGamePadSpeedButtonsSpeedStepTitle" tools:ignore="Typos">Ausmass der Veränderung durch Geschwindigkeitsknöpfe</string>
 
     <string name="prefSwipeThroughRoutesTitle">Wischen durch Fahrstrassen?</string>
     <string name="prefSwipeThroughRoutesSummary" tools:ignore="Typos">Fahrstrassenanzeige einschliessen beim Wischen zwischen Anzeigen.</string>
-
     <string name="prefSwipeThroughTurnoutsSummary" tools:ignore="Typos">Weichenanzeige einschliessen beim Wischen zwischen Anzeigen.</string>
 
     <string name="prefHideIfNoUserNameSummary">Weiche/Fahrstrasse aus Liste weglassen wenn der Benutzername leer ist.</string>
@@ -61,16 +59,14 @@
     <string name="prefHostImportExportSummary">\'Import\' oder \'Export\' deiner Voreinstellungen für einen spezifischen Host in das \'\\Android\\data\\jmri.enginedriver\\files\\\' Verzeichnis. Der Host muss in deiner Liste Letzte Verbindungen sein.\nWird SOFORT nach Auswahl der Option ausgeführt.\n(Nur verfügbar wenn momentan nicht verbunden.)</string>
 
     <string name="gamepadTestHelp">Nach unten rollen um eine vollständige Anleitung zu sehen…\n\nDrücke ALLE Dpad UND vier primäre Knöpfe oder das Gamepad WIRD NICHT FUNKTIONIEREN.\n\nWenn nicht alle Knöpfe aktiviert werden können, dann wechsle den Gamepad Modus (siehe Anleitung zu deinem Gamepad) oder versuche ein anderer Gamepad Typ (oben).\n\n\'ZURÜCK\' oder \'ABBRECHEN\' wird den Test beenden, aber das Gamepad WIRD NICHT FUNKTIONIEREN.\n\'ÜBERSPRINGEN\', oder dreimaliges Drücken des Gamepad Knopfes \'Geschwindigkeit verringern\' erzwingt einen guten Test, selbst wenn das Gamepad nicht einwandfrei funktioniert.\n\'ZURÜCKSETZEN\' lässt ED annehmen, dass bisher keine Gamepads benutzt wurden.\nWenn für den Test \'einfach\' gewählt wurde, wird einmaliges Drücken des Knopfes \'Geschwindigkeit verringern\' den Test überspringen.\n\nVerwende die \'Gamepad Test n\' Menüoptionen, um zu dieser Seite zurück zu kommen.</string>
-
-    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">"Schliessen"</string>
-
+    <string name="gamepadTestCancelNonForced" tools:ignore="Typos">Schliessen</string>
     <string name="prefGamepadTestNowSummary">Erlaubt dir zu bestätigen, dass die gewählte Einstellung korrekt funktioniert.\nTest Seite wird SOFORT bei Auswahl gestartet.</string>
 
     <string name="toastShakeWebViewUnavailable">Web Anzeige muss zuerst in den Voreinstellungen ermöglicht werden.</string>
 
     <string name="toastPreferencesOutsideLimits" tools:ignore="Typos">Eingegebener Wert liegt ausserhalb der Grenzen (%1$s-%2$s). Zurücksetzen auf %3$s.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Befehl geschickt zum Stellen der Fahrstrasse "</string>-->
+<!--    <string name="toastRoutesCommandSent">Befehl geschickt zum Stellen der Fahrstrasse </string>-->
 
     <string name="prefFlashlightSummary">Zeige Knopf für Taschenlampe in Fahrregler-, Weichen- und Fahrstrassenanzeigen?</string>
 

--- a/EngineDriver/src/main/res/values-de/arrays.xml
+++ b/EngineDriver/src/main/res/values-de/arrays.xml
@@ -66,11 +66,11 @@
         <item>Switching &#8211; (2)</item>
         <item>Switching &#8211; Left (1)</item>
         <item>Switching &#8211; Rechts (1)</item>
-        <item>Switching &#8211; Horizontal (3)</item>
+        <item>Horizontales Umschalten (1-3)</item>
         <item tools:ignore="TypographyDashes">Einfach &#8211; Tablet empfohlen (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Shunting Left (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Vertical Left (1-6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Halbrealistische Linke (1)</item>
     </string-array>
     <string-array name="DisplayClockEntries">
         <item>Keine</item>
@@ -84,7 +84,7 @@
         <item >2</item>
     </string-array>
     -->
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Halte alle</item>
         <item>Halt</item>
         <item>Vorwärts</item>
@@ -132,11 +132,11 @@
         <item>Horn (IPLS)</item>
         <item>Horn Kurz (IPLS)</item>
         <item>Sprechen Sie aktuelle Geschwindigkeit</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutral</item>
+        <item>Bremse erhöhen</item>
+        <item>Bremse verringern</item>
+        <item>Last erhöhen</item>
+        <item>Last verringern</item>
     </string-array>
     <string-array name="prefAutoImportExportEntries">
         <item>Keine</item>
@@ -184,12 +184,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Benutze globale Einstellungen des Telefons</item>
         <item>English (USA) - Engine Driver\'s Standard</item>
+        <item>Englisch (Australien)</item>
+        <item>Englisch (Kanada)</item>
+        <item>Englisch (Neuseeland)</item>
+        <item>Englisch (Vereinigtes Königreich)</item>
         <item>Italienisch</item>
         <item>Portugiesisch</item>
         <item>Deutsch</item>
         <item>Spanisch</item>
         <item>Katalanisch</item>
         <item>Französisch</item>
+        <item>Französisch (Kanada)</item>
         <item>Tschechische</item>
     </string-array>
 
@@ -198,7 +203,7 @@
         <item>Komplexe Textabgleich - Lead Lok immer dann aktiviert, folgt Trail Regeln unten</item>
         <item>Besondere Exact - Lead and All Trail aktiviert, wenn sie genau die Funktion Etiketten entsprechen</item>
         <item>Spezielles Teil - Blei und alle Trail aktiviert, wenn sie teilweise die Funktion Etiketten entsprechen</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Nur spezieller Teil enthält – Aktiviert, wenn die Funktionsbezeichnung die Standardbezeichnung enthält</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -26,7 +26,7 @@
 <!--    <string name="function_buttons">Funktionstasten</string>-->
     <string name="introMenu">Einführung</string>
 
-    <string name="app_description">Engine Driver - Fahrpult für ihr Android Telefon. Diese Anwendung kann eine Verbindung mit einem JMRI, MRC oder Digitrax WiThrottle Server erstellen und ermöglicht damit die Steuerung von Lokomotiven. Geschwindigkeit, Fahrrichtung und bis zu 29 DCC Funktionen werden für eine oder zwei Lokomotiven unterstützt.</string>
+    <string name="app_description">Engine Driver - Fahrpult für ihr Android Telefon. Diese Anwendung kann eine Verbindung mit einem JMRI, DCC-EX, MRC oder Digitrax WiThrottle Server erstellen und ermöglicht damit die Steuerung von Lokomotiven. Geschwindigkeit, Fahrrichtung und bis zu 32 DCC Funktionen werden für eine oder zwei Lokomotiven unterstützt.</string>
     <string name="app_name_intro">Einführung</string>
     <string name="app_name_connect">Verbinden mit Server</string>
     <string name="app_name_throttle">Fahrregler</string>
@@ -37,8 +37,7 @@
     <string name="app_name_routes">Fahrstraßen</string>
     <string name="app_name_routes_long">Engine Driver - Fahrstraßen</string>
     <string name="app_name_routes_short">Fahrstraßen</string>
-    <string name="app_name_turnouts">Weichen</string>
-    <string name="app_name_turnouts_long">Engine Driver - Weichen</string>
+    <string name="app_name_turnouts">Engine Driver - Weichen</string>
     <string name="app_name_turnouts_short">Weichen</string>
     <string name="app_name_about">Über</string>
     <string name="app_name_functions">Standardfunktionseinstellungen</string>
@@ -61,7 +60,7 @@
     <string name="select_loco">Lokadresse eingeben zum Übernehmen</string>
     <string name="select_loco_address">Adresse</string>
     <string name="acquire_button">Übernehmen</string>
-    <string name="roster_list">Auswahl aus Lokverzeichnis/Lokverbundeingaben</string>
+    <string name="roster_list">Auswahl aus Lokverzeichnis / Lokverbundeingaben</string>
     <string name="recent_engines">Auswahl aus kürzlich verwendeten Loks</string>
 <!--    <string name="direction">Vorwärts</string>-->
 <!--    <string name="speed">Geschwindigkeit:</string>-->
@@ -79,13 +78,12 @@
     <string name="fb_header">Funktionen bearbeiten</string>
     <string name="consist_help">Eine Lok anklicken um ihre Richtung im Vergleich zum Kopf des Lokverbundes zu ändern. Lange auf eine Lok drücken, um sie aus dem Lokverbund zu entfernen. Zurück-Pfeil drücken wenn fertig.</string>
     <string name="about">Über</string>
-    <string name="web">Web</string>
     <string name="about_page_url">file:///android_asset/about_page-de.html</string>
     <string name="mrc_settings">MRC Einstellungen</string>
     <string name="dccesp_settings">DCC ESP-Einstellungen</string>
     <string name="loco">Lok:</string>
-    <string name="loco_direction_left_extra">"\u00B7V\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7V\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Auswahl</string>
     <string name="powerWillNotWorkTitle">Funktioniert nicht!</string>
     <string name="powerWillNotWork">Stromschalter - Engine Driver</string>
@@ -139,7 +137,7 @@
     <string name="prefSwipeUpDownSummary">Optionen für Wischen nach oben/unten im Fahrregler.</string>
     <string name="prefThrottleNameTitle">Fahrreglername</string>
 
-    <string name="prefThrottleNameSummary">Wähle einen Namen für dieses Gerät (angezeigt auf WiThrottle Bildschirm)</string>
+    <string name="prefThrottleNameSummary">Wähle einen Namen für dieses Gerät (angezeigt auf JMRI WiThrottle Bildschirm)</string>
     <string name="prefThrottleOrientationTitle">Orientierung des Bildschirms</string>
 <!--    <string name="prefThrottleOrientationDefaultValue">Hochformat</string> -->
     <string name="prefThrottleOrientationSummary">Bildschirmorientierung (außer Web)</string>
@@ -217,7 +215,7 @@
     <string name="prefEsuMc2Title">ESU MobileControl II Optionen</string>
     <string name="prefEsuMc2Summary">Wähle ESU MobileControl II Optionen</string>
     <string name="prefEsuMc2ButtonsCategoryTitle">Optionen für seitliche Knöpfe</string>
-    <string name="prefEsuMc2ButtonTLTitle">Aktion für Knopf Oben-Links </string>
+    <string name="prefEsuMc2ButtonTLTitle">Aktion für Knopf Oben-Links</string>
     <string name="prefEsuMc2ButtonTLSummary">Wähle die Aktion für das Drücken des Knopfes.</string>
 <!--    <string name="prefEsuMc2ButtonTLDefaultValue">Geschwindigkeit erhöhen</string> -->
     <string name="prefEsuMc2ButtonBLTitle">Aktion für Knopf Unten-Links</string>
@@ -247,13 +245,13 @@
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Zeige Standard Funktionsbezeichnungen statt jene aus dem Lokverzeichnis.</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Überschreiben Sie die Sperrung der WiThrottle-Funktion</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Verwenden Sie die Standardverriegelung von Engine Driver für Nicht-Dienstplanloks und nicht die von WiThrottle bereitgestellten Standardeinstellungen</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Zeigen Sie die standardmäßigen Funktionsbezeichnungen anstelle der Bezeichnungen aus Dienstplaneinträgen an.                                                               \\nDies MUSS aktiviert sein, um die „Speziellen“ Folgeregelstile zu verwenden.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Zeigen Sie die standardmäßigen Funktionsbezeichnungen anstelle der Bezeichnungen aus Dienstplaneinträgen an.\nDies MUSS aktiviert sein, um die „Speziellen“ Folgeregelstile zu verwenden.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Verkleinere Loknummernhöhe?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Verwende kleinere Knöpfe für Loknummer, Geschwindigkeit und Fahrrichtung.</string>
     <string name="prefNumOfThrottles">Anzahl der Fahrregler</string>
     <string name="prefNumOfThrottlesSummary">Wähle wieviele Fahrregler angezeigt werden sollen.</string>
     <string name="prefThrottleScreenTypeTitle">Fahrregler Anzeigetyp</string>
-    <string name="prefThrottleScreenTypeSummary">Welchen Typ Anzeige für Fahrregler verwenden.\nWARNUNG! Engine Driver wird sofort neu starten!</string>
+    <string name="prefThrottleScreenTypeSummary">Welchen Typ Anzeige für Fahrregler verwenden.\n(Die Zahl in Klammern nach dem Namen gibt die Anzahl der Drosselklappen an, die das Layout unterstützen kann.)</string>
     <string name="prefMaximumThrottleTitle">Maximale Fahrregler Prozente</string>
 
     <string name="prefMaximumThrottleSummary">Maximal erlaubter Wert für Geschwindigkeitsschieber in %</string>
@@ -272,9 +270,9 @@
     <string name="prefSelectiveLeadSoundTitle">Selektiver Sound der führenden Einheit?</string>
     <string name="prefSelectiveLeadSoundSummary">Sende Horn/Glocke Funktionen nur zur führenden Lok in einem EngineDriver Lokverbund</string>
     <string name="prefSelectiveLeadSoundF1Title">Behandle F1 immer als Sound</string>
-    <string name="prefSelectiveLeadSoundF1Summary">Für die Option "Selective Lead Unit Sound"</string>
+    <string name="prefSelectiveLeadSoundF1Summary">Für die Option \"Selective Lead Unit Sound\"</string>
     <string name="prefSelectiveLeadSoundF2Title">Behandle F2 immer als Sound</string>
-    <string name="prefSelectiveLeadSoundF2Summary">Für die Option "Selective Lead Unit Sound"</string>
+    <string name="prefSelectiveLeadSoundF2Summary">Für die Option \"Selective Lead Unit Sound\"</string>
     <string name="prefStopOnPhonecallTitle">Stop bei Telefonanruf?</string>
     <string name="prefStopOnPhonecallSummary">Stoppe Lok(s) wenn ein Telefonanruf angenommen oder gewählt wird</string>
     <string name="prefStopOnReleaseTitle">Stop beim Freigeben?</string>
@@ -344,10 +342,6 @@
     <string name="PrefConnectToFirstServerSummary">Automatisch mit zuerst gefundenem WiThrottle Server verbinden?</string>
     <string name="prefDisplayClockTitle">Anzeige Schnelle Uhr</string>
     <string name="prefDisplayClockSummary">Format einstellen für Schnelle Uhr in Fahrregler- und Webanzeigen.</string>
-
-
-
-
 
     <string name="prefDisplaySpeedArrowsTitle">Geschwindigkeitsknöpfe anzeigen?</string>
     <string name="prefDisplaySpeedArrowsSummary">Knöpfe neben Schiebern für Geschwindigkeitsänderungen der Lok anzeigen?</string>
@@ -429,7 +423,7 @@
 
     <string name="prefThemeTitle">Motiv/Stil</string>
 
-    <string name="prefThemeSummary">App Motiv.\n\'Benötigt Android Honeycomb oder neuer.</string>
+    <string name="prefThemeSummary">App Motiv.</string>
 <!--    <string name="prefThemeDefaultValue">Standard</string> -->
     <string name="prefHideDemoServerTitle">Demo Server ausblenden</string>
     <string name="prefHideDemoServerSummary">Verberge den Demo Server \'jmri.mstevetodd.com\' in der Liste der Verbindungen.</string>
@@ -448,8 +442,6 @@
     <string name="functionButton00DefaultValue">Licht</string>
     <string name="functionButton01DefaultValue">Glocke</string>
     <string name="functionButton02DefaultValue">Horn</string>
-
-
 
     <string name="gamepadTestButtonLabelDpadUp">Oben</string>
     <string name="gamepadTestButtonLabelDpadDown">Unten</string>
@@ -471,23 +463,25 @@
     <string name="gamepadTestCompleteLabel">Test Status:</string>
     <string name="gamepadTestHelp">Nach unten rollen um eine vollständige Anleitung zu sehen…\n\nDrücke ALLE Dpad UND vier primäre Knöpfe oder das Gamepad WIRD NICHT FUNKTIONIEREN.\n\nWenn nicht alle Knöpfe aktiviert werden können, dann wechsle den Gamepad Modus (siehe Anleitung zu deinem Gamepad) oder versuche ein anderer Gamepad Typ (oben).\n\n\'ZURÜCK\' oder \'ABBRECHEN\' wird den Test beenden, aber das Gamepad WIRD NICHT FUNKTIONIEREN.\n\'ÜBERSPRINGEN\', oder dreimaliges Drücken des Gamepad Knopfes \'Geschwindigkeit verringern\' erzwingt einen guten Test, selbst wenn das Gamepad nicht einwandfrei funktioniert.\n\'ZURÜCKSETZEN\' läßt ED annehmen, daß bisher keine Gamepads benutzt wurden.\nWenn für den Test \'einfach\' gewählt wurde, wird einmaliges Drücken des Knopfes \'Geschwindigkeit verringern\' den Test überspringen.\n\nVerwende die \'Gamepad Test n\' Menüoptionen, um zu dieser Seite zurück zu kommen.</string>
     <string name="gamepadTestHelpNonForced">Wenn nicht alle Knöpfe aktiviert werden können, dann wechsle den Gamepad Modus (siehe Anleitung zu deinem Gamepad) oder versuche ein anderer Gamepad Typ (oben).\nMöglicherweise musst du das Gamepad erneut testen, sobald du es erstmals im Fahrregler Bildschirm benützt.</string>
-    <string name="gamepadTestIncomplete">"Test unvollständig"</string>
-    <string name="gamepadTestComplete">"Test beendet"</string>
-    <string name="gamepadTestCompleteToast">"Gamepad Test erfolgreich beendet"</string>
-    <string name="gamepadTestInvalidKeycode">"Ungültiger Tastencode für diesen Modus"</string>
-    <string name="gamepadTestReset">"Zurücksetzen"</string>
-    <string name="gamepadTestCancel">"Abbrechen"</string>
-    <string name="gamepadTestCancelNonForced">"Schließen"</string>
-    <string name="gamepadTestSkip">"Überspringen"</string>
+    <string name="gamepadTestIncomplete">Test unvollständig</string>
+    <string name="gamepadTestComplete">Test beendet</string>
+    <string name="gamepadTestCompleteToast">Gamepad Test erfolgreich beendet</string>
+    <string name="gamepadTestInvalidKeycode">Ungültiger Tastencode für diesen Modus</string>
+    <string name="gamepadTestReset">Zurücksetzen</string>
+    <string name="gamepadTestCancel">Abbrechen</string>
+    <string name="gamepadTestCancelNonForced">Schließen</string>
+    <string name="gamepadTestSkip">Überspringen</string>
 
 
-    <string name="gamepadTestKeyCodesUpCode">"Ob"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Un"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Li"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Re"</string>
+    <string name="gamepadTestKeyCodesUpCode">Ob</string>
+    <string name="gamepadTestKeyCodesDownCode">Un</string>
+    <string name="gamepadTestKeyCodesLeftCode">Li</string>
+    <string name="gamepadTestKeyCodesRightCode">Re</string>
     <string name="prefGamepadTestNowTitle">Teste jetzt Gamepad Einstellungen!</string>
     <string name="prefGamepadTestNowSummary">Erlaubt dir zu bestätigen, daß die gewählte Einstellung korrekt funktioniert.\nTest Seite wird SOFORT bei Auswahl gestartet.</string>
 
+    <string name="toastWaitingForConnection">Zeitüberschreitung beim Warten auf die WiThrottle \'VN\'-Nachricht von %1$s:%2$s. Trennen</string>
+    <string name="toastWaitingForConnectionDccEx">Zeitüberschreitung beim Warten auf die DCC-EX \'iDCCEX...\'-Nachricht von %1$s:%2$s. Trennen</string>
     <string name="toastThreadedAppNoLocalIp">Keine lokale IP Adresse gefunden.\n Überprüfe deine WiFi Verbindung.</string>
     <string name="toastThreadedAppErrorCreatingWiThrottle">Fehler beim Erstellen eines von WiThrottle selbständig konfigurierten Zuhörers: IOException:\n%1$s</string>
     <string name="toastThreadedAppWiThrottleNotSupported">WiThrottle Version %1$s wird nicht unterstützt.</string>
@@ -544,7 +538,7 @@
     <string name="toastConnectRemoveDemoHostError">Der Demo-Server kann nur durch Ändern der Einstellungen entfernt werden.</string>
     <string name="toastConnectRemoved">Server wurde aus der Liste entfernt.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Befehl geschickt zum Stellen der Fahrstraße "</string>-->
+<!--    <string name="toastRoutesCommandSent">Befehl geschickt zum Stellen der Fahrstraße </string>-->
     <string name="toastImportExportExportSucceeded">Voreinstellungen exportieren zu \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' war erfolgreich.</string>
     <string name="toastImportExportImportSucceeded">Voreinstellungen importieren von \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' war erfolgreich.</string>
     <string name="toastImportExportExportFailed">Voreinstellungen exportieren zu \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ist fehlgeschlagen!</string>
@@ -629,6 +623,8 @@
 <!--    <string name="FilterRosterList">Filter</string>-->
     <string name="FilterRosterListHint">Enthält&#8230;</string>
 
+    <string name="prefDoubleBackButtonToExitTitle">Doppelte Zurück-Taste zum Beenden?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Durch zweimaliges Drücken der Android-Taste „Zurück“ innerhalb von 3 Sekunden auf dem Bildschirm „Gas“ oder „Verbindung“ wird Engine Driver beendet</string>
     <string name="prefRosterOwnersFilterShowOptionTitle">Filtern Sie nach Dienstplanbesitzer</string>
     <string name="prefRosterOwnersFilterShowOptionSummary">Zeigen Sie eine Option zum Filtern des Dienstplans nach Besitzer an</string>
     <string name="prefRosterOwnersFilterDefaultOwner">Alle</string>
@@ -636,6 +632,7 @@
     <string name="LocoSelectMethodRoster">JMRI Lokverzeichnis</string>
     <string name="LocoSelectMethodRecent">Kürzlich verwendete</string>
     <string name="LocoSelectMethodHelp">Gebe die DCC Adresse deiner Lok oben ein und klicke auf \Übernehmen\'.\n\nWähle alternativ eine Lok aus dem JMRI \'Lokverzeichnis\' oder aus deiner Liste \'Kürzlich verwendete\' durch anklicken obiger Knöpfe.</string>
+    <string name="toastAddressExceedsMax">Adresse „%1$s“ überschreitet den maximal unterstützten Wert (‚%2$s‘)</string>
     <string name="flashlightAction">Taschenlampe</string>
     <string name="flashlightStateOn">Taschenlampe ist an</string>
     <string name="flashlightStateOff">Taschenlampe ist aus</string>
@@ -744,6 +741,9 @@
     <string name="introDccexQuestionNo">Nein, ich werde KEINE EX-CommandStation verwenden</string>
     <string name="introbackButtonPress">Starten Sie die Engine Driver app erneut, um die Einführung abzuschließen.</string>
     <string name="consist_trail_label">Leitlokomotive</string>
+    <string name="prefHeartbeatResponseFactorTitle">Herzschlag-Reaktionsfaktor</string>
+    <string name="prefHeartbeatResponseFactorSummary">Prozentsatz der Heartbeat-Periode für den Zeitpunkt, zu dem der Heartbeat gesendet werden soll (50 %–90 %). Wird bei der nächsten Verbindung wirksam.</string>
+    <string name="server">Server</string>
     <string name="prefGamepadTestEnforceTestingSimpleTitle">Verwenden einfacher Test</string>
     <string name="prefGamepadTestEnforceTestingSimpleSummary">Nur testen, dass Sie die Geschwindigkeit reduzieren.</string>
     <string name="gamepadTestButtonLabelButtonLeftShoulder">Linke Schulter</string>
@@ -789,6 +789,9 @@
 
     <string name="prefLimitSpeedButtonTitle">Show \'Limit Geschwindigkeit\' Taste</string>
     <string name="prefLimitSpeedButtonSummary">Option zu zeigen, eine Schaltfläche, um die maximale Geschwindigkeit einer Lok einschränkt.</string>
+    <string name="prefPauseAlternateButtonTitle">Alternative Schaltfläche „Pause“.</string>
+    <string name="prefEsuMc2StopButtonShortPressTitle">Aktivieren Sie „Kurz drücken“.</string>
+    <string name="prefPauseAlternateButtonSummary">Alternative Schaltfläche „Pause“ neben der Schaltfläche „Stopp“ anzeigen. (Nur vertikale Layouts)</string>
     <string name="prefLimitSpeedPercentTitle">\'Limit Geschwindigkeit\' auf \%</string>
     <string name="prefLimitSpeedPercentSummary" tools:ignore="Typos">Stellen Sie den \% der Drosselklappe, die die Geschwindigkeit auf diese beschränkt sind.</string>
     <string name="limitSpeedButtonLabel">Grenzgeschwindigkeit</string>
@@ -801,7 +804,7 @@
     <string name="RecentConsistsNameEditTitle">Aktuelle Consist-Name</string>
     <string name="RecentsNameEditText">Geben Sie einen Namen für die Loco</string>
     <string name="RecentsNameEditTitle">Aktuelle Lokname</string>
-    <string name="rosterDetailsDialogTitle">"Wählen Sie aus Roster / Consist Einträge "</string>
+    <string name="rosterDetailsDialogTitle">Wählen Sie aus Roster / Consist Einträge </string>
     <string name="toastRecentCleared">Loco entfernt von der Liste</string>
     <string name="toastRecentConsistCleared">Consist aus der Liste entfernt</string>
     <string name="editConsistButtonLabel">Bearbeiten Reihenfolge und Richtung</string>
@@ -881,7 +884,7 @@
     <string name="prefFunctionConsistLocosDefaultValue">führen</string>
     <string name="functionConsistHelpText" tools:ignore="Typos">Nur für die \\ verwendet Sonder \\ \'Funktion folgende Optionen bestehen + DCC-EX. Wählen Sie, wie der Text der einzelnen Funktionen wird in der bestehen für jede Lok in den Funktionsetiketten gesucht werden.</string>
     <string name="functionConsistHeader">Funktion Aktionen</string>
-    <string name="app_name_consist_functions">Consist Funktionseinstellungen - Lokomotivführer</string>
+    <string name="app_name_consist_functions">Consist Funktionseinstellungen</string>
     <string name="prefShowTimeOnLogEntryTitle">Zeige Zeitstempel auf Log</string>
     <string name="prefShowTimeOnLogEntrySummary">Zeigen Datum Zeit für jeden Eintrag auf dem Log-Bildschirm.</string>
     <string name="prefVerticalStopButtonMarginTitle">Stopp-Taste Vertikale Ränder</string>
@@ -909,7 +912,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Wie viel Zeit zwischen den Wiederholungen der Beschleunigungsgeschwindigkeitsschritte vergeht (in Millisekunden). Kleiner ist schneller.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Verzögerungsgeschwindigkeit, Schrittwiederholungsverzögerung</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Wie lange zwischen den Wiederholungen der Verzögerungsgeschwindigkeitsschritte vergeht (in Millisekunden). Kleiner ist schneller.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Geschwindigkeitsstufe "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Geschwindigkeitsstufe </string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Wie stark die tatsächliche Geschwindigkeit bei jedem Schritt zur Zielgeschwindigkeit springt.  Größer ist schneller.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Drosselklappenkerben</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Passen Sie den Gashebel als Prozentsatz oder um eine bestimmte Anzahl von Schritten/Kerben an</string>
@@ -917,7 +920,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Passen Sie die Anzahl der Schritte im Bremsschieber an</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Bewerten Sie die Aktualisierung der Druckluftbremsen</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Passen Sie die Geschwindigkeit an, mit der die Druckluftbremsen aktualisiert/aufgefüllt werden (in Millisekunden). Kleiner ist schneller.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Anzahl der Lasten "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Anzahl der Lasten </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Passen Sie die Anzahl der Schritte im Lastschieberegler an</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Multiplikator für den Lastprozentsatz</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Passen Sie die Auswirkung des Lastreglers auf die Geschwindigkeitsänderungen an. &gt;100 % = mehr Last</string>
@@ -942,6 +945,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Optionen für Seitenhiebe zu ändern Bildschirme</string>
     <string name="prefHapticFeedbackDurationTitle">Haptisches Feedback Dauer</string>
     <string name="prefHapticFeedbackDurationSummary">Dauer jeder Schwingung (in Millisekunden).</string>
+    <string name="prefHapticFeedbackButtonsTitle">Haptisches Feedback beim Tastendruck</string>
+    <string name="prefHapticFeedbackButtonsSummary">Haptisches Feedback (Vibration) beim Tastendruck.</string>
     <string name="LocoSelectMethodIDNGo">Anfordern Loco ID</string>
     <string name="idngo_label">Anfordern Loco ID</string>
     <string name="idngo_button">Anfordern Loco ID</string>
@@ -975,6 +980,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Verzögerung (Momentum) pro Schrittwechsel in Millisekunden (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">Im Telefon Impuls</string>
     <string name="deviceSoundsMuteButton">Stumm</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 und F2 aktivieren außerdem IPLS Bell und Horn</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 und F2 aktivieren Glocke und Hupe?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Blenden Sie die IPLS-Stummschalttaste an den Gashebeln aus</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Stummschalttaste ausblenden</string>
     <string name="prefDeviceSoundsButtonSummary">Zeigen Sie eine Action-Bar-Taste, um die LocO-Sounds in Telefon-Look zu ändern</string>
     <string name="prefDeviceSoundsButtonTitle">Im Telefon Sounds-Taste</string>
     <string name="deviceSoundsMenu">Loco-Sounds</string>
@@ -988,7 +997,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Die Bell-Taste ist momentan. (Verriegelung, wenn nicht markiert.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Glockenknopfverriegelung / momentan</string>
 <!--    <string name="permissionsReadLegacyFiles">Der Engine-Treiber benötigt Speicherberechtigungen, um die Einstellungen der Alt- (alten Standort-) zu laden.</string>-->
-    <string name="permissionsReadPhoneState">Engine-Treiber benötigt Telefonberechtigungen, um den Betrieb bei einem Anruf anzuhalten.</string>
+    <string name="permissionsReadPhoneState">Engine Driver benötigt Telefonberechtigungen, um den Betrieb bei einem Anruf anzuhalten.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Zusätzliche Präferenzen</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Zusätzlich in Telefon Loco Sounds-Vorlieben</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco-Step-Sounds spielen bis zum Ende, wenn Sie den Schritt ändern. Der Momentummenge (oben) wird nur zu einer Mindestzeit.</string>
@@ -1022,10 +1031,10 @@
     <string name="usingProtocolDCCEX">Verwenden des DCC-EX-Protokolls. Deaktivieren Sie \"Verwenden Sie native DCC-EX-Befehle\", um das WithRottle-Protokoll zu verwenden.</string>
     <string name="prefDccexConnectionOptionSummary">Option anzeigen, um zwischen Withrottle und DCC-EX-Protokollen im Verbindungsbildschirm zu wechseln.</string>
     <string name="prefDccexConnectionOptionTitle">Protokolloption anzeigen</string>
-    <string name="prefActionBarShowDccExButtonSummary">Sehen Sie die Schaltfläche in Aktionsleiste an, um auf den ECC-EX-Bildschirm zuzugreifen. (Nur für native DCC-EX-Verbindungen.)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Sehen Sie die Schaltfläche in Aktionsleiste an, um auf den DCC-EX-Bildschirm zuzugreifen. (Nur für native DCC-EX-Verbindungen.)</string>
     <string name="prefActionBarShowDccExButtonTitle">DCC-EX-Taste?</string>
     <string name="DCCEXactionTypeLabel">Aktion</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(ausschließen \'&lt;\' und \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(ausschließen \'&lt;\' und \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Klar</string>
     <string name="DccexConnectionOptionTitle">Verbindungsprotokoll</string>
     <string name="DccexFailed">Aktion: fehlgeschlagen</string>
@@ -1037,10 +1046,10 @@
     <string name="DccexSendCommandButtonLabel">Senden</string>
     <string name="witActionTypeLabel">Aktion</string>
     <string name="witWriteAddressLabel">DCC-Adresse</string>
-    <string name="witPomWarning">Hinweise: - Dies funktioniert auf einigen DCC-Systemen nicht. - Änderung der Lokadresse wird verhindert – CVs 1, 17 &amp; 18 und Bit 5 von CV 29. \\n\\nMit Vorsicht verwenden.</string>
+    <string name="witPomWarning">Hinweise: - Dies funktioniert auf einigen DCC-Systemen nicht. - Änderung der Lokadresse wird verhindert – CVs 1, 17 &amp; 18 und Bit 5 von CV 29. \n\nMit Vorsicht verwenden.</string>
     <string name="witPomMaxValueWarning">Der Wert „%1$s“ überschreitet den maximal unterstützten Wert (‚%2$s‘).</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">Gängige CMDs</string>
+    <string name="DCCEXcommonCommandsLabel">Gängige CMDs</string>
     <string name="DCCEXsetTrackButtonLabel">Satz</string>
     <string name="DccexSucceeded">Aktion erfolgreich</string>
     <string name="DCCEXturnoutClosed">Abgeschlossen</string>
@@ -1080,5 +1089,21 @@
     <string name="order">Sortieren</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Immer Wurf/Schließen anzeigen?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Zeigen Sie für Weichen immer die Schaltflächen „Werfen“ und „Schließen“ an, niemals die Schaltfläche „Umschalten“.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Verbinden</string>
+
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Decoder-Bremstyp</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Ative as funções de freio no decodificador</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Número de função baixa da ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU - Qual função do decodificador ativar no valor de freio baixo</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Número de função intermediária da ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU - Qual função do decodificador ativar no valor médio do freio</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">Número de alta função ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU - Qual função do decodificador ativar em valor de freio alto</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Valor de freio baixo da ESU (porcentagem)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU – Qual a Porcentagem de Freio para ativar o Número de Função Baixo</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">Valor do freio intermediário da ESU (porcentagem)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU - Qual a porcentagem de freio para ativar o número da função intermediária</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Alto valor de freio da ESU (porcentagem)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU – Qual a Porcentagem de Freio para ativar o Número de Função Alto</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-en-rAU/strings.xml
+++ b/EngineDriver/src/main/res/values-en-rAU/strings.xml
@@ -13,12 +13,8 @@
       Public License along with this program; if not, write to the Free Software
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
-<resources>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
-    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
-
-    <string name="app_name_turnouts">Points</string>
-    <string name="app_name_turnouts_long">Engine Driver - Points</string>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name_turnouts">Engine Driver - Points</string>
     <string name="app_name_turnouts_short">Points</string>
 
     <string name="turnouts">Points</string>
@@ -55,9 +51,61 @@
 
     <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirm that you want remove all the Recent Points</string>
 
-    <string name="prefPauseAlternateButtonSummary">Show alternate \'Pause\' button near the \'Stop\' button. (Vertical layouts only)</string>
-
     <string name="prefSortOrderTurnoutsTitle">Points sort order</string>
     <string name="prefSortOrderTurnoutsSummary">Order that the Points entries will appear, by default, each time you start Engine Driver</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Always show both the Throw and Close buttons for Points, never the Toggle button.</string>
+
+<!--    Consist == MU  -->
+
+    <string name="app_name_consist_functions">Consist (MU) Function Settings</string>
+    <string name="app_name_ConsistEdit">Consist (MU) Edit</string>
+    <string name="app_name_ConsistLightsEdit">Consist (MU) Lights</string>
+    <string name="consist_help">Click a loco to change its direction with respect to the front of the consist (MU). Long press a loco to remove it from the consist (MU). Press Back Arrow or Close when done.</string>
+    <string name="consist_list_label">All Locos in Consist (MU)</string>
+    <string name="dialogRecentConsistsConfirmClearQuestions">Confirm that you want remove all the Recent Consists (MUs)</string>
+
+    <string name="edit_consist_menu">\≡ Edit Consist (MU)</string>
+    <string name="edit_consist_lights_throttle_1">Edit Consist (MU) Lights Throttle 1</string>
+    <string name="edit_consist_lights_throttle_2">Edit Consist (MU) Lights Throttle 2</string>
+    <string name="edit_consist_lights_throttle_3">Edit Consist (MU) Lights Throttle 3</string>
+    <string name="edit_consist_lights_throttle_4">Edit Consist (MU) Lights Throttle 4</string>
+    <string name="edit_consist_lights_throttle_5">Edit Consist (MU) Lights Throttle 5</string>
+    <string name="edit_consist_lights_throttle_6">Edit Consist (MU) Lights Throttle 6</string>
+    <string name="edit_consist_throttle_1">Edit Consist (MU) Throttle 1</string>
+    <string name="edit_consist_throttle_2">Edit Consist (MU) Throttle 2</string>
+    <string name="edit_consist_throttle_3">Edit Consist (MU) Throttle 3</string>
+    <string name="edit_consist_throttle_4">Edit Consist (MU) Throttle 4</string>
+    <string name="edit_consist_throttle_5">Edit Consist (MU) Throttle 5</string>
+    <string name="edit_consist_throttle_6">Edit Consist Throttle 6</string>
+    <string name="functionConsistHeader">Consist (MU) Function Actions</string>
+    <string name="functionConsistHelpText">Only used for the \'Special\' consist (MU) function following options. Select how the text of each function will be searched for in the function labels for each loco in the consist (MU).</string>
+    <string name="functionConsistSettings">Consist (MU) Function Settings</string>
+    <string name="LocoSelectMethodRecentConsist">Recent Consist (MU)</string>
+
+    <string name="prefConsistFollowAction1Summary">Which locos in the consist (MU) should react to the found headlight functions.</string>
+    <string name="prefConsistFollowAction2Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction3Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction4Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction5Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowDefaultActionSummary">Which locos in the consist (MU) should react to the function buttons if none of the rules below are meet.</string>
+    <string name="prefConsistFollowRuleStyleSummary" tools:ignore="TypographyEllipsis">Which style of rules to follow in a consist (MU) when function buttons are pressed.\nNote: If \'Use Default function labels\' is enabled, \'Special...\' will also apply to the lead (or only) loco.</string>
+    <string name="prefConsistFollowRuleStyleTitle">Consist (MU) Functions - Follow Rule Style</string>
+    <string name="prefConsistFollowString1Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise the \'Headlight\' function (normally F0).</string>
+    <string name="prefConsistFollowString2Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString3Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString4Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString5Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowSummary">Options for how functions will behave in a Consist (MU).</string>
+    <string name="prefConsistFollowTitle">Consist (MU) Function Follow Preferences</string>
+    <string name="prefConsistLightsLongClickSummary">Change the Lights of the individual locos in a Consist (MU) with a long click on the Loco Select button.</string>
+    <string name="prefConsistLightsLongClickTitle">Control Consist (MU) lights on long click</string>
+    <string name="prefEsuMc2StopButtonShortPressSummary">Control Consist (MU) lights on long click</string>
+    <string name="prefSelectiveLeadSoundSummary">Send Horn/Bell functions to only the Lead unit in an EngineDriver consist (MU).  (Only/any function with a \'label\' that includes \'bell\', \'horn\' or \'whistle\' as part of the label.)</string>
+    <string name="recent_consists">Select from Recent Consists (MUs)</string>
+    <string name="RecentConsistsNameEditText">Enter a name for the Consist (MU)</string>
+    <string name="RecentConsistsNameEditTitle">Recent Consist (MU) Name</string>
+    <string name="roster_list">Select from Roster / Consist (MU) Entries</string>
+    <string name="toastRecentConsistCleared">Consist (MU) removed from list</string>
+<!--    <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists (MUs) by pressing the 'Clear List' button AGAIN.</string>-->
+
 </resources>

--- a/EngineDriver/src/main/res/values-en-rCA/arrays.xml
+++ b/EngineDriver/src/main/res/values-en-rCA/arrays.xml
@@ -25,4 +25,12 @@
         <item>Colourful</item>
     </string-array>
 
+    <string-array name="prefBackgroundImagePositionEntries">  <!-- display version -->
+        <item>Fit - Shrink/expand</item>
+        <item>Fill - Crop one edge pair</item>
+        <item>Centre - No Scaling</item>
+        <item>Fit - Shrink only</item>
+        <item>Fill - Distort if needed</item>
+    </string-array>
+
 </resources>

--- a/EngineDriver/src/main/res/values-en-rCA/strings.xml
+++ b/EngineDriver/src/main/res/values-en-rCA/strings.xml
@@ -16,4 +16,23 @@
 <resources>
     <string name="introThemeSummary">Choose the colours and appearance of the whole app.</string>
 
+    <string name="app_name_turnouts">Engine Driver - Turnouts</string>
+    <string name="app_name_turnouts_short">Turnouts</string>
+
+    <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirm that you want to remove all the Recent Turnouts</string>
+
+    <string name="prefSortOrderTurnoutsTitle">Turnouts Sort Order</string>
+    <string name="prefSortOrderTurnoutsSummary">Order that the Turnouts entries will appear, by default, each time you start Engine Driver</string>
+    <string name="prefSwipeThroughTurnoutsTitle">Swipe Through Turnouts?</string>
+    <string name="prefSwipeThroughTurnoutsSummary">Include Turnouts Screen when swiping between screens</string>
+    <string name="prefTurnoutsTitle">Turnouts and Routes Preferences</string>
+    <string name="prefTurnoutsShowThrowCloseButtonsSummary">Always show both the Throw and Close buttons for Turnouts, never the Toggle button.</string>
+
+    <string name="turnouts">Turnouts</string>
+    <string name="turnouts_direct_entry_label">Enter Turnout # or name</string>
+    <string name="turnouts_list_label">Turnouts (click state to toggle)</string>
+    <string name="turnouts_location_label">Filter by Location</string>
+    <string name="turnouts_turnout">Turnout</string>
+    <string name="turnoutsRecentHeading">Recent Turnouts</string>
+    <string name="turnoutsSelectionTypeHeading">Turnout Selection Method</string>
 </resources>

--- a/EngineDriver/src/main/res/values-en-rGB/strings.xml
+++ b/EngineDriver/src/main/res/values-en-rGB/strings.xml
@@ -13,12 +13,8 @@
       Public License along with this program; if not, write to the Free Software
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
-<resources>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
-    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
-
-    <string name="app_name_turnouts">Points</string>
-    <string name="app_name_turnouts_long">Engine Driver - Points</string>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name_turnouts">Engine Driver - Points</string>
     <string name="app_name_turnouts_short">Points</string>
 
     <string name="turnouts">Points</string>
@@ -55,9 +51,58 @@
 
     <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirm that you want remove all the Recent Points</string>
 
-    <string name="prefPauseAlternateButtonSummary">Show alternate \'Pause\' button near the \'Stop\' button. (Vertical layouts only)</string>
-
     <string name="prefSortOrderTurnoutsTitle">Points sort order</string>
     <string name="prefSortOrderTurnoutsSummary">Order that the Points entries will appear, by default, each time you start Engine Driver</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Always show both the Throw and Close buttons for Points, never the Toggle button.</string>
+
+    <!--    Consist == MU  -->
+
+    <string name="app_name_consist_functions">Consist (MU) Function Settings</string>
+    <string name="app_name_ConsistEdit">Consist (MU) Edit</string>
+    <string name="app_name_ConsistLightsEdit">Consist (MU) Lights</string>
+    <string name="consist_help">Click a loco to change its direction with respect to the front of the consist (MU). Long press a loco to remove it from the consist (MU). Press Back Arrow or Close when done.</string>
+    <string name="consist_list_label">All Locos in Consist (MU)</string>
+    <string name="dialogRecentConsistsConfirmClearQuestions">Confirm that you want remove all the Recent Consists (MUs)</string>
+    <string name="edit_consist_lights_throttle_1">Edit Consist (MU) Lights Throttle 1</string>
+    <string name="edit_consist_lights_throttle_2">Edit Consist (MU) Lights Throttle 2</string>
+    <string name="edit_consist_lights_throttle_3">Edit Consist (MU) Lights Throttle 3</string>
+    <string name="edit_consist_lights_throttle_4">Edit Consist (MU) Lights Throttle 4</string>
+    <string name="edit_consist_lights_throttle_5">Edit Consist (MU) Lights Throttle 5</string>
+    <string name="edit_consist_lights_throttle_6">Edit Consist (MU) Lights Throttle 6</string>
+    <string name="edit_consist_throttle_1">Edit Consist (MU) Throttle 1</string>
+    <string name="edit_consist_throttle_2">Edit Consist (MU) Throttle 2</string>
+    <string name="edit_consist_throttle_3">Edit Consist (MU) Throttle 3</string>
+    <string name="edit_consist_throttle_4">Edit Consist (MU) Throttle 4</string>
+    <string name="edit_consist_throttle_5">Edit Consist (MU) Throttle 5</string>
+    <string name="edit_consist_throttle_6">Edit Consist Throttle 6</string>
+    <string name="functionConsistHeader">Consist (MU) Function Actions</string>
+    <string name="functionConsistHelpText">Only used for the \'Special\' consist (MU) function following options. Select how the text of each function will be searched for in the function labels for each loco in the consist (MU).</string>
+    <string name="functionConsistSettings">Consist (MU) Function Settings</string>
+    <string name="LocoSelectMethodRecentConsist">Recent Consist (MU)</string>
+
+    <string name="prefConsistFollowAction1Summary">Which locos in the consist (MU) should react to the found headlight functions.</string>
+    <string name="prefConsistFollowAction2Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction3Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction4Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction5Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowDefaultActionSummary">Which locos in the consist (MU) should react to the function buttons if none of the rules below are meet.</string>
+    <string name="prefConsistFollowRuleStyleSummary" tools:ignore="TypographyEllipsis">Which style of rules to follow in a consist (MU) when function buttons are pressed.\nNote: If \'Use Default function labels\' is enabled, \'Special...\' will also apply to the lead (or only) loco.</string>
+    <string name="prefConsistFollowRuleStyleTitle">Consist (MU) Functions - Follow Rule Style</string>
+    <string name="prefConsistFollowString1Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise the \'Headlight\' function (normally F0).</string>
+    <string name="prefConsistFollowString2Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString3Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString4Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString5Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowSummary">Options for how functions will behave in a Consist (MU).</string>
+    <string name="prefConsistFollowTitle">Consist (MU) Function Follow Preferences</string>
+    <string name="prefConsistLightsLongClickSummary">Change the Lights of the individual locos in a Consist (MU) with a long click on the Loco Select button.</string>
+    <string name="prefConsistLightsLongClickTitle">Control Consist (MU) lights on long click</string>
+    <string name="prefEsuMc2StopButtonShortPressSummary">Control Consist (MU) lights on long click</string>
+    <string name="prefSelectiveLeadSoundSummary">Send Horn/Bell functions to only the Lead unit in an EngineDriver consist (MU).  (Only/any function with a \'label\' that includes \'bell\', \'horn\' or \'whistle\' as part of the label.)</string>
+    <string name="recent_consists">Select from Recent Consists (MUs)</string>
+    <string name="RecentConsistsNameEditText">Enter a name for the Consist (MU)</string>
+    <string name="RecentConsistsNameEditTitle">Recent Consist (MU) Name</string>
+    <string name="roster_list">Select from Roster / Consist (MU) Entries</string>
+    <string name="toastRecentConsistCleared">Consist (MU) removed from list</string>
+    <!--    <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists (MUs) by pressing the 'Clear List' button AGAIN.</string>-->
 </resources>

--- a/EngineDriver/src/main/res/values-en-rNZ/strings.xml
+++ b/EngineDriver/src/main/res/values-en-rNZ/strings.xml
@@ -13,12 +13,8 @@
       Public License along with this program; if not, write to the Free Software
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
-<resources>
-    <string name="prefEsuMc2ZeroTrimSummary">Set the Control Knob zero trim setting.\nSmaller is closer to anti-clockwise end-stop position.\nPermitted range 0&#8211;255.</string>
-    <string name="prefEsuMc2EndStopDirectionChangeSummary">Allow Loco direction to change when control knob at anti-clockwise end-stop position.</string>
-
-    <string name="app_name_turnouts">Points</string>
-    <string name="app_name_turnouts_long">Engine Driver - Points</string>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name_turnouts">Engine Driver - Points</string>
     <string name="app_name_turnouts_short">Points</string>
 
     <string name="turnouts">Points</string>
@@ -55,9 +51,58 @@
 
     <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirm that you want remove all the Recent Points</string>
 
-    <string name="prefPauseAlternateButtonSummary">Show alternate \'Pause\' button near the \'Stop\' button. (Vertical layouts only)</string>
-
     <string name="prefSortOrderTurnoutsTitle">Points sort order</string>
     <string name="prefSortOrderTurnoutsSummary">Order that the Points entries will appear, by default, each time you start Engine Driver</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Always show both the Throw and Close buttons for Points, never the Toggle button.</string>
+
+    <!--    Consist == MU  -->
+
+    <string name="app_name_consist_functions">Consist (MU) Function Settings</string>
+    <string name="app_name_ConsistEdit">Consist (MU) Edit</string>
+    <string name="app_name_ConsistLightsEdit">Consist (MU) Lights</string>
+    <string name="consist_help">Click a loco to change its direction with respect to the front of the consist (MU). Long press a loco to remove it from the consist (MU). Press Back Arrow or Close when done.</string>
+    <string name="consist_list_label">All Locos in Consist (MU)</string>
+    <string name="dialogRecentConsistsConfirmClearQuestions">Confirm that you want remove all the Recent Consists (MUs)</string>
+    <string name="edit_consist_lights_throttle_1">Edit Consist (MU) Lights Throttle 1</string>
+    <string name="edit_consist_lights_throttle_2">Edit Consist (MU) Lights Throttle 2</string>
+    <string name="edit_consist_lights_throttle_3">Edit Consist (MU) Lights Throttle 3</string>
+    <string name="edit_consist_lights_throttle_4">Edit Consist (MU) Lights Throttle 4</string>
+    <string name="edit_consist_lights_throttle_5">Edit Consist (MU) Lights Throttle 5</string>
+    <string name="edit_consist_lights_throttle_6">Edit Consist (MU) Lights Throttle 6</string>
+    <string name="edit_consist_throttle_1">Edit Consist (MU) Throttle 1</string>
+    <string name="edit_consist_throttle_2">Edit Consist (MU) Throttle 2</string>
+    <string name="edit_consist_throttle_3">Edit Consist (MU) Throttle 3</string>
+    <string name="edit_consist_throttle_4">Edit Consist (MU) Throttle 4</string>
+    <string name="edit_consist_throttle_5">Edit Consist (MU) Throttle 5</string>
+    <string name="edit_consist_throttle_6">Edit Consist Throttle 6</string>
+    <string name="functionConsistHeader">Consist (MU) Function Actions</string>
+    <string name="functionConsistHelpText">Only used for the \'Special\' consist (MU) function following options. Select how the text of each function will be searched for in the function labels for each loco in the consist (MU).</string>
+    <string name="functionConsistSettings">Consist (MU) Function Settings</string>
+    <string name="LocoSelectMethodRecentConsist">Recent Consist (MU)</string>
+
+    <string name="prefConsistFollowAction1Summary">Which locos in the consist (MU) should react to the found headlight functions.</string>
+    <string name="prefConsistFollowAction2Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction3Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction4Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowAction5Summary">Which locos in the consist (MU) should react to the found functions.</string>
+    <string name="prefConsistFollowDefaultActionSummary">Which locos in the consist (MU) should react to the function buttons if none of the rules below are meet.</string>
+    <string name="prefConsistFollowRuleStyleSummary" tools:ignore="TypographyEllipsis">Which style of rules to follow in a consist (MU) when function buttons are pressed.\nNote: If \'Use Default function labels\' is enabled, \'Special...\' will also apply to the lead (or only) loco.</string>
+    <string name="prefConsistFollowRuleStyleTitle">Consist (MU) Functions - Follow Rule Style</string>
+    <string name="prefConsistFollowString1Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise the \'Headlight\' function (normally F0).</string>
+    <string name="prefConsistFollowString2Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString3Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString4Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowString5Summary">Comma separated string(s) to look for in the function labels of the locos in the consist (MU) to recognise a similar function.</string>
+    <string name="prefConsistFollowSummary">Options for how functions will behave in a Consist (MU).</string>
+    <string name="prefConsistFollowTitle">Consist (MU) Function Follow Preferences</string>
+    <string name="prefConsistLightsLongClickSummary">Change the Lights of the individual locos in a Consist (MU) with a long click on the Loco Select button.</string>
+    <string name="prefConsistLightsLongClickTitle">Control Consist (MU) lights on long click</string>
+    <string name="prefEsuMc2StopButtonShortPressSummary">Control Consist (MU) lights on long click</string>
+    <string name="prefSelectiveLeadSoundSummary">Send Horn/Bell functions to only the Lead unit in an EngineDriver consist (MU).  (Only/any function with a \'label\' that includes \'bell\', \'horn\' or \'whistle\' as part of the label.)</string>
+    <string name="recent_consists">Select from Recent Consists (MUs)</string>
+    <string name="RecentConsistsNameEditText">Enter a name for the Consist (MU)</string>
+    <string name="RecentConsistsNameEditTitle">Recent Consist (MU) Name</string>
+    <string name="roster_list">Select from Roster / Consist (MU) Entries</string>
+    <string name="toastRecentConsistCleared">Consist (MU) removed from list</string>
+    <!--    <string name="toastSelectConsistsConfirmClear">Confirm that you want remove all the Recent Consists (MUs) by pressing the 'Clear List' button AGAIN.</string>-->
 </resources>

--- a/EngineDriver/src/main/res/values-es/arrays.xml
+++ b/EngineDriver/src/main/res/values-es/arrays.xml
@@ -66,11 +66,11 @@
         <item >Switching &#8211; (2)</item>
         <item >Switching &#8211; izquierdo (1)</item>
         <item >Switching &#8211; derecha (1)</item>
-        <item >Switching &#8211; Horizontal (3)</item>
+        <item >Switching - Horizontal (1-3)</item>
         <item>Simple &#8211; tablet recomendado (1&#8211;6)</item>
         <item>Tablet Switching Left (1&#8211;6)</item>
         <item>Tablet Vertical Left (1&#8211;6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Izquierda semirealista (1)</item>
     </string-array>
     <string-array name="DisplayClockEntries">
         <item>Ninguno</item>
@@ -84,7 +84,7 @@
         <item >2</item>
     </string-array>
     -->
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Detiene todo</item>
         <item>Detiene</item>
         <item>Adelante</item>
@@ -132,11 +132,11 @@
         <item>Bocina (IPLS)</item>
         <item>Cuerno Corto (IPLS)</item>
         <item>Hablar la velocidad actual</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutral</item>
+        <item>Aumentar freno</item>
+        <item>Disminuir freno</item>
+        <item>aumentar la carga</item>
+        <item>Disminuir la carga</item>
     </string-array>
     <string-array name="prefAutoImportExportEntries">
         <item>Ninguno</item>
@@ -184,12 +184,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Utilizar los parámetros globales del teléfono</item>
         <item>Inglés (USA) - Engine Driver\'s por defecto</item>
+        <item>Inglés (Australia)</item>
+        <item>Inglés (Canadá)</item>
+        <item>Inglés (Nueva Zelanda)</item>
+        <item>Inglés (Reino Unido)</item>
         <item>Italiano</item>
         <item>Portugués</item>
         <item>Alemán</item>
         <item>Español</item>
         <item>Catalán</item>
         <item>Francés</item>
+        <item>Francés (Canadá)</item>
         <item>Checo</item>
     </string-array>
 
@@ -198,7 +203,7 @@
         <item>Complejo texto coincidente - loco plomo siempre activado, Trail sigue las reglas siguientes</item>
         <item>Especial exacta - El plomo y el Camino para activarse si coinciden exactamente las etiquetas de función</item>
         <item>Especial Parcial - Plomo y Camino para activarse si coinciden parcialmente las etiquetas de función</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Sólo contiene parcial especial: se activa si la etiqueta de función contiene la etiqueta predeterminada</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Locomotora delantera - Coincidencia parcial</item>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -24,7 +24,7 @@
 <!--    <string name="function_buttons">botones_de_funciones</string>-->
     <string name="introMenu">Introducción</string>
 
-    <string name="app_description">Engine Driver - Un Controlador para tu teléfono Android. Esta aplicación permite conectar a servidores WiThrottle como JMRI, MRC o Digitrax, y tripular tus Locomotoras. Velocidad, dirección, y mas de 29 funciones DCC están soportadas para una o dos Locomotoras</string>
+    <string name="app_description">Engine Driver - Un Controlador para tu teléfono Android. Esta aplicación permite conectar a servidores WiThrottle como JMRI, DCC-EX, MRC o Digitrax, y tripular tus Locomotoras. Velocidad, dirección, y mas de 32 funciones DCC están soportadas para una o dos Locomotoras</string>
     <string name="app_name_intro">Introducción</string>
     <string name="app_name_connect">Conectar al servidor</string>
     <string name="app_name_throttle">Controlador</string>
@@ -35,8 +35,7 @@
     <string name="app_name_routes">Rutas</string>
     <string name="app_name_routes_long">Engine Driver - Rutas</string>
     <string name="app_name_routes_short">Rutas</string>
-    <string name="app_name_turnouts">Desvíos</string>
-    <string name="app_name_turnouts_long">Engine Driver - Desvíos</string>
+    <string name="app_name_turnouts">Engine Driver - Desvíos</string>
     <string name="app_name_turnouts_short">Desvíos</string>
     <string name="app_name_about">Acerca de</string>
     <string name="app_name_functions">Parámetros de funciones por defecto</string>
@@ -59,7 +58,7 @@
     <string name="select_loco">Entra la dirección de la Locomotora</string>
     <string name="select_loco_address">Dirección</string>
     <string name="acquire_button">Adquirir</string>
-    <string name="roster_list">Selecciona desde la flota/Tracción Múltiple</string>
+    <string name="roster_list">Selecciona desde la flota / Tracción Múltiple</string>
     <string name="recent_engines">Selecciona desde Lomotoras recientes</string>
 <!--    <string name="direction">Adelante</string>-->
 <!--    <string name="speed">Velocidad:</string>-->
@@ -76,14 +75,13 @@
     <string name="fb_header">Modificar funciones</string>
     <string name="consist_help">Pulsar una Locomotora para cambiar su dirección respecto a la de la Tracción Múltiple. Mantener pulsado para eliminar una Locomotora de la Tracción Múltiple. Pulsar Atrás para terminar</string>
     <string name="about">Acerca de</string>
-    <string name="web">Web</string>
     <string name="about_page_url">file:///android_asset/about_page-es.html</string>
 
     <string name="mrc_settings">Parámetros MRC</string>
     <string name="dccesp_settings">Configuración de DCC ESP</string>
     <string name="loco">Locomotora:</string>
-    <string name="loco_direction_left_extra">"\u00B7A\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7A\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Seleccionar</string>
     <string name="powerWillNotWorkTitle">¡No funcionará!</string>
     <string name="powerWillNotWork">JMRI tiene el control de alimentación WiThrottle apagado.\nEliminará el icono de tensión de vía.\nSe mostrará de nuevo cuando se active en el JMRI</string>
@@ -127,6 +125,7 @@
     <string name="disabled">Deshabilitado</string>
     <string name="yes">Sí</string>
     <string name="no">No</string>
+    <string name="cancel">Cancelar</string>
     <string name="exit_text">¿Salir del Engine Driver?</string>
     <string name="exit_title">Salir</string>
     <string name="steal_text">Coger dirección %1$s?</string>
@@ -138,7 +137,7 @@
     <string name="prefSwipeUpDownSummary">Opciones para deslizar el dedo arriba-abajo en la pantalla del Controlador</string>
     <string name="prefThrottleNameTitle">Nombre del Controlador</string>
 
-    <string name="prefThrottleNameSummary">Establece el nombre de este dispositivo (se muestra en la ventana del WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Establece el nombre de este dispositivo (se muestra en la ventana del JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">Orientación de la pantalla</string>
 
     <string name="prefThrottleOrientationSummary">Orientación de la pantalla (excepto Web)</string>
@@ -235,14 +234,14 @@
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Muestra las etiquetas de funciones predeterminadas en lugar de las etiquetas de las entradas de la flota</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Anular con el bloqueo de la función del acelerador</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Utilice el bloqueo predeterminado de Engine Driver para ubicaciones que no pertenecen a la lista, en lugar de los valores predeterminados proporcionados por WiThrottle</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Muestra las etiquetas de función predeterminadas en lugar de las etiquetas de las entradas de la lista.                                                               \\nEsto DEBE estar habilitado para usar los estilos de regla de seguimiento \\\'especiales\\\'.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Muestra las etiquetas de función predeterminadas en lugar de las etiquetas de las entradas de la lista.\nEsto DEBE estar habilitado para usar los estilos de regla de seguimiento \'especiales\'.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">¿Disminuye la altura del número de Locomotora?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Utiliza teclas pequeñas para el número de Locomotora, velocidad y teclas de dirección</string>
     <string name="prefNumOfThrottles">Número de Controladores</string>
     <string name="prefNumOfThrottlesSummary">Elige la cantidad de Controladores que desea mostrar</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipo de pantalla del Controlador</string>
-    <string name="prefThrottleScreenTypeSummary">Qué tipo de pantalla utilizará el Controlador</string>
+    <string name="prefThrottleScreenTypeSummary">Qué tipo de pantalla utilizará el Controlador.\n(El número entre paréntesis después del nombre es la cantidad de aceleraciones que el diseño puede admitir).</string>
 
     <string name="prefMaximumThrottleTitle">Porcentage máximo del Controlador</string>
 
@@ -288,7 +287,7 @@
     <string name="prefDefaultAddressLengthTitle">Direcciones por defecto (cortas/largas)</string>
 
     <string name="prefDefaultAddressLengthSummary">Longitud predeterminada de la dirección de la Locomotora, (Auto se establecerá en función de # de dígitos)</string>
-    <string name="prefWebTitle">Preferencias web</string>
+    <string name="prefWebTitle">Preferencias Web</string>
     <string name="prefDisplaySpeedUnitsTitle">Unidades de velocidad</string>
 
     <string name="prefDisplaySpeedUnitsSummary">¿Muestra la velocidad como porcentaje o por pasos de velocidad?</string>
@@ -394,6 +393,9 @@
     <string name="prefGamepadTestEnforceTestingTitle">Forzar la prueba del gamepad</string>
     <string name="prefGamepadTestEnforceTestingSummary">Prueba el gamepad cada vez que sea conectado</string>
 
+    <string name="prefHeartbeatResponseFactorTitle">Factor de respuesta al latido del corazón</string>
+    <string name="prefHeartbeatResponseFactorSummary">Porcentaje del período de latido para cuándo enviar el latido (50 % -90 %). Entrará en vigor en la próxima conexión.</string>
+    <string name="server">Servidor</string>
     <string name="prefGamepadTestEnforceTestingSimpleTitle">Utiliza la prueba simple</string>
     <string name="prefGamepadTestEnforceTestingSimpleSummary">Solo prueba que puedas reducir la velocidad</string>
 
@@ -415,7 +417,7 @@
 
     <string name="prefThemeTitle">Tema/estilo</string>
 
-    <string name="prefThemeSummary">Tema de la App.\nRequiere Android Honeycomb o posterior</string>
+    <string name="prefThemeSummary">Tema de la App.</string>
 
     <string name="prefHideDemoServerTitle">Esconde la Demo del Servidor</string>
     <string name="prefHideDemoServerSummary">Esconde la demo del Servidor\'jmri.mstevetodd.com\' en la lista de conexiones</string>
@@ -458,19 +460,19 @@
     <string name="gamepadTestCompleteLabel">Prueba de estado:\s\s</string>
     <string name="gamepadTestHelp">Desplácese hacia abajo para ver las instrucciones completas&#8230;\n\nPresionar TODOS Dpad Y las cuatro teclas principales del gamepad NO FUNCIONARÁ.\n\nSi no puedes activar todas las teclas, cambia el modo del gamepad (mira las instrucciones que vienen con tu gamepad) o prueba un tipo de gamepad diferente (arriba).\n\n\'ATRÁS \' o \'CANCELA\' saldrá de la prueba pero el gamepad NO FUNCIONARÁ.\n\'OMITE\', o presionando la tecla \'Reducir Velocidad\' del gamepad tres veces, forzará el paso de la prueba, incluso si el gamepad no funciona correctamente.\n\'REINICIA\' hará que ED piense que todavía no se han utilizado gamepads.\nSi selecciona la prueba \'simple\', al presionar una sola tecla \'Reducir velocidad\' se omitirá la prueba.\n\nUtiliza las opciones del menú \'Prueba de gamepad n\' para regresar a esta página</string>
     <string name="gamepadTestHelpNonForced">Si no puedes activar todas las teclas, cambia el modo del gamepad de juegos (mira las instrucciones que vienen con tu dispositivo) o prueba un tipo de gamepad diferente (arriba).\nEs posible que tengas que volver a probar el gamepad cuando lo utilices por primera vez en la pantalla del Controlador</string>
-    <string name="gamepadTestIncomplete">"Prueba incompleta"</string>
-    <string name="gamepadTestComplete">"Prueba completada"</string>
-    <string name="gamepadTestCompleteToast">"Prueba gamepad completada satisfactoriamente" </string>
-    <string name="gamepadTestInvalidKeycode">"Código de tecla no válido para este modo"</string>
-    <string name="gamepadTestReset">"Reinicia"</string>
-    <string name="gamepadTestCancel">"Cancela"</string>
-    <string name="gamepadTestCancelNonForced">"Cierra"</string>
-    <string name="gamepadTestSkip">"Omite"</string>
+    <string name="gamepadTestIncomplete">Prueba incompleta</string>
+    <string name="gamepadTestComplete">Prueba completada</string>
+    <string name="gamepadTestCompleteToast">Prueba gamepad completada satisfactoriamente</string>
+    <string name="gamepadTestInvalidKeycode">Código de tecla no válido para este modo</string>
+    <string name="gamepadTestReset">Reinicia</string>
+    <string name="gamepadTestCancel">Cancela</string>
+    <string name="gamepadTestCancelNonForced">Cierra</string>
+    <string name="gamepadTestSkip">Omite</string>
 
-    <string name="gamepadTestKeyCodesUpCode">"Ar"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Ab"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Iz"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Dr"</string>
+    <string name="gamepadTestKeyCodesUpCode">Ar</string>
+    <string name="gamepadTestKeyCodesDownCode">Ab</string>
+    <string name="gamepadTestKeyCodesLeftCode">Iz</string>
+    <string name="gamepadTestKeyCodesRightCode">Dr</string>
     <string name="prefGamepadTestNowTitle">¡Prueba de configuración del gamepad ahora!</string>
     <string name="prefGamepadTestNowSummary">Permite confirmar que la configuración seleccionada funciona correctamente.\nLa página de prueba se iniciará INMEDIATAMENTE al seleccionarla</string>
     <string name="toastDoubleBackButtonToExit">Presione \'Atrás\' nuevamente para salir de Engine Driver</string>
@@ -517,7 +519,7 @@
     <string name="toastConnectRemoveDemoHostError">El servidor de demostración solo se puede eliminar modificando las preferencias</string>
     <string name="toastConnectRemoved">Servidor eliminado de la lista</string>
 
-<!--    <string name="toastRoutesCommandSent">"Comando enviado para establecer la ruta"</string>-->
+<!--    <string name="toastRoutesCommandSent">Comando enviado para establecer la ruta</string>-->
     <string name="toastImportExportExportSucceeded">La exportación de preferencias a \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha tenido éxito</string>
     <string name="toastImportExportImportSucceeded">La importación de preferencias desde \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha tenido éxito</string>
     <string name="toastImportExportExportFailed">!La exportación de preferencias a  \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' ha fallado¡</string>
@@ -611,16 +613,21 @@
     <string name="LocoSelectMethodRoster">JMRI flota</string>
     <string name="LocoSelectMethodRecent">Reciente</string>
     <string name="LocoSelectMethodHelp">Ingrese arriba la dirección DCC de su Locomotora y haga clic en \'Adquirir\'.\n\nAlternativamente, seleccione una Locomotora de la \'Flota\' del JMRI o seleccione entre sus Locomotoras usadas \'Recientes\' haciendo clic en uno de las opciones que aparecen arriba</string>
+    <string name="toastAddressExceedsMax">La dirección \'%1$s\' excede el máximo admitido (\'%2$s\')</string>
     <string name="flashlightAction">Luz flash</string>
     <string name="flashlightStateOn">La luz flash está encendida</string>
     <string name="flashlightStateOff">La luz flash está apagada</string>
     <string name="prefFlashlightSummary">¿Muestra las teclas de la linterna en las pantallas de Controlador, desvíos y rutas?</string>
     <string name="prefFlashlightTitle">¿Muestra la tecla de la luz flash?</string>
     <string name="toastFlashlightOnFailed">¡Disculpa! Ha habido un error al cambiar a la linterna&#8230;</string>
+    <string name="prefDoubleBackButtonToExitTitle">¿Doble botón Atrás para salir?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Al presionar el botón \"Atrás\" de Android dos veces en 3 segundos en la pantalla \"Acelerador\" o \"Conexión\" se saldrá de Engine Driver.</string>
     <string name="prefConnectTimeoutMsTitle">Tiempo de espera de conexión inicial</string>
     <string name="prefConnectTimeoutMsSummary">Establece el tiempo de espera de conexión inicial en milisegundos</string>
     <string name="prefSocketTimeoutMsTitle">Tiempo de espera del socket</string>
     <string name="prefSocketTimeoutMsSummary">Establece el tiempo de espera en milisegundos para el socket </string>
+    <string name="toastWaitingForConnection">Se agotó el tiempo de espera para el mensaje WiThrottle \'VN\' de %1$s:%2$s. Desconectando</string>
+    <string name="toastWaitingForConnectionDccEx">Se agotó el tiempo de espera para el mensaje DCC-EX \'iDCCEX...\' de %1$s:%2$s. Desconectando</string>
     <string name="toastThreadedAppNoLocalIp">No se ha encontrado dirección IP.\nVerifica la conexión WIFI</string>
     <string name="toastThreadedAppErrorCreatingWiThrottle">Error creando el cliente zeroconf del withrottle: Excepción IO:\n%1$s</string>
     <string name="toastThreadedAppWiThrottleNotSupported">Versión de WiThrottle %1$s no soportada</string>
@@ -694,6 +701,12 @@
     <string name="prefKidsTimerTitle">Tiempo limitado de ejecución</string>
     <string name="prefKidsTimerSummary">Restrinja el tiempo que circulará una Locomotora. Por ejemplo, cada niño tendrá la misma cantidad de tiempo</string>
 
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Cambio de dirección al final de carrera</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Permita que la dirección del loco cambie cuando la perilla de control esté en la posición final en sentido antihorario.</string>
+    <string name="prefEsuMc2KnobButtonTitle">Cambio de dirección al final de carrera</string>
+    <string name="prefEsuMc2KnobButtonSummary">Permita que la perilla de control se desactive mediante un botón de acción en la pantalla del acelerador.</string>
+    <string name="EsuMc2KnobAction">Perilla de activación/desactivación</string>
+    <string name="toastThreadedAppNotWIFI">El uso de la red %1$s, no WIFI.\nCompruebe la configuración de Wi-Fi.\n</string>
     <string name="prefKidsTimerRestartPasswordTitle">Reinicia contraseña</string>
     <string name="prefKidsTimerRestartPasswordSummary">Contraseña para reiniciar los parámetros actuales del temporizador</string>
 
@@ -704,6 +717,7 @@
     <string name="app_name_throttle_kids_enabled">Temporizador preparado</string>
     <string name="app_name_throttle_kids_ended">Temporizador terminado</string>
 
+    <string name="prefEsuMc2StopButtonShortPressTitle">Habilitar pulsación corta</string>
     <string name="kidsTimer">Temporizador</string>
     <string name="timerDialogTitle">Contraseña del temporizador</string>
     <string name="timerDialogMessage">Contraseña :</string>
@@ -775,6 +789,8 @@
 
     <string name="prefLimitSpeedButtonTitle">Mostrar la tecla de límite de velocidad</string>
     <string name="prefLimitSpeedButtonSummary">Opción para mostrar una tecla que limita la velocidad máxima de una Locomotora</string>
+    <string name="prefPauseAlternateButtonTitle">Botón alternativo \'Pausa\'</string>
+    <string name="prefPauseAlternateButtonSummary">Mostrar el botón \'Pausa\' alternativo cerca del botón \'Detener\'. (Solo diseños verticales)</string>
     <string name="prefLimitSpeedPercentTitle">Límite de velocidad a \%</string>
     <string name="prefLimitSpeedPercentSummary">Ajusta el \% de la aceleración que la velocidad se limitará a</string>
     <string name="limitSpeedButtonLabel">Límite de velocidad</string>
@@ -787,7 +803,7 @@
     <string name="RecentsNameEditText">Introduzca un nombre para una Locomotora</string>
     <string name="infoSaveLogFile">Iniciando sesión en: %s</string>
     <string name="RecentsNameEditTitle">Nombres recientes de Locomotoras</string>
-    <string name="rosterDetailsDialogTitle">"Detalles de la flota para "</string>
+    <string name="rosterDetailsDialogTitle">Detalles de la flota para </string>
     <string name="toastRecentCleared">Locomotora eliminada de la lista</string>
     <string name="toastRecentConsistCleared">Tracción múltiple eliminada de la lista</string>
     <string name="editConsistButtonLabel">Edita el orden y el frontal</string>
@@ -894,7 +910,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Cuánto tiempo transcurre entre repeticiones de pasos de velocidad de aceleración (en milisegundos). Cuanto más pequeño es más rápido.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Desaceleración Velocidad Paso Repetición Retardo</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Cuánto tiempo transcurre entre repeticiones de pasos de velocidad de desaceleración (en milisegundos). Cuanto más pequeño es más rápido.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Paso de velocidad "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Paso de velocidad </string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Cuánto salta la velocidad real en cada paso hasta la velocidad objetivo.  Cuanto más grande es más rápido.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Muescas del acelerador</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Ajuste el acelerador como porcentaje o mediante un número específico de pasos/muescas</string>
@@ -902,7 +918,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Ajustar el número de pasos en el control deslizante de freno</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Califica la actualización de los frenos de aire</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Ajuste la velocidad a la que los frenos de aire se actualizarán/recargarán (en milisegundos). Cuanto más pequeño es más rápido.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Número de carga "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Número de carga </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Ajustar el número de pasos en el control deslizante de carga</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Multiplicador de porcentaje de carga</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Ajuste el efecto del control deslizante de carga en los cambios de velocidad. >100% = más carga</string>
@@ -928,6 +944,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Opciones de deslizamiento al cambiar de pantallas</string>
     <string name="prefHapticFeedbackDurationTitle">Comentarios de la duración táctil</string>
     <string name="prefHapticFeedbackDurationSummary">Duración de cada vibración (en milisegundos)</string>
+    <string name="prefHapticFeedbackButtonsTitle">Duración de cada vibración (en milisegundos).</string>
+    <string name="prefHapticFeedbackButtonsSummary">Retroalimentación háptica al presionar botones</string>
     <string name="LocoSelectMethodIDNGo">Solicitar ID de Locomotora</string>
     <string name="idngo_label">Solicitar ID de Locomotora</string>
     <string name="idngo_button">Solicitar ID de Locomotora</string>
@@ -958,6 +976,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Retraso (impulso) por cambio de paso en milisegundos (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">En el impulso telefónico</string>
     <string name="deviceSoundsMuteButton">Silencio</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 y F2 también activan la campana y la bocina IPLS</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">¿F1 y F2 activan Bell y Horn?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Ocultar el botón de silencio IPLS en los aceleradores</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Ocultar botón de silencio</string>
     <string name="prefDeviceSoundsButtonSummary">Mostrar un botón de la barra de acción para cambiar las opciones de sonidos de LOCO de teléfono.</string>
     <string name="prefDeviceSoundsButtonTitle">En el botón de sonidos telefónicos</string>
     <string name="deviceSoundsMenu">Suena loco</string>
@@ -971,7 +993,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Botón de campana Latching / Momenty</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botón de campana es momentáneo. (Enganchando si no se controla).</string>
 <!--    <string name="permissionsReadLegacyFiles">El controlador del motor necesita permisos de almacenamiento para cargar la configuración de Legacy (antigua ubicación).</string>-->
-    <string name="permissionsReadPhoneState">El controlador del motor necesita permisos telefónicos para pausar las operaciones cuando se llame.</string>
+    <string name="permissionsReadPhoneState">Engine Driver necesita permisos telefónicos para pausar las operaciones cuando se llame.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferencias adicionales</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Adicional en teléfono loco sonidas preferencias</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Los sonidos del paso de Loco jugarán hasta su final al cambiar el paso. La cantidad de impulso (arriba) se convierte en un tiempo mínimo solamente.</string>
@@ -1009,10 +1031,10 @@
     <string name="usingProtocolDCCEX">Usando el protocolo DCC-EX. Desactivar \"Use los comandos DCC-EX nativos\" Preferencia para usar el protocolo Witrottle.</string>
     <string name="prefDccexConnectionOptionSummary">Mostrar opción para cambiar entre los protocolos Withrottle y DCC-EX en la pantalla de conexión.</string>
     <string name="prefDccexConnectionOptionTitle">Opción de protocolo Mostrar</string>
-    <string name="prefActionBarShowDccExButtonSummary">Mostrar el botón en la barra de acción para acceder a la pantalla ECC-EX. (Solo para conexiones nativas de DCC-EX).</string>
+    <string name="prefActionBarShowDccExButtonSummary">Mostrar el botón en la barra de acción para acceder a la pantalla DCC-EX. (Solo para conexiones nativas de DCC-EX).</string>
     <string name="prefActionBarShowDccExButtonTitle">¿Botón DCC-EX?</string>
     <string name="DCCEXactionTypeLabel">Acción</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(excluir \'&lt;\' y \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(excluir \'&lt;\' y \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Claro</string>
     <string name="DccexConnectionOptionTitle">Protocolo de conexión</string>
     <string name="DccexFailed" tools:ignore="Typos">Accion: Fallida</string>
@@ -1024,10 +1046,10 @@
     <string name="DccexSendCommandButtonLabel">Enviar</string>
     <string name="witActionTypeLabel">Acción</string>
     <string name="witWriteAddressLabel">Dirección DCC</string>
-    <string name="witPomWarning">Notas: - Esto no funcionará en algunos sistemas DCC. - Se evita el cambio de dirección de locomotora - CV 1, 17 y 2. 18 y bit 5 de CV 29. \\n\\nUtilizar con precaución.</string>
+    <string name="witPomWarning">Notas: - Esto no funcionará en algunos sistemas DCC. - Se evita el cambio de dirección de locomotora - CV 1, 17 y 2. 18 y bit 5 de CV 29.\n\nUtilizar con precaución.</string>
     <string name="witPomMaxValueWarning">El valor \'%1$s\' excede el máximo admitido (\'%2$s\')</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">CMD comunes</string>
+    <string name="DCCEXcommonCommandsLabel">CMD comunes</string>
     <string name="DCCEXsetTrackButtonLabel">Colocar</string>
     <string name="DccexSucceeded">Acción tuvo éxito</string>
     <string name="DCCEXturnoutClosed">Cerrado</string>
@@ -1067,4 +1089,22 @@
     <string name="order">Clasificar</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">¿Mostrar siempre Lanzar/Cerrar?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Muestre siempre los botones Lanzar y Cerrar para Desvíos, nunca el botón Alternar.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Unirse</string>
+
+    <string name="air_reservoir">Depósito de aire</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Tipo de freno decodificador</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Aktivieren Sie die Bremsfunktionen am Decoder</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Niedrige ESU-Funktionsnummer</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU – Welche Decoderfunktion soll bei niedrigem Bremswert aktiviert werden?</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">ESU Mid Function Number</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU – Welche Decoderfunktion soll bei mittlerem Bremswert aktiviert werden?</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">ESU High Function Number</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU – Welche Decoderfunktion soll bei hohem Bremswert aktiviert werden?</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Niedriger ESU-Bremswert (Prozent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU – Welcher Prozentsatz der Bremse, um die niedrige Funktionsnummer zu aktivieren</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">ESU Mid Brake Wert (Prozent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU – Welcher Prozentsatz der Bremse, um die mittlere Funktionsnummer zu aktivieren</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">ESU-Hochbremswert (Prozent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU – Welcher Prozentsatz der Bremse, um die hohe Funktionsnummer zu aktivieren</string>
+
 </resources>

--- a/EngineDriver/src/main/res/values-fr-rCA/strings.xml
+++ b/EngineDriver/src/main/res/values-fr-rCA/strings.xml
@@ -1,0 +1,548 @@
+<!--
+      Copyright (C) 2017 M. Steve Todd mstevetodd@gmail.com
+      This program is free software; you can redistribute it and/or modify it
+      under the terms of the GNU General Public License as published by the
+      Free Software Foundation;
+      either version 3 of the License, or (at your option) any later version.
+
+      This program is distributed in the hope that it will be useful, but
+      WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+      or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+      for more details. You should have received a copy of the GNU General
+      Public License along with this program; if not, write to the Free Software
+      Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+      original translation by Alain Carasso
+-->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="about">À propos</string>
+
+
+    <string name="app_description">Engine Driver - Application pour Android. Cette application peut se connecter à un serveur JMRI, DCC-EX, MRC ou DigiTrax WiThrottle, et à son tour contrôler vos locomotives. La vitesse, la direction et jusqu\'à 32 fonctions DCC sont prises en charge pour une ou deux locomotives.</string>
+
+    <string name="app_name_about">À propos</string>
+    <string name="app_name_connect">Connexion au Serveur - Engine Driver</string>
+    <string name="app_name_consist_functions">Paramètres des fonctions d\'unités multiples</string>
+    <string name="app_name_ConsistEdit">Édition des unités multipes</string>
+    <string name="app_name_ConsistLightsEdit">Phares des unités multiples</string>
+    <string name="app_name_device_sounds_settings">Sons des locomotives via le téléphone</string>
+    <string name="app_name_functions">Paramètres des fonctions par défaut - Engine Driver</string>
+    <string name="app_name_gamepad_test">Manette de jeu - Engine Driver</string>
+
+    <string name="app_name_log_viewer">Visionneuse du journal</string>
+    <string name="app_name_power_control">Contrôle de l\'alimentation - Engine Driver</string>
+
+    <string name="app_name_reconnect_status">État de la reconnexion</string>
+    <string name="app_name_reconnect_status_long">État de la reconnexion - Engine Driver</string>
+
+    <string name="app_name_select_loco">Sélection / Libération de locomotive - Engine Driver</string>
+    <string name="app_name_throttle">Régulateur - Engine Driver</string>
+    <string name="app_name_throttle_kids_enabled">Régulateur - Minuterie prête</string>
+    <string name="app_name_throttle_kids_ended">Régulateur - Minuterie terminée</string>
+    <string name="app_name_throttle_kids_running">Régulateur - %1$s secondes restantes</string>
+    <string name="app_name_throttle_short">Régulateur</string>
+    <string name="app_name_turnouts_short">Aiguillages</string>
+    <string name="app_name_turnouts">Aiguillages - Engine Driver</string>
+
+
+    <string name="ca_recent_conn_notice">Les connexions récentes ne sont pas disponibles - Carte SD introuvable.</string>
+    <string name="cancel">Annuler</string>
+    <string name="ClearConnList">Effacer la liste des locomotives récemment utilisées</string>
+    <string name="clearLocoList">Effacer la liste</string>
+    <string name="close_button">Fermer</string>
+
+    <string name="consist_help">Choisir une locomotive pour définir sa direction de marche en fonction de la locomotive de tête. Un appui long supprime la locomotive de l\'unité multiple.  Appuyer sur la flèche de retour une fois terminé.</string>
+
+    <string name="consist_list_label">Unité multiple de tête</string>
+
+    <string name="ConsistEditLabelLead">TÊTE</string>
+
+    <string name="consistLights_help">Cliquer sur une locomotive pour alterner les phares entre \'Off\' et \'Selon la touche de fonction\'.\n\nUn clic prolongé sur une locomotive force l\'état des phares à \'Off\' sans envoyer la commande vers la locomotive (ie: si Engine Driver est confus par exemple).\n\nAppuyer sur la flèche de retour une fois terminé.</string>
+
+
+    <string name="copy_function_labels">Copier les libellés à partir du catalogue (JMRI roster)</string>
+
+    <string name="cv29AddressSize2bit">Adresse courte: 2 bits (0-127)</string>
+    <string name="cv29AddressSize4bit">Adresse longue: 4 bits (1-10239)</string>
+    <string name="cv29AnalogueConversionOff">Conversion analogique: OFF</string>
+    <string name="cv29AnalogueConversionOn">Conversion analogique: ON</string>
+    <string name="cv29DirectionForward">Direction de marche: Avant</string>
+    <string name="cv29DirectionReverse">Direction de marche: Recul</string>
+    <string name="cv29SpeedSteps14">Crans de vitesse: 14</string>
+    <string name="cv29SpeedSteps28">Crans de vitesse: 28/128</string>
+    <string name="cv29SpeedTableNo">Table de vitesse: Inutilisée (utilisation des CV 2, 5 et 6)</string>
+    <string name="cv29SpeedTableYes">Table de vitesse: En utilisation</string>
+    <string name="cv29SpeedToggleDirection">Écrire une valeur %d dans le CV29 pour changer la direction de marche.</string>
+    <string name="dccesp_settings">DCC ESP - Réglages</string>
+
+
+
+    <string name="DCCEXclearCommands">Effacer</string>
+
+    <string name="DCCEXcommonCvsLabel">CV du NMRA</string>
+
+
+    <string name="DccexFailed">Action échouée</string>
+    <string name="dccExFunctionSettings">DCC-EX - Réglages des fonctions</string>
+
+
+
+
+
+    <string name="DccexPreviousCommandButtonLabel">Précédent</string>
+
+    <string name="DCCEXrequestLocoIdFailed">Acquisition du \'Loco ID\' a échoué</string>
+
+    <string name="DCCEXrouteSet">Assigner</string>
+
+    <string name="DCCEXsetTrackButtonLabel">Assigner</string>
+    <string name="DccexSucceeded">Action réussie</string>
+
+
+    <string name="DCCEXturnoutThrown">Ouvert</string>
+
+    <string name="DccexWriteAddressButtonLabel">Écrire</string>
+
+    <string name="DCCEXJoinTrackButtonLabel">Joindre</string>
+    <string name="DccexSendCommandLabel">Cmd DCC-EX\n<small>(exclure \'&lt;\' and \'&gt;\')</small></string>
+
+
+    <string name="deviceSoundsMenu">Sons de locomotive via le téléphone</string>
+
+
+    <string name="dialogConfirmImportPreferencesTitle">Préférences pour les importations</string>
+
+    <string name="dialogImportPreferencesQuestion">Confirmer l\'importation des préférences.\nLes préférences actuelles seront perdues.</string>
+    <string name="dialogRecentConnectionsConfirmClearQuestions">Confirmer la suppression de toutes les connexions récemment utilisées</string>
+    <string name="dialogRecentConsistsConfirmClearQuestions">Confirmer la suppression de toutes les Unités Multiples récemment utilisées</string>
+    <string name="dialogRecentLocoConfirmClearQuestion">Confirmer la suppression de toutes les locomotives récemment utilisées</string>
+    <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirmer la suppression de tous les aiguillages récemment utilisés</string>
+    <string name="dialogResetPreferencesQuestion">Confirmer la réinitialisation de toutes les préférences.\nTOUTES les préférences actuelles seront perdues.</string>
+
+
+
+
+
+    <string name="discovered_services">Serveurs découverts</string>
+
+    <string name="edit_consist_lights_throttle_1">Modifier phares de l\'unité multiple du régulateur 1</string>
+    <string name="edit_consist_lights_throttle_2">Modifier phares de l\'unité multiple du régulateur 2</string>
+    <string name="edit_consist_lights_throttle_3">Modifier phares de l\'unité multiple du régulateur 3</string>
+    <string name="edit_consist_lights_throttle_4">Modifier phares de l\'unité multiple du régulateur 4</string>
+    <string name="edit_consist_lights_throttle_5">Modifier phares de l\'unité multiple du régulateur 5</string>
+    <string name="edit_consist_lights_throttle_6">Modifier phares de l\'unité multiple du régulateur 6</string>
+    <string name="edit_consist_throttle_1">Modifier l\'unité multiple du régulateur 1</string>
+    <string name="edit_consist_throttle_2">Modifier l\'unité multiple du régulateur 2</string>
+    <string name="edit_consist_throttle_3">Modifier l\'unité multiple du régulateur 3</string>
+    <string name="edit_consist_throttle_4">Modifier l\'unité multiple du régulateur 4</string>
+    <string name="edit_consist_throttle_5">Modifier l\'unité multiple du régulateur 5</string>
+    <string name="edit_consist_throttle_6">Modifier l\'unité multiple du régulateur 6</string>
+    <string name="editConsistButtonLabel">Modifier l\'ordre et la direction de marche</string>
+    <string name="editConsistLightsButtonLabel">Modifier phares</string>
+    <string name="editConsistLocoFacingLabel">Orientation</string>
+
+
+    <string name="EsuMc2KnobAction">Activer / Désactiver la molette</string>
+    <string name="exit">Quitter</string>
+    <string name="exit_text">Quitter Engine Driver?</string>
+    <string name="exit_title">Quitter</string>
+    <string name="fb_column_function"># Fonct.</string>
+
+    <string name="fb_header">Modifier les fonctions</string>
+    <string name="fb_helptext">Saisir les libellés et numéros de fonction dans la liste de droite.  Laisser le libellé à blanc pour cacher cette touche.  Ils serviront lorsque les informations du cataloogue ne sont pas disponibles.</string>
+
+    <string name="fbResetFunctionLabels">Réinitialisation complète</string>
+
+    <string name="FilterRosterListHint">Contient...</string>
+
+
+
+
+    <string name="flashlightAction">Lampe de poche</string>
+    <string name="flashlightStateOff">Lampe de poche éteinte</string>
+    <string name="flashlightStateOn">Lampe de poche allumée</string>
+
+    <string name="fs_edit_notice"> ATTENTION: Les modifications des paramètres des fonctions par défaut seront perdues à la sortie de l\'application - Aucune carte SD trouvée!</string>
+
+    <string name="functionButton00DefaultValue">Phares</string>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <string name="functionButtonLookForBell">CLOCHE</string>
+    <string name="functionButtonLookForHead">TÊTE</string>
+
+    <string name="functionButtonLookForLight">PHARES</string>
+
+
+
+
+
+    <string name="functionConsistHeader">Actions des fonctions d\'unités multiples</string>
+    <string name="functionConsistHelpText">Utilisation uniquement pour les fonctions d\'unités multiples \'Spéciales\' suivantes.  Spécifier comment sera recherché le libellé de chaque fonction pour chacune des locomotives de l\'unité multiple.</string>
+    <string name="functionConsistSettings">Paramètres d\'unités multiples</string>
+    <string name="gamepad_test_reset">Réinitialisation complète de la manette de jeu</string>
+    <string name="gamepad1_test">Vérification de la manette de jeu 1</string>
+    <string name="gamepad2_test">Vérification de la manette de jeu 2</string>
+    <string name="gamepad3_test">Vérification de la manette de jeu 3</string>
+    <string name="gamepadTestAllKeyCodesLabel">Tous les codes:\s\s</string>
+
+
+    <string name="gamepadTestButtonLabelButtonEnter">Sélectionner | Entrer</string>
+    <string name="gamepadTestButtonLabelButtonLeftShoulder">Gâchette haute de gauche</string>
+    <string name="gamepadTestButtonLabelButtonLeftThumb">Joystick de gauche</string>
+    <string name="gamepadTestButtonLabelButtonLeftTrigger">Gâchette de gauche</string>
+    <string name="gamepadTestButtonLabelButtonRightShoulder">Gâchette haute de droite</string>
+    <string name="gamepadTestButtonLabelButtonRightThumb">Joystick de droite</string>
+    <string name="gamepadTestButtonLabelButtonRightTrigger">Gâchette de droite</string>
+    <string name="gamepadTestButtonLabelButtonStart">Démarrer | Entrer</string>
+
+
+
+
+
+
+    <string name="gamepadTestCancel">Annuler</string>
+
+    <string name="gamepadTestComplete">Test complété</string>
+    <string name="gamepadTestCompleteLabel">État du test:\s\s</string>
+    <string name="gamepadTestCompleteToast">Test de la manette de jeu terminé avec succès</string>
+
+
+    <string name="gamepadTestHelp">Défiler vers le bas pour consulter l\'ensemble des instructions...\n\nAppuyer sur les 4 extrémités de la croix ainsi que les 4 touches primaires sinon la manette de jeu NE FONCTIONNERA PAS.\n\nSi vous ne pouvez activer l\'ensemble des touches, changer le mode de disposition des boutons de la manette de jeu (suivre les instructions fournies avec votre manette de jeu) ou essayer un différent type de manette de jeu (voir plus haut).\n\n\'RETOUR\' ou \'ANNULER\' terminera le test mais la manette de jeu ne fonctionnera pas.\n\'IGNORER\' ou appuyer à 3 répétitions sur la touche de réduction de vitesse de la manette de jeu forcera la réussite du test et ce même si la manette de jeu ne fonctionne pas correctement.\n\'RÉINITIALISATION\' fera croire à Engine Driver qu\'aucune manette de jeu n\'a été utilisée jusqu\'à présent.\nlfTest \'Simple\' est sélectionné, un simple appui sur la touche \'Réduire vitesse\' annulera le test.\n\nUtiliser les options du menu \'Test de la manette de jeu\' pour revenir à cette page.</string>
+    <string name="gamepadTestHelpNonForced">Si vous ne pouvez activer l\'ensemble des boutons, changer le mode de disposition des boutons de la manette de jeu (suivre les instructions fournies avec votre manette de jeu) ou essayer un différent type de manette de jeu (voir plus haut).\nIl peut être nécessaire de refaire le test de la manette de jeu lors de sa première utilisation à partir de l\'écran du régulateur.</string>
+
+    <string name="gamepadTestInvalidKeycode">Code numérique invalide pour ce mode</string>
+    <string name="gamepadTestKeyboardHelp">Sélectionner \'Ignorer\' ci-dessous pour utiliser le clavier--------------------Commandes du clavier--------------------Haut ou \'+\' ou \'=\' = Augmenter la vitesseBas ou \'-\' = Réduire la vitesse\'X\' = ArrêtGauche ou \'\[\' = Marche arrière (Marche avant si les touches sont interchangées dans les préférences)Droite ou \'\]\' = Marche avant (Marche arrière si les touches sont interchangées dans les préférences)\'D\' = Direction de marche - Alterne entre Avant/Arrière\'N\' = Régulateur suivant\'Z\' = Arrêt completF00 - F28 = FonctionDoit débuter par \'F\' suivi de 2 chiffres\'0\'-\'9\' = Fonctions 0-9Sans aucun préfixe \'F\', \'S\' or \'L\'S000 - S100 = VitesseDoit débuter par \'S\' suivi de 3 chiffresSons de locomotive émis par le téléphone (IPLS)\'B\' = Cloche\'H\' = Klaxon / SiffletShift + \'H\' = Klaxon court\'M\' ou Volume Muet = Rendre IPLS muetT0 - T5 = Spécifier un régulateur pour la prochaine commandeDoit débuter par \'T\' suivi d\'un seul chiffreLa commande qui suivra sera dirigée vers le régulateur spécifié indépendemment de la manette de jeu actuellement sélectionnéeToutes les autres commandes sont ignoréesNe pas compléter \'F\', \'S\' ou \'L\' avec le bon nombre de chiffres annulera cette commande</string>
+    <string name="gamepadTestKeycodeLabel">Code de clé:\s\s</string>
+
+
+
+
+
+
+
+    <string name="gamepadTestOptionalLabel">Optionnel (peut ne pas être présent sur l\'appareil)</string>
+    <string name="gamepadTestReset">Réinitialiser</string>
+    <string name="gamepadTestSkip">Ignorer</string>
+
+    <string name="idngo_button">Demander le ID de la loco</string>
+    <string name="idngo_help_text">Appuyer sur la touche pour envoyer une requête au serveur pour identifier et acquérir la locomotive actuellement sur la voie de programmation et retourner ses valeurs au régulateur.</string>
+    <string name="idngo_label">Demander le ID de la loco</string>
+    <string name="importServerAutoDialog">Un nouveau fichier de préférences a été trouvé sur ce serveur: (%1$s).\nVoulez-vous importer celles-ci?\n\nAttention!\n\'Complet\' - Toutes vos préférences seront écrasées.\n\n\'Partiel\' - Toutes les préférences, sauf la thématique et quelques préférences de type de page seront écrasées.</string>
+
+
+    <string name="infoSaveLogFile">Enregistré sous: %s</string>
+
+
+
+    <string name="introbackButtonPress">Svp, redémarrer l\'application Engine Driver pour terminer l\'introduction.</string>
+
+    <string name="introButtonsSlider">Curseur seulement\n(non disponible avec \'Grosses touches\')</string>
+    <string name="introButtonsSliderAndButtons">Curseur + touches\n(non disponible avec \'Grosses touches\')</string>
+    <string name="introButtonsSummary">Sélectionner comment ajuster la vitesse de vos trains.</string>
+    <string name="introButtonsTitle">Vitesse des curseurs et touches</string>
+
+
+    <string name="introFinishSummary2">Pour des instructions détaillées, consulter la page \'À propos\' du menu ou visiter la page d\'accueil de Engine Driver au\n\'https://enginedriver.mstevetodd.com\'.</string>
+    <string name="introFinishSummary3">Il est possible d\'effectuer des ajustements d\'apparence et de comportements de l\'application à partir du menu \'Préférences\'.</string>
+
+    <string name="introMenu">Assistant Introduction/Installation</string>
+    <string name="introThemeSummary">Sélectionner les couleurs et apparences de l\'ensemble de cette application.</string>
+    <string name="introThrottleNameSummary">Définir un nom pour cet appareil</string>
+    <string name="introThrottleNameSummary1">Le nom défini apparaîtra dans la fenêtre WiThrottle de JMRI.  Ceci peut aider quand vient le temps de résoudre des problèmes avec plusieurs régulateurs connectés.  Ce nom doit être unique.</string>
+    <string name="introThrottleTypeSummary">Sélectionner la mise en page de l\'écran principal.</string>
+    <string name="introThrottleTypeSummary2">Selon la mise en page sélectionnée, le nombre maximal de régulateurs (1 à 6) sera ajusté à l\'écran.</string>
+    <string name="introWelcomeSummary">Cette application peut se connecter à un serveur WIThrottle JMRI, MRC ou Digitrax pour contrôler vos locomotives et accessoires DCC.  Les pages qui suivent vous assisteront pour la configuration initiale.</string>
+
+    <string name="introDccexTitle">Options pour la EX-CommandStation</string>
+    <string name="introDccexSummary">Engine Driver offre des fonctionnalités additionnelles, incluant la programmation des CV si vous utilisez directement la EX-CommandStation de DCC-EX (et non via JMRI)\n\nEn répondant \'Oui\' ci-dessous, Engine Driver utilisera par défaut les commandes propres à DCC-EX au lieu de celles de WiThrottle si le nom du serveur contient \'DCC-EX\' ou \'DCCEX\'.</string>
+    <string name="introDccexQuestionYes">Oui, j\'utiliserai la EX-CommandStation</string>
+    <string name="introDccexQuestionNo">Non, je n\'utiliserai pas la EX-CommandStation</string>
+    <string name="kidsTimer">Minuterie</string>
+
+
+
+
+
+
+    <string name="lightsTextFollow">Copier Touche Fonc</string>
+
+
+    <string name="limitSpeedButtonLabel">Limiter vitesse</string>
+    <string name="load">Chargement</string>
+    <string name="location_all">TOUS LES EMPLACEMENTS</string>
+
+
+
+
+    <string name="locoPressToSelect">Sélectionner</string>
+
+    <string name="LocoSelectMethodHelp">Inscrire l\'adresse DCC de la locomotive ci-dessus et cliquer sur \'Acquérir\'.\nAlternativement, sélectionner une locomotive du catalogue JMRI (Roster) ou sélectionner à partir de la liste des locomotives récemment utilisées via la boutons radio ci-dessus.</string>
+    <string name="LocoSelectMethodIDNGo">Demander le ID de la loco</string>
+
+
+    <string name="LocoSelectMethodRecentConsist">Unités multiples récentes</string>
+    <string name="LocoSelectMethodRoster">Catalogue JMRI (Roster)</string>
+    <string name="logViewer">Affichage du journal</string>
+
+    <string name="logviewerSave">Débuter l\'enregistrement du fichier</string>
+
+
+
+
+
+    <string name="none">Aucun</string>
+    <string name="notification_text">Appuyer pour ouvrir Engine Driver à nouveau</string>
+    <string name="notification_title">Engine Driver en cours d\'exécution</string>
+
+
+    <string name="ok">Ok</string>
+
+
+
+    <string name="permissionsACCESS_FINE_LOCATION">Engine Driver nécessite la permission ACCESS_FINE_LOCATION pour récupérer le SSDI Wi-Fi actuel.</string>
+    <string name="permissionsAppSettingsButton">Réglages de l\'application</string>
+
+
+
+    <string name="permissionsConnectToServer">Engine Driver nécessite la permission STORAGE pour consigner les connexions récentes et les permissions téléphoniques pour suspendre l\'application lors d\'un appel téléphonique.</string>
+
+
+    <string name="permissionsPOST_NOTIFICATIONS">Engine Driver nécessite la permission NOTIFICATION pour vous aviser avec des notifications lorsque l\'application est basculée en arrière plan.</string>
+    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver nécessite la permission READ_MEDIA_IMAGES pour afficher les images en arrière plan.</string>
+
+
+
+    <string name="permissionsReadPhoneState">Engine Driver nécessite la permission PHONE pour suspendre l\'application à la réception d\'un appel.</string>
+
+
+    <string name="permissionsRequestTitle">Permissions requises</string>
+
+
+
+
+
+
+
+    <string name="permissionsVIBRATE">Engine Driver nécessite la permission VIBRATE pour utiliser le retour haptique de votre appareil.</string>
+    <string name="permissionsWriteSettings">Engine Driver nécessite la permission WRITE SETTINGS pour altérer la luminosité de l\'écran.</string>
+    <string name="permissionsWriteSettingsAdditional">- Sélectionner le bouton ci-dessous.\nAccorder la permission.\n- Sélectionner \'Retour\' pour revenir à cet écran.</string>
+    <string name="permissionsWriteSettingsAdditional2">Ignorer ceci s\'il n\'est pas nécessaire que Engine Driver altère la luminosité de l\'écran.</string>
+
+
+
+    <string name="power_control_label">Paramètre de contrôle de l\'alimentation électrique du réseau.</string>
+    <string name="power_control_not_allowed">Le contrôle de l\'alimentation électrique du réseau n\'est pas permis.   Modifier le paramètre correspondant dans les préférences du serveur.</string>
+
+    <string name="powerWillNotWork">L\'alimentation électrique WiThrottle de JMRI est actuellement coupée.\nL\'icône d\'alimentation électrique n\'est plus visible mais elle réapparaîtra dès que JMRI rétablira l\'alimentation électrique.</string>
+
+
+    <string name="prefAccelerometerShakeSummary">Options quand l\'appareil est secoué.</string>
+
+    <string name="prefAccelerometerShakeThresholdSummary">Seuil à partir duquel la secousse sera détectée. (1.5&#8211;3.5)  Une valeur moindre détectera les secousses plus douces.\nNécessite un redémarrage de l\'application pour prendre effet.</string>
+    <string name="prefAccelerometerShakeThresholdTitle">Seuil de secousse</string>
+    <string name="prefAccelerometerShakeTitle">Action lors d\'une secousse</string>
+    <string name="prefAccelerometerSummary">Options de mouvement de l\'appareil pour la page du régulateur.</string>
+    <string name="prefAccelerometerTitle">Préférences de l\'accélémomètre</string>
+    <string name="prefActionBarShowDccExButtonSummary">Affiche une touche dans la barre d\'outils permettant l\'accès à l\'écran DCC-EX. (Pour les connexions directes DCC-EX seulement).</string>
+    <string name="prefActionBarShowDccExButtonTitle">Touche DCC-EX ?</string>
+    <string name="prefActionBarShowServerDescriptionSummary">Afficher la description du serveur actuel dans la barre d\'outils</string>
+    <string name="prefActionBarShowServerDescriptionTitle">Afficher la description du serveur</string>
+    <string name="prefAllowMobileDataSummary">Permettre à votre appareil une connexion à JMRI via les données mobiles.</string>
+    <string name="prefAllowMobileDataTitle">Permettre les connexions via les données mobiles.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Afficher les libellés de fonctions par défaut au lieu de ceux provenant du catalogue des locomotives (Roster).</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Afficher les libellés de fonctions par défaut au lieu de ceux provenant du catalogue des locomotives (Roster).\nCeci est un PRÉ-REQUIS pour activer le style la copie de règles \'Spéciales\'.</string>
+    <string name="prefCenterDirectionButtonsShortDefaultValue">N</string>
+    <string name="prefAlwaysUseFunctionsFromServerSummary">Si désactivé, utiliser les libellés par défaut de Engine Driver pour les locomotives sélectionées via une adresse (et non via le catalogue des locomotives (Roster)).  Les libellés par défaut du serveur sont ignorés.</string>
+
+
+
+    <string name="prefAlwaysUseFunctionsFromServerTitle">Toujours utiliser les libellés de fonctions provenant du serveur..</string>
+    <string name="prefAppIconActionSummary">Action exécutée lors d\'un clic sur l\'icône de l\'application ou sur le nom de l\'application dans la barre d\'outils.</string>
+    <string name="prefAppIconActionTitle">Action de l\'icône de l\'application</string>
+
+    <string name="prefAutoImportExportSummary">Pour chacune des connexions vers un serveur, \'Importer\' AUTOMATIQUEMENT les préférences de ce serveur et optionnellement les \'Exporter\' à la déconnexion.\n(Pour réinitialiser systématiquement à un état précis, ajuster à \'Importation automatique sur connexion seulement\' après l\'utilisation initiale ou suite à une sauvegarde manuelle (ci-dessous)).</string>
+    <string name="prefAutoImportExportTitle">Importation/Exportation automatique par serveur</string>
+    <string name="prefBackgroundImageFileNameNoImageSelected">Aucune image sélectionée</string>
+    <string name="prefBackgroundImageFileNameSummary">Entrer le nom de l\'image d\'arrière plan.</string>
+    <string name="prefBackgroundImageFileNameTitle">Nom de fichier de l\'image d\'arrière plan.</string>
+    <string name="prefBackgroundImagePositionSummary">Spécifier l\'emplacement de l\'image d\'arrière plan sur l\'écran.</string>
+    <string name="prefBackgroundImagePositionTitle">Emplacement de l\'image d\'arrière plan</string>
+    <string name="prefBackgroundImagePreferencesTitle">Préférences de l\'image d\'arrière plan</string>
+    <string name="prefBackgroundImageSummary">Afficher une image d\'arrière plan sur l\'écran du régulateur</string>
+    <string name="prefBackgroundImageTitle">Image d\'arrière plan</string>
+    <string name="prefCategoryDevicePageTitle">Préférences de l\'appareil</string>
+    <string name="prefConnectTimeoutMsSummary">Delai de connexion initiale par défaut</string>
+    <string name="prefConnectTimeoutMsTitle">Délai de connexion initiale</string>
+
+    <string name="PrefConnectToFirstServerSummary">Connexion automatique au premier serveur WiThrottle découvert?</string>
+    <string name="PrefConnectToFirstServerTitle">Connexion automatique au premier serveur WiThrottle découvert?</string>
+    <string name="prefConsistFollowAction1Summary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux commandes de phares.</string>
+
+    <string name="prefConsistFollowAction2Summary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux fonctions trouvées.</string>
+    <string name="prefConsistFollowAction2Title">Action pour la chaîne de caractères 2</string>
+    <string name="prefConsistFollowAction3Summary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux fonctions trouvées.</string>
+    <string name="prefConsistFollowAction3Title">Action pour la chaîne de caractères 3</string>
+    <string name="prefConsistFollowAction4Summary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux fonctions trouvées.</string>
+    <string name="prefConsistFollowAction4Title">Action pour la chaîne de caractères 4</string>
+    <string name="prefConsistFollowAction5Summary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux fonctions trouvées.</string>
+    <string name="prefConsistFollowAction5Title">Action pour la chaîne de caractères 5</string>
+    <string name="prefConsistFollowDefaultActionSummary">Préciser quelles locomotives de l\'unité multiple\' doivent réagir aux touches de fonctions si aucune des règles ci-dessous ne sont respectées.</string>
+    <string name="prefConsistFollowDefaultActionTitle">Action effectuée si l\'ensemble de la validation échoue</string>
+    <string name="prefConsistFollowRuleStyleSummary">Préciser le style de règles à appliquer aux unités multiples lorsqu\'une touche de fonction est appuyée.\nNote: Si \'Utiliser le libellé par défaut des fonctions\' est activé, \'... Spéciales\' seront également appliqués à la locomotive de tête.</string>
+    <string name="prefConsistFollowRuleStyleTitle">Fonctions des unités multiples - Respecter le style de la règle</string>
+    <string name="prefConsistFollowString1DefaultValue">PHARES</string>
+    <string name="prefConsistFollowString1Summary">Chaîne de caractères séparée par des virgules à inspecter pour les libellés des fonctions des locomotives de l\'unité multiple pour reconnaître la fonction \'Phares\' (habituellement F0).</string>
+    <string name="prefConsistFollowString1Title">Chaîne de caractères 1 spécifique aux phares</string>
+
+    <string name="prefConsistFollowString2Summary">Chaîne de caractères séparée par des virgules à inspecter pour les libellés des fonctions des locomotives de l\'unité multiple pour identifier une fonction similaire.</string>
+    <string name="prefConsistFollowString2Title">Chaîne de caractères 2</string>
+    <string name="prefConsistFollowString3Summary">Chaîne de caractères séparée par des virgules à inspecter pour les libellés des fonctions des locomotives de l\'unité multiple pour identifier une fonction similaire.</string>
+    <string name="prefConsistFollowString3Title">Chaîne de caractères 3</string>
+    <string name="prefConsistFollowString4Summary">Chaîne de caractères séparée par des virgules à inspecter pour les libellés des fonctions des locomotives de l\'unité multiple pour identifier une fonction similaire.</string>
+    <string name="prefConsistFollowString4Title">Chaîne de caractères 4</string>
+    <string name="prefConsistFollowString5Summary">Chaîne de caractères séparée par des virgules à inspecter pour les libellés des fonctions des locomotives de l\'unité multiple pour identifier une fonction similaire.</string>
+    <string name="prefConsistFollowString5Title">Chaîne de caractères 5</string>
+    <string name="prefConsistFollowSummary">Options pour déterminer le comportement des fonctions à l\'intérieur des unités multiples.</string>
+    <string name="prefConsistFollowTitle">Préférences à suivre pour les fonctions des unités multiples</string>
+    <string name="prefConsistLightsLongClickSummary">Modifier de façon indépendante les phares de chacune des locomotives des unités multiples en appuyant longuement sur la touche de sélection des locomotives.</string>
+    <string name="prefConsistLightsLongClickTitle">Gestion des phares des unités multiples via un appui prolongé</string>
+    <string name="prefDccexConnectionOptionSummary">Afficher l\'option de basculer entre les protocoles WiThrottle et DCC-EX à l\'écran de connexion.</string>
+    <string name="prefDccexConnectionOptionTitle">Afficher les options des protocoles</string>
+
+
+    <string name="prefDccexSummary">Utilisation des commandes natives DCC-EX plutôt que celles de WiThrottle pour l\'ensemble des connexions.  Note: Ne prendra effet qu\'au prochain redémarrage de Engine Driver suivi d\'une connexion à un serveur.</string>
+    <string name="prefDccexTitle">Utilisation des commandes natives DCC-EX</string>
+    <string name="prefDecreaseLocoNumberHeightSummary">Réduire la taille des touches Numéro loco, vitesse et direction de marche.</string>
+    <string name="prefDecreaseLocoNumberHeightTitle">Réduire la taille du numéro de locomotive?</string>
+
+    <string name="prefDefaultAddressLengthSummary">Longueur par défaut de l\'adresse de locomotive (Auto se basera sur le nombre de chiffres inscrits).</string>
+    <string name="prefDefaultAddressLengthTitle">Longueur par défaut de l\'adresse de locomotive</string>
+    <string name="prefDefaultFunctionsSummary">Indique quand ainsi que la façon dont sont affichés les libellés des touches de fonctions.</string>
+    <string name="prefDefaultFunctionsTitle">Préférences par défaut des touches de fonction</string>
+
+    <string name="prefDelimiterSummary">Spécifier le caractère qui délimite la fin de la portion de l\'emplacement de l\'aiguillage et des noms de routes</string>
+    <string name="prefDelimiterTitle">Délémiteur d\'emplacement</string>
+    <string name="prefDeviceSounds0Summary">Utiliser les sons de base via le téléphone pour le régulateur 1</string>
+    <string name="prefDeviceSounds0Title">Sons de locomotive - Régulateur 1</string>
+    <string name="prefDeviceSounds1Summary">Utiliser les sons de base via le téléphone pour le régulateur 2</string>
+    <string name="prefDeviceSounds1Title">Sons de locomotive - Régulateur 2</string>
+    <string name="prefDeviceSoundsAdditionalPreferencesSummary">Préférences supplémentaires pour les sons via le téléphone.</string>
+
+
+
+    <string name="prefDeviceSoundsBellIsMomentarySummary">La touche Cloche est momentanée.  (Verrouillage si décoché).</string>
+    <string name="prefDeviceSoundsBellIsMomentaryTitle">Touche Cloche verrouillée / momentanée</string>
+    <string name="prefDeviceSoundsBellVolumeSummary">Volume des sons de cloche via le téléphone (1-100)</string>
+    <string name="prefDeviceSoundsBellVolumeTitle">Volume des sons de cloche via le téléphone</string>
+    <string name="prefDeviceSoundsButtonSummary">Afficher une touche sur la barre d\'outils pour modifier les sons de locomotives via le téléphone</string>
+    <string name="prefDeviceSoundsButtonTitle">Touche de volume des sons via le téléphone</string>
+    <string name="prefDeviceSoundsCategoryTitle">Volume des sons de locomotives via le téléphone</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 et F2 activent également la cloche IPLS et le klaxon</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 et F2 activent la cloche et le klaxon?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Ne pas afficher la touche Muet sur les régulateurs</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Ne pas afficher la touche Muet</string>
+    <string name="prefDeviceSoundsHornVolumeSummary">Volume des sons de cloche/sifflet va le téléphone (1-100)</string>
+    <string name="prefDeviceSoundsHornVolumeTitle">Volume du klaxon et du sifflet via le téléphone</string>
+    <string name="prefDeviceSoundsLocoVolumeSummary">Volume des sons de moteur via le téléphone (1-100)</string>
+    <string name="prefDeviceSoundsLocoVolumeTitle">Volume des sons de locomotives via le téléphone</string>
+    <string name="prefDeviceSoundsMomentumOverrideSummary">Les sons de locomotives proportionnels à la vitesse sont joués en entier lors d\'un changement de régime moteur.  Le taux de momentum (ci-dessus) devient un temps minimal seulement.</string>
+    <string name="prefDeviceSoundsMomentumOverrideTitle">Ne pa interrompre les sons proportionnnels à la vitesse</string>
+    <string name="prefDeviceSoundsMomentumSummary">Délai (momentum) par changement de régime en millisecondes (0-2000)</string>
+    <string name="prefDeviceSoundsMomentumTitle">Momentum via le téléphone</string>
+    <string name="prefDirChangeWhileMovingSummary">Permettre le changement de direction de marche en déplacement.</string>
+    <string name="prefDirChangeWhileMovingTitle">Changement de direction de marche en déplacement?</string>
+
+    <string name="prefDirectionButtonLongPressDelaySummary">Combien de millisecondes constituent un appui long sur les touches de direction de marche.</string>
+    <string name="prefDirectionButtonLongPressDelayTitle">Délai de l\'appui long des touches de direction de marche.</string>
+
+
+
+    <string name="prefDirectionSummary">Options pour les touches de direction de marche.</string>
+    <string name="prefDirectionTitle">Préférences des touches de direction de marche</string>
+    <string name="prefDisableVolumeKeysSummary">Désactiver les boutons physiques de volume de l\'appareil/tablette qui autrement contrôleraient la vitesse.  Note: Si sélectionné: remplace \'l\'indicateur de sélection de locomotive additionnelle\'.</string>
+    <string name="prefDisableVolumeKeysTitle">Désactiver les boutons physiques de volume de l\'appareil.</string>
+
+    <string name="prefDisplayClockSummary">Spécifier le format de l\'horloge rapide (Fast clock) dans les écrans du régulateur et des écrans web.</string>
+    <string name="prefDisplayClockTitle">Affichage de l\'horloge rapide (Fast clock)</string>
+    <string name="prefDisplaySpeedArrowsSummary">Aficher des touches près du curseur de vitesse afin de changer la vitesse de la locomotive??</string>
+    <string name="prefDisplaySpeedArrowsTitle">Afficher les touches de vitesse?</string>
+
+    <string name="prefDisplaySpeedUnitsSummary">Afficher la vitesse en pourcentage ou en nombre de crans (steps)?</string>
+    <string name="prefDisplaySpeedUnitsTitle">Unités de vitesse</string>
+    <string name="prefDropOnAcquireSummary">Libérer la locomotive actuelle avant d\'acquérir une nouvelle locomotive.</string>
+    <string name="prefDropOnAcquireTitle">Libérer la locomotive actuelle avant d\'acquérir?</string>
+    <string name="prefEmerStopSummary">Afficher la touche d\'arrêt d\'urgence dans la barre d\'outils?</string>
+    <string name="prefEmerStopTitle">Afficher la touche d\'arrêt d\'urgence?</string>
+
+
+    <string name="prefEsuMc2ButtonBLSummary">Sélectionner l\'action lorsqu\'une touche est apuyée.</string>
+    <string name="prefEsuMc2ButtonBLTitle">Action de la touche d\'action inférieure gauche</string>
+
+    <string name="prefEsuMc2ButtonBRSummary">Sélectionner l\'action lorsqu\'une touche est apuyée.</string>
+    <string name="prefEsuMc2ButtonBRTitle">Action de la touche d\'action inférieure droite</string>
+    <string name="prefEsuMc2ButtonsCategoryTitle">Options des touches latérales de l\'appareil</string>
+
+    <string name="prefEsuMc2ButtonsRepeatSummary">Délai entre les répétions des toudches latérales de l\'appareil.</string>
+    <string name="prefEsuMc2ButtonsRepeatTitle">Délai de répétition des touches</string>
+
+    <string name="prefEsuMc2ButtonTLSummary">Sélectioner l\'action quand la touche est appuyée.</string>
+    <string name="prefEsuMc2ButtonTLTitle">Action de la touche supérieure gauche</string>
+
+    <string name="prefEsuMc2ButtonTRSummary">Sélectioner l\'action quand la touche est appuyée.</string>
+    <string name="prefEsuMc2ButtonTRTitle">Action de la touche supérieure droite</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Permettre le changement de direction de marche de la locomotive quand la molette est tournée complètement en sens anti-horaire.</string>
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Changement de direction lorsque la molette est réglée à 0</string>
+    <string name="prefEsuMc2KnobButtonSummary">Permettre de désactiver la molette via une touche d\'action à l\'écran du régulateur.</string>
+    <string name="prefEsuMc2KnobButtonTitle">Afficher la touche de désactivation de la molette</string>
+    <string name="prefEsuMc2StopButtonCategoryTitle">Options lorsque la molette est réglée à 0</string>
+
+    <string name="prefEsuMc2StopButtonDelaySummary">Délai pour un \'appui prolongé\' de la touche d\'arrêt.\nUn \'appui prolongé\' force l\'arrêt de l\'ensemble des régulateurs; une \'pression rapide\' force l\'arrêt du régulateur actruel.\nUn valeur basse correspond à un délai plus court.</string>
+    <string name="prefEsuMc2StopButtonDelayTitle">Durée de l\'appui prolongé de la touche d\'arrêt</string>
+    <string name="prefEsuMc2StopButtonShortPressSummary"> Une \'pression rapide\' suspend la locomotive ou l\'unité multiple actuelle.\nLa vitesse sera rétablie à la reprise des opérationsl.</string>
+    <string name="prefEsuMc2StopButtonShortPressTitle">Activer la \'pression rapide\'</string>
+    <string name="prefEsuMc2Summary"> Sélectionner les options du module ESU MobileControl II</string>
+
+    <string name="prefEsuMc2Title">Options du module ESU MobileControl II</string>
+    <string name="prefEsuMc2ZeroTrimCategoryTitle">Options de la molette de contrôle</string>
+
+    <string name="prefEsuMc2ZeroTrimSummary">Définir la zone d\'arrêt de la molette de commande.\nUne valeur basse déplace la zone vers l\'extrémité anti-horaire.\nÉtendue autorisée 0&#8211;255.</string>
+    <string name="prefEsuMc2ZeroTrimTitle">Zone d\'arrêt de la molette de commande</string>
+    <string name="prefFeedbackOnDisconnectSummary">Émettre un son et faire vibrer l\'appareil lors d\'une déconnexion imPrévue.</string>
+    <string name="prefFeedbackOnDisconnectTitle">Réaction lors d\'une déconnexion</string>
+    <string name="prefFeedbackWhenGoingToBackgroundSummary">Alerte sonore lorsque l\'application se retrouve en arrière plan.</string>
+    <string name="prefFeedbackWhenGoingToBackgroundTitle">Alerte en arrière plan</string>
+    <string name="prefFlashlightSummary">Afficher la touche de lampe de poche à l\'écran du régulateur, des aiguillages et des itinéraires?</string>
+    <string name="prefFlashlightTitle">Afficher la touche de la lampe de poche?</string>
+    <string name="prefFullScreenSwipeAreaSummary">Lorsque activé, seule la barre d\'outils peut être balayée latéralement pour basculer entre les écrans</string>
+    <string name="prefFullScreenSwipeAreaTitle">Désactivation du balayage latéral plein écran</string>
+
+</resources>

--- a/EngineDriver/src/main/res/values-fr/arrays.xml
+++ b/EngineDriver/src/main/res/values-fr/arrays.xml
@@ -71,7 +71,7 @@
         <item tools:ignore="TypographyDashes">Switching - (2)</item>
         <item tools:ignore="TypographyDashes">Switching - Gauche (1)</item>
         <item tools:ignore="TypographyDashes">Switching - Droite (1)</item>
-        <item tools:ignore="TypographyDashes">Switching - Horizontal (3)</item>
+        <item tools:ignore="TypographyDashes">Switching - horizontale (1-3)</item>
         <item tools:ignore="TypographyDashes">Simple – Recommandé Tablette (1–6)</item>
         <item tools:ignore="TypographyDashes">Switching a gauche tablette (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablette verticale à gauche (1-6)</item>
@@ -84,7 +84,7 @@
         <item>Format 24 heures</item>
     </string-array>
 
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Arrêter tout</item>
         <item>Arrêt</item>
         <item>Avant</item>
@@ -132,11 +132,11 @@
         <item>Klaxon (IPLS)</item>
         <item>Klaxon court (IPLS)</item>
         <item>Annonce vitesse actuelle</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutre</item>
+        <item>Augmenter le frein</item>
+        <item>Diminuer le frein</item>
+        <item>Augmenter la charge</item>
+        <item>Diminuer la charge</item>
     </string-array>
 
 <!--
@@ -194,12 +194,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Utiliser les paramètres globaux du téléphone</item>
         <item>Anglais (Etats-Unis) - Engine Driver\'s Standard</item>
+        <item>Anglais (Australie)</item>
+        <item>Anglais (Canada)</item>
+        <item>Anglais (Nouvelle-Zélande)</item>
+        <item>Anglais (Royaume-Uni)</item>
         <item>Italien</item>
         <item>Portugais</item>
         <item>Allemand</item>
         <item>Espanol</item>
         <item>Catalan</item>
         <item>Français</item>
+        <item>Français (Canada)</item>
         <item>Tchèque</item>
     </string-array>
 
@@ -208,7 +213,7 @@
         <item>Correspondance exacte du texte - loco de tete toujours active, les autres locos suivent les règles suivantes</item>
         <item>Correspondance complete - Fonctions appliquees a toutes les locos en cas de correspondance exacte des libelles</item>
         <item>Correspondance partielle - Fonctions appliquees a toutes les locos en cas de correspondance partielle des libelles</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Le partiel spécial contient uniquement - Activé si l\'étiquette de fonction contient l\'étiquette par défaut</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
@@ -234,26 +239,6 @@
         <item>5 minutes</item>
         <item>10 minutes</item>
         <item>Session terminée</item>
-    </string-array>
-
-    <string-array name="prefGamePadTypeEntries">  <!-- display version -->
-        <item >Aucun</item>
-        <item >Mocute iCade</item>
-        <item >Mocute iCade+DPAD</item>
-        <item >Mocute MTK</item>
-        <item >Mocute Android-Game</item>
-        <item >Mocute Android-Game</item>
-        <item >MagicseeR1 Android-Game B</item>
-        <item >MagicseeR1 Android-Mode A</item>
-        <item >MagicseeR1 Android-Mode C</item>
-        <item >Flydigi Wee 2</item>
-        <item >Utopia 360 Android-C</item>
-        <item >Auvisio Android-B</item>
-        <item >Auvisio Android-B - ↺ DPAD</item>
-        <item tools:ignore="TypographyDashes">ESP32 DIY (Btns 0-9 +4x4 Hat +Encoder)</item>
-        <item tools:ignore="TypographyDashes">ESP32 DIY (Btns 0-9 +3x4 Hat +Encoder)</item>
-        <item >Keyboard</item>
-        <item >USB Volume Dial</item>
     </string-array>
 
     <string-array name="prefGamePadFlydigiWee2Labels">

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -19,13 +19,12 @@
     <string name="exit">Sortir</string>
     <string name="functionDefaultSettings">Fonction par défaut</string>
 <!--    <string name="fb_label">Libellé de  fonction</string>-->
-    <string name="functionLatchingSettings">Paramètres de verrouillage des fonctions</string>
+    <string name="functionLatchingSettings">Paramètres des fonctions de verrouillage</string>
     <string name="fb_column_label">Libellé</string>
     <string name="fb_column_function">Fn num.</string>
 <!--    <string name="function_buttons">Touche de fonction</string>-->
 
-
-    <string name="app_description">Engine Driver - Application pour Android. Cette application peut se connecter à un serveur JMRI, MRC ou DigiTrax WiThrottle, et à son tour contrôler vos locomotives. La vitesse, la direction et jusqu à 29 fonctions DCC sont prises en charge pour une ou deux locomotives.</string>
+    <string name="app_description">Engine Driver - Application pour Android. Cette application peut se connecter à un serveur JMRI, DCC-EX, MRC ou DigiTrax WiThrottle, et à son tour contrôler vos locomotives. La vitesse, la direction et jusqu à 32 fonctions DCC sont prises en charge pour une ou deux locomotives.</string>
 
     <string name="app_name_connect">Connection au Serveur</string>
     <string name="app_name_throttle">régulateur</string>
@@ -36,8 +35,7 @@
     <string name="app_name_routes">Itinéraires</string>
     <string name="app_name_routes_long">Engine Driver - Itinéraires</string>
     <string name="app_name_routes_short">Itinéraires</string>
-    <string name="app_name_turnouts">Aiguilles</string>
-    <string name="app_name_turnouts_long">Engine Driver - Aiguilles</string>
+    <string name="app_name_turnouts">Engine Driver - Aiguilles</string>
     <string name="app_name_turnouts_short">Aiguilles</string>
     <string name="app_name_about">A propos</string>
     <string name="app_name_functions">Paramètres par défaut de la fonction</string>
@@ -79,12 +77,11 @@
     <string name="fb_header">Editer/Modifier les fonctions</string>
     <string name="consist_help">Choisir une locomotive pour définir son sens de marche en fonction du sens de la locomotive de tête. Un appui long supprime la locomotive de l UM. Faire un retour arrière une fois terminé.</string>
     <string name="about">A propos</string>
-    <string name="web">Web</string>
     <string name="about_page_url">file:///android_asset/about_page-fr.html</string>
     <string name="mrc_settings">Paramètres MRC</string>
     <string name="loco">Loco:</string>
-    <string name="loco_direction_left_extra">"\u00B7A\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7A\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Sélection</string>
     <string name="powerWillNotWorkTitle">Ne fonctionnera pas!</string>
     <string name="powerWillNotWork">JMRI a coupé l alimentation WiThrottle.\nEffacement icone alimentation.\nAffichage Icone alimentation quand JMRI sera actif.</string>
@@ -123,7 +120,6 @@
     <string name="power">Alimentation</string>
     <string name="throttle">Commande</string>
 
-
     <string name="set">Activé</string>
     <string name="disabled">Désactivé</string>
 
@@ -142,7 +138,7 @@
     <string name="prefSwipeUpDownSummary">Options du Glisser Haut vers Bas sur régulateur</string>
     <string name="prefThrottleNameTitle">Nom du régulateur</string>
 
-    <string name="prefThrottleNameSummary">Définir le nom de ce terminal (affiché sur l écran WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Définir le nom de ce terminal (affiché sur l écran JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">orientation de l écran</string>
 
     <string name="prefThrottleOrientationSummary">orientation de l écran (sauf Web)</string>
@@ -188,8 +184,6 @@
     <string name="prefGamePadFeedbackVolumeTitle">\% de click des touches Gamepad</string>
     <string name="prefGamePadFeedbackVolumeSummary">Definition du pourcentage de volume pour les touches Gamepad</string>
 
-
-
     <string name="prefGamePadSpeedButtonsRepeatTitle">délai de répétion touche de vitesse</string>
     <string name="prefGamePadSpeedButtonsRepeatSummary">délai d attente répétition touches de vitesse Gamepad. Plus c est petit, plus ça va vite.</string>
 
@@ -207,16 +201,6 @@
     <string name="prefGamePadButtonDownTitle">Action touche DPAD Bas</string>
     <string name="prefGamePadButtonLeftTitle">Action touche DPAD Gauche</string>
     <string name="prefGamePadButtonSummary">Choisir l action affectée à la touche</string>
-
-
-
-
-
-
-
-
-
-
 
     <string name="prefEsuMc2Title">Options ESU MobileControl II</string>
     <string name="prefEsuMc2Summary">Choisir les options pour ESU MobileControl II</string>
@@ -258,14 +242,14 @@
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Laisser votre appareil se connecter en Data à JMRI</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Remplacer le verrouillage de la fonction WiThrottle</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Utilisez le verrouillage par défaut d\'Engine Driver pour les locs hors liste, plutôt que les valeurs par défaut fournies par WiThrottle.</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Affichez les étiquettes de fonction par défaut au lieu des étiquettes des entrées de la liste.                                                               \\nCela DOIT être activé pour utiliser les styles de règles de suivi \\\'Spécial\\\'.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Affichez les étiquettes de fonction par défaut au lieu des étiquettes des entrées de la liste.\nCela DOIT être activé pour utiliser les styles de règles de suivi \'Spécial\'.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Réduire hauteur icone locomotive?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Utilisation de touches plus petites pour n° de loco, vitesse et sens de marche.</string>
     <string name="prefNumOfThrottles">Nombre de régulateurs</string>
     <string name="prefNumOfThrottlesSummary">Choisir le nombre maximum de régulateurs désiré.</string>
 
     <string name="prefThrottleScreenTypeTitle">Type d écran du régulateur</string>
-    <string name="prefThrottleScreenTypeSummary">Quelle type d ecran utiliser pour le régulateur</string>
+    <string name="prefThrottleScreenTypeSummary">Quelle type d ecran utiliser pour le régulateur.\n(Le nombre entre parenthèses après le nom est le nombre de manettes que la disposition peut prendre en charge.)</string>
 
     <string name="prefMaximumThrottleTitle">Pourcentage de vitesse Maxi</string>
 
@@ -355,10 +339,6 @@
     <string name="prefDisplayClockTitle">Affichage Horloge rapide</string>
     <string name="prefDisplayClockSummary">Definition format d affichage de l Horloge rapide.</string>
 
-
-
-
-
     <string name="prefDisplaySpeedArrowsTitle">Afficher touches de vitesse?</string>
     <string name="prefDisplaySpeedArrowsSummary">Afficher aussi les touches de vitesse à coté du curseur de vitesse?</string>
 
@@ -416,6 +396,9 @@
     <string name="prefGamepadSwapForwardReverseWithScreenButtonsSummary">Inversion temporaire des touches de direction du Gamepad si les touches à l écran sont inversées.</string>
     <string name="prefGamepadTestEnforceTestingTitle">Test renforcé Gamepad</string>
     <string name="prefGamepadTestEnforceTestingSummary">Test du Gamepad à chaque connexion.</string>
+    <string name="prefHeartbeatResponseFactorTitle">Facteur de réponse au rythme cardiaque</string>
+    <string name="prefHeartbeatResponseFactorSummary">Pourcentage de la période de battement de coeur indiquant quand envoyer le battement de coeur (50 % à 90 %). Prend effet à la prochaine connexion.</string>
+    <string name="server">Serveur</string>
     <string name="prefGamepadTestEnforceTestingSimpleTitle">Test simplifié</string>
     <string name="prefGamepadTestEnforceTestingSimpleSummary">Test uniquement réduction de la vitesse</string>
     <string name="prefLeftDirectionButtonsTitle">Libellé touche de direction à Gauche</string>
@@ -435,14 +418,12 @@
 
     <string name="prefRightDirectionButtonsShortDefaultValue">AR</string>
 
-
-    <string name="prefThemeSummary">Thème de l appli.\nNécessite Android 3.0 minimum.</string>
+    <string name="prefThemeSummary">Thème de l appli.</string>
 
     <string name="prefHideDemoServerTitle">Cache le serveur de démonstration</string>
     <string name="prefHideDemoServerSummary">Cache le serveur de démonstration \'jmri.mstevetodd.com\'  dans la liste de serveurs de connexion.</string>
 <!--    <string name="prefDirectionButtonsTitle">Libellé des touches de direction</string>-->
 <!--    <string name="prefDirectionButtonsSummary">Libellé de toutes les touches de direction</string>-->
-
 
     <string name="prefAccelerometerTitle">Préférences de l accéléromètre</string>
     <string name="prefAccelerometerSummary">Options liées aux mouvements du terminal sur la page du régulateur.</string>
@@ -455,7 +436,6 @@
     <string name="functionButton00DefaultValue">Lampes</string>
     <string name="functionButton01DefaultValue">Cloche</string>
     <string name="functionButton02DefaultValue">Klaxon</string>
-
 
     <string name="gamepadTestButtonLabelDpadUp">Haut</string>
     <string name="gamepadTestButtonLabelDpadDown">Bas</string>
@@ -489,28 +469,29 @@
         \nIf \'simple\' test est choisi, un seul appui sur la touche \'Reduire vitesse\' sautera le test.
         \n
         \nUtilisez les options du menu \'Gamepad Test n\' pour revenir sur cette page.</string>
-    <string name="gamepadTestKeyboardHelp">"Sons via téléphone: \nB Cloche \nH Klaxon \nShift H Klaxon court \nM Coupe son
+    <string name="gamepadTestKeyboardHelp">Sons via téléphone: \nB Cloche \nH Klaxon \nShift H Klaxon court \nM Coupe son
         \n\nT0....Tx specifie manette x pour prochaine commande.
-        \n\nLes autres codes sont ignorés. "</string>
+        \n\nLes autres codes sont ignorés.</string>
     <string name="gamepadTestHelpNonForced">Si vous ne pouvez pas activer toutes les touches, changer le mode du Gamepad (voir notice) ou essayer un autre type de Gamepad (voir ci dessus).
         \n Vous serez peut etre ammener à tester à nouveau le Gamepad à la première utilisation via l écran du régulateur.</string>
-    <string name="gamepadTestIncomplete">"Test incomplet"</string>
-    <string name="gamepadTestComplete">"Test complet"</string>
-    <string name="gamepadTestCompleteToast">"Test du Gamepad terminé avec succès"</string>
-    <string name="gamepadTestInvalidKeycode">"Code clé invalide pour ce mode"</string>
-    <string name="gamepadTestReset">"Reset"</string>
-    <string name="gamepadTestCancel">"Annulation"</string>
-    <string name="gamepadTestCancelNonForced">"Fermer"</string>
-    <string name="gamepadTestSkip">"Passer"</string>
+    <string name="gamepadTestIncomplete">Test incomplet</string>
+    <string name="gamepadTestComplete">Test complet</string>
+    <string name="gamepadTestCompleteToast">Test du Gamepad terminé avec succès</string>
+    <string name="gamepadTestInvalidKeycode">Code clé invalide pour ce mode</string>
+    <string name="gamepadTestReset">Reset</string>
+    <string name="gamepadTestCancel">Annulation</string>
+    <string name="gamepadTestCancelNonForced">Fermer</string>
+    <string name="gamepadTestSkip">Passer</string>
 
-
-    <string name="gamepadTestKeyCodesUpCode">"H"</string>
-    <string name="gamepadTestKeyCodesDownCode">"B"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"G"</string>
-    <string name="gamepadTestKeyCodesRightCode">"D"</string>
+    <string name="gamepadTestKeyCodesUpCode">H</string>
+    <string name="gamepadTestKeyCodesDownCode">B</string>
+    <string name="gamepadTestKeyCodesLeftCode">G</string>
+    <string name="gamepadTestKeyCodesRightCode">D</string>
     <string name="prefGamepadTestNowTitle">Test paramétrage Gamepad!</string>
     <string name="prefGamepadTestNowSummary">Vous permet de confirmer que le paramétrage effectué fonctionne correctement.
         \nLa page de test va démarrer IMMEDIATEMENT!</string>
+    <string name="toastWaitingForConnection">Délai d\'attente en attente du message WiThrottle \'VN\' de %1$s:%2$s. Déconnexion</string>
+    <string name="toastWaitingForConnectionDccEx">Délai d\'attente pour le message DCC-EX \'iDCCEX...\' de %1$s:%2$s. Déconnexion</string>
     <string name="toastThreadedAppNoLocalIp">Adresse IP locale non trouvée.\n Verifier votre connexion WiFi.</string>
     <string name="toastThreadedAppErrorCreatingWiThrottle">Erreur à la création du listener WiThrottle Zeroconf: IOException:\n%1$s</string>
     <string name="toastThreadedAppWiThrottleNotSupported">WiThrottle version %1$s pas supportée.</string>
@@ -562,7 +543,7 @@
     <string name="toastConnectErrorSavingRecentConnection">Erreur en sauvegardant la liste de connexions récentes.</string>
     <string name="toastConnectRemoveDemoHostError">La suppression du serveur de démo ne peut se faire qu\'en modifiant les préférences</string>
     <string name="toastConnectRemoved">Serveur supprimé de la liste.</string>
-<!--    <string name="toastRoutesCommandSent">"Commande envoyée pour définir itinéraire "</string>-->
+<!--    <string name="toastRoutesCommandSent">Commande envoyée pour définir itinéraire </string>-->
     <string name="toastImportExportExportSucceeded">Exportation des préférences d \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' avec succès.</string>
     <string name="toastImportExportImportSucceeded">Importation des préférences d \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' avec succès.</string>
     <string name="toastImportExportExportFailed">Exportation des préférences d \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' en ERREUR.</string>
@@ -649,15 +630,15 @@
 <!--    <string name="FilterRosterList">Filtre</string>-->
     <string name="FilterRosterListHint">Contenant…</string>
 
-    <string name="prefRosterOwnersFilterShowOptionTitle">Filtrer par propriétaire de liste</string>
-    <string name="prefRosterOwnersFilterShowOptionSummary">Afficher une option pour filtrer la liste par propriétaire</string>
+    <string name="prefRosterOwnersFilterShowOptionTitle">Filtrer par propriétaires du catalogue</string>
+    <string name="prefRosterOwnersFilterShowOptionSummary">Afficher l\'option de filtrer par propriétaires du catalogue</string>
     <string name="prefRosterOwnersFilterDefaultOwner">Tous</string>
     <string name="LocoSelectMethodAddress">Adresse DCC</string>
     <string name="LocoSelectMethodRoster">Catalogue (roster) JMRI</string>
     <string name="LocoSelectMethodRecent">Récent</string>
-    <string name="LocoSelectMethodHelp">"Entrer l adresse DCC de la locomotive et cliquer sur \'Acquérir\'.
+    <string name="LocoSelectMethodHelp">Entrer l adresse DCC de la locomotive et cliquer sur \'Acquérir\'.
 \nOu la choisir dans le répertoire JMRI,
-\nOu la choisir dans les locomotives récentes en cliquant sur un des boutons ci dessus."</string>
+\nOu la choisir dans les locomotives récentes en cliquant sur un des boutons ci dessus.</string>
     <string name="flashlightAction">Lampe Flash</string>
     <string name="flashlightStateOn">Lampe Flash allumée</string>
     <string name="flashlightStateOff">Lampe Flash éteinte</string>
@@ -716,7 +697,7 @@
     <string name="introDccexSummary">Engine Driver permet des foncstionnalités supplémentaires, par exemple la programmation directe de CV sur une centrale DCC-EX (et pas via JMRI)
         \n\nSi vous repondez \'Oui\' ci-dessous, Engine Driver utiliserales commandes natives DCC-EX et pas celle de WiThrottle si le nom du serveur contient \'DCC-EX\' or \'DCCEX\'.</string>
     <string name="introDccexQuestionYes">Oui, j\'utiliserai une centrale EX-</string>
-    <string name="introDccexQuestionNo">Non, je n\\\'utiliserai pas une centrale EX-</string>
+    <string name="introDccexQuestionNo">Non, je n\'utiliserai pas une centrale EX-</string>
     <string name="introbackButtonPress">Merci de redémarrer Engine Driver pour terminer cette introduction.</string>
     <string name="functionButtonLookForWhistle">SIFFLET</string>
     <string name="functionButtonLookForHorn">KLAXON</string>
@@ -851,9 +832,9 @@
     <string name="dialogRecentLocoConfirmClearQuestion">Confirmer la suppression des dernières locomotives utilisées</string>
     <string name="dialogRecentTurnoutsConfirmClearQuestions">Confirmer la suppression des dernières aiguilles utilisées</string>
 
-    <string name="dialogDownloadRosterConfirmQuestion">Confirmez que vous souhaitez télécharger toutes les entrées de liste dans la liste des locomotives récentes.</string>
-    <string name="prefHideInstructionalToastsTitle">Masquer les conseils pédagogiques</string>
-    <string name="prefHideInstructionalToastsSummary">Masquer l\'aide/les conseils contextuels du « toast » pédagogique</string>
+    <string name="dialogDownloadRosterConfirmQuestion">Confirmer que le téléchargement des entrées du catalogue vers la liste des locomotives récemment utilisées</string>
+    <string name="prefHideInstructionalToastsTitle">Masquer les conseils instructifs</string>
+    <string name="prefHideInstructionalToastsSummary">Masquer l\'aide et les conseils instructifs contextuels </string>
     <string name="dialogConfirmResetPreferencesTitle">Réinitialiser les préférences</string>
     <string name="dialogResetPreferencesQuestion">Confirmer la réinitialisation de toutes les préférences.\nTOUTES PREFERENCES REINITIALISEES</string>
     <string name="dialogConfirmImportPreferencesTitle">Préférences pour les imports</string>
@@ -929,7 +910,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Combien de temps entre les répétitions des pas de vitesse d\'accélération (en millisecondes). Plus petit est plus rapide.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Délai de répétition des étapes de vitesse de décélération</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Combien de temps entre les répétitions des pas de vitesse de décélération (en millisecondes). Plus petit est plus rapide.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Pas de vitesse "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Pas de vitesse </string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Dans quelle mesure la vitesse réelle saute à chaque pas jusqu\'à la vitesse cible.  Plus grand est plus rapide.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Encoches d\'accélérateur</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Ajustez la manette des gaz en pourcentage ou par un nombre spécifique de pas/encoches</string>
@@ -937,7 +918,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Ajustez le nombre d\'étapes dans le curseur de frein</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Évaluez le rafraîchissement des freins pneumatiques</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Ajustez la fréquence de rafraîchissement/remplissage des freins pneumatiques (en millisecondes). Plus petit est plus rapide.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Nombre de charge "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Nombre de charge </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Ajustez le nombre d’étapes dans le curseur de charge</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Multiplicateur de pourcentage de charge</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Ajustez l\'effet du curseur de charge sur les changements de vitesse. > 100 % = plus de charge</string>
@@ -962,6 +943,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Options de balayage pour changer les écrans</string>
     <string name="prefHapticFeedbackDurationTitle">Durée du feedback tactile</string>
     <string name="prefHapticFeedbackDurationSummary">Durée de chaque vibration en millisecondes</string>
+    <string name="prefHapticFeedbackButtonsTitle">Retour haptique sur touches</string>
+    <string name="prefHapticFeedbackButtonsSummary">Retour haptique sur touches (vibration)</string>
     <string name="LocoSelectMethodIDNGo">Demander l ID de la loco</string>
     <string name="idngo_label">Demander l ID de la loco</string>
     <string name="idngo_button">Demander l ID de la loco</string>
@@ -1039,10 +1022,10 @@
     <string name="usingProtocolDCCEX">Utilisation du protocol DCC-EX. Decocher la preference \"utilisez les commandes natives DCC-EX\" pour utiliser le protocole WiThrottle.</string>
     <string name="prefDccexConnectionOptionSummary">Afficher l option pour basculer entre les protocoles WiThrottle ou DCC-EX sur l ecran de connexion.</string>
     <string name="prefDccexConnectionOptionTitle">Afficher les choix de protocoles</string>
-    <string name="prefActionBarShowDccExButtonSummary">Afficher le bouton pour acceder a l ecran ECC-EX (uniquement pour connexions natives DCC-EX)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Afficher le bouton pour acceder a l ecran DCC-EX (uniquement pour connexions natives DCC-EX)</string>
     <string name="prefActionBarShowDccExButtonTitle">Bouton DCC-EX ?</string>
     <string name="DCCEXactionTypeLabel">Action</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(exclure \'&lt;\' et \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(exclure \'&lt;\' et \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Efface</string>
     <string name="DccexConnectionOptionTitle">Protocole de connexion</string>
     <string name="DccexFailed">Action echouee</string>
@@ -1054,10 +1037,10 @@
     <string name="DccexSendCommandButtonLabel">Send</string>
     <string name="witActionTypeLabel">Action</string>
     <string name="witWriteAddressLabel">Adresse DCC</string>
-    <string name="witPomWarning">Remarques: - Cela ne fonctionnera pas sur certains systèmes DCC. - Le changement d\'adresse de locomotive est empêché - CV 1, 17 et amp; 18 et bit 5 du CV 29. \\n\\nÀ utiliser avec prudence.</string>
+    <string name="witPomWarning">Remarques: - Cela ne fonctionnera pas sur certains systèmes DCC. - Le changement d\'adresse de locomotive est empêché - CV 1, 17 et amp; 18 et bit 5 du CV 29.\n\nÀ utiliser avec prudence.</string>
     <string name="witPomMaxValueWarning">La valeur \'%1$s\' dépasse le maximum pris en charge (\"%2$s\")</string>
     <string name="DCCEXcommonCvsLabel">CVs NMRA</string>
-    <string name="DCCEXcommonCommnadsLabel">CMD courants</string>
+    <string name="DCCEXcommonCommandsLabel">Commandes CMD courantes</string>
     <string name="DCCEXsetTrackButtonLabel">Poser</string>
     <string name="DccexSucceeded">Action effectuée!</string>
     <string name="DCCEXturnoutClosed">Fermé</string>
@@ -1078,6 +1061,8 @@
     <string name="prefAlwaysUseFunctionsFromServerSummary">Si désactivé, EngineDriver utilisera les libellés de fonction par defaut pour les locos choisies par adresse (pas via le catalogue), ignorante ceux par defaut du serveur.</string>
     <string name="dccExFunctionSettings">Reglages DCC-EX</string>
     <string name="dccesp_settings">Reglages DCC ESP</string>
+    <string name="prefDoubleBackButtonToExitTitle">Double bouton Retour pour quitter?</string>
+    <string name="prefDoubleBackButtonToExitSummary">En appuyant deux fois sur le bouton « Retour » d\'Android dans les 3 secondes sur l\'écran « Accélérateur » ou « Connexion », vous quitterez Engine Driver.</string>
     <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 et F2 activent aussi Cloche en klaxon</string>
     <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">Activation par F1 et F2 de la cloche et du klaxon?</string>
     <string name="prefDeviceSoundsHideMuteButtonSummary">ne pas afficher le bouton Mute sur les manettes</string>
@@ -1086,11 +1071,11 @@
     <string name="gamepadTestButtonLabelButtonLeftThumb">Pouce gauche</string>
     <string name="gamepadTestButtonLabelButtonRightThumb">Pouce droit</string>
     <string name="infoSaveLogFile">Enregistré dans %s</string>
-    <string name="DCCEXbuttonTrackManager">Gestionnaire de suivi</string>
-    <string name="DCCEXbuttonDefaultFunctions">Fns par défaut</string>
-    <string name="DCCEXheadingCvProgrammerProgTrack">DCC-EX - Piste de programmation (mode Service)</string>
-    <string name="DCCEXheadingCvProgrammerPoM">DCC-EX - Programmation sur principal (mode de fonctionnement)</string>
-    <string name="DCCEXheadingTrackManager">DCC-EX - Gestionnaire de piste/district</string>
+    <string name="DCCEXbuttonTrackManager">Gestionnaire des voies</string>
+    <string name="DCCEXbuttonDefaultFunctions">Fonctions par défaut</string>
+    <string name="DCCEXheadingCvProgrammerProgTrack">DCC-EX - Voie de programmation (Mode service)</string>
+    <string name="DCCEXheadingCvProgrammerPoM">DCC-EX - Programmation sur la voie principale (Mode opération)</string>
+    <string name="DCCEXheadingTrackManager">DCC-EX - Gestionnaire de voies / districts</string>
     <string name="DCCEXrequestLocoIdFailed">Demande Id Loco ratée</string>
     <string name="cv29SpeedSteps14">14 crans de vitesse</string>
     <string name="cv29SpeedSteps28">28/128 crans de vitesse</string>
@@ -1107,5 +1092,22 @@
     <string name="order">Trier</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Toujours afficher les boutons dévié/non dévié ?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Toujours afficher les boutons dévié/non dévié pour les aiguillages et pas basculer</string>
+    <string name="DCCEXJoinTrackButtonLabel">Rejoindre</string>
+
+    <string name="air_reservoir">Réservoir d\'air</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Type de frein du décodeur</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Attivare le funzioni Freno sul decoder</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Numero funzione bassa ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU - Quale funzione del decoder attivare al valore basso del freno</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Numero funzione centrale ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU - Quale funzione del decoder attivare al valore medio del freno</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">Numero funzione alta ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU - Quale Funzione Decoder attivare con Valore Freno Alto</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Valore freno basso ESU (percentuale)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU - Quale Freno Percentuale per attivare il Numero Funzione Basso</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">Valore freno medio ESU (percentuale)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU - Quale freno percentuale per attivare il numero di funzione centrale</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Valore freno elevato ESU (percentuale)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU - Quale Freno Percentuale per attivare il Numero di Funzione Alto</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-it/arrays.xml
+++ b/EngineDriver/src/main/res/values-it/arrays.xml
@@ -68,11 +68,11 @@
         <item >Switching &#8211; (2)</item>
         <item >Switching &#8211; Sinistra (1)</item>
         <item >Switching &#8211; Destra (1)</item>
-        <item >Switching &#8211; Horizontal (3)</item>
+        <item >Commutazione orizzontale (1-3)</item>
         <item >Semplice &#8211; Consigliato Tablet (1&#8211;6)</item>
         <item tools:ignore="TypographyDashes">Tablet Shunting Sinistra (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Vertical Sinistra (1-6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Sinistra semi-realistica (1)</item>
     </string-array>4
 
     <string-array name="DisplayClockEntries">
@@ -87,7 +87,7 @@
         <item >2</item>
     </string-array>
     -->
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Ferma Tutto</item>
         <item>Stop</item>
         <item>Avanti</item>
@@ -135,11 +135,11 @@
         <item>Corno (IPLS)</item>
         <item>Corta Corta (IPLS)</item>
         <item>Parla velocità attuale</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutro</item>
+        <item>Aumenta il freno</item>
+        <item>Diminuire il freno</item>
+        <item>Aumenta il carico</item>
+        <item>Diminuire il carico</item>
     </string-array>
 
     <string-array name="prefImportExportEntries">  <!-- display version -->
@@ -203,12 +203,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Usare le impostazioni globali del telefono</item>
         <item>Inglese (USA) - Impostazione predefinita Engine Driver</item>
+        <item>Inglese (Australia)</item>
+        <item>Inglese (Canada)</item>
+        <item>Inglese (Nuova Zelanda)</item>
+        <item>Inglese (Regno Unito)</item>
         <item>Italiano</item>
         <item>Portoghese</item>
         <item>Tedesco</item>
         <item>Spagnolo</item>
         <item>Catalano</item>
         <item>Francese</item>
+        <item>Francese (Canada)</item>
         <item>Ceco</item>
     </string-array>
 
@@ -217,7 +222,7 @@
         <item>testo complesso di corrispondenza - Loco di piombo sempre attivato, Sentiero segue le regole qui sotto</item>
         <item>Speciale esatta - Piombo e All Trail attivato se corrispondono esattamente le etichette delle funzioni</item>
         <item>Speciale parziale - Piombo e All Trail attivati ​​se in parte corrispondono alle etichette di funzione</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Solo parziale speciale contiene: attivato se l\'etichetta della funzione contiene l\'etichetta predefinita</item>
     </string-array>
     <string-array name="prefConsistFollowEntries">  <!-- display version -->
         <item>Lead Loco - Partial Part</item>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -23,19 +23,18 @@
 <!--    <string name="function_buttons">Default Funzioni</string>-->
     <string name="introMenu">Introduzione</string>
 
-    <string name="app_description">Engine Driver - Controllo per il tuo telefono Android. Questa app può connettersi a JMRI, MRC o server Digitrax WiThrottle, e controllare gli scambi e le locomotive. Velocità, direzione, e fino a 29 funzioni DCC sono supportatte per una o due locomotive.</string>
+    <string name="app_description">Engine Driver - Controllo per il tuo telefono Android. Questa app può connettersi a JMRI, DCC-EX, MRC o server Digitrax WiThrottle, e controllare gli scambi e le locomotive. Velocità, direzione, e fino a 32 funzioni DCC sono supportatte per una o due locomotive.</string>
     <string name="app_name_intro">Introduzione</string>
     <string name="app_name_connect">Connessione al Server</string>
     <string name="app_name_throttle">Controllo</string>
     <string name="app_name_throttle_long">Engine Driver - Controllo</string>
-    <string name="app_name_throttle_short">Controllo </string>
+    <string name="app_name_throttle_short">Controllo</string>
     <string name="app_name_power_control">Controllo di Energia</string>
     <string name="app_name_reconnect_status">Status Ri-connessione</string>
     <string name="app_name_routes">Rotte</string>
     <string name="app_name_routes_long">Engine Driver - Rotte</string>
     <string name="app_name_routes_short">Rotte</string>
-    <string name="app_name_turnouts">Scambi</string>
-    <string name="app_name_turnouts_long">Engine Driver - Scambi</string>
+    <string name="app_name_turnouts">Engine Driver - Scambi</string>
     <string name="app_name_turnouts_short">Scambi</string>
     <string name="app_name_about">Circa</string>
     <string name="app_name_functions">Configurazione Funzioni Default</string>
@@ -58,7 +57,7 @@
     <string name="select_loco">Inserire Indirizzo Locomotiva da Acquisire</string>
     <string name="select_loco_address">Indirizzo</string>
     <string name="acquire_button">Acquisire</string>
-    <string name="roster_list">Selezionare da Elenco/Convogli</string>
+    <string name="roster_list">Selezionare da Elenco / Convogli</string>
     <string name="recent_engines">Selezionare da Locomotive Recenti</string>
 <!--    <string name="direction">Avanti</string>-->
 <!--    <string name="speed">Velocità:</string>-->
@@ -83,11 +82,10 @@
 
     <string name="consist_help">Cliccare una locomotiva per cambiare la sua direzione rispetto alla testa del convoglio. Premere a lungo per rimuovere una locmotiva dal convoglio. Premere Indietro quando pronto.</string>
     <string name="about">Circa</string>
-    <string name="web">Web</string>
     <string name="mrc_settings">Configurazione MRC</string>
     <string name="dccesp_settings">Impostazioni ESP DCC</string>
-    <string name="loco_direction_left_extra">"\u00B7A\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7I\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7A\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7I\u00B7</string>
     <string name="locoPressToSelect">Selezionare</string>
     <string name="powerWillNotWorkTitle">Non funzionerà!</string>
     <string name="powerWillNotWork">JMRI ha regolato il  controllo di energia WiThrottle su spento.\nRimuoverà adesso l\'icona di energia.\nMostrerà di nuovo quando la regolazione di JMRI sarà su acceso.</string>
@@ -150,7 +148,7 @@
     <string name="prefSwipeUpDownSummary">Opzioni scorrimento Alto-Basso schermo Controllore.</string>
     <string name="prefThrottleNameTitle">Nome Controllore</string>
 
-    <string name="prefThrottleNameSummary">Definire nome del presente dispositivo (mostrato sullo schermo WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Definire nome del presente dispositivo (mostrato sullo schermo JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">Orientamento schermo</string>
 
     <string name="prefThrottleOrientationSummary">Orientamento schermo (eccetto Web)</string>
@@ -250,14 +248,14 @@
     <string name="prefAlwaysUseDefaultFunctionLabelsSummary">Visualizzare le etichette funzione di default al posto delle etichette delle entrate dell\'elenco locomotive.</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Override con blocco della funzione acceleratore</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Utilizza il blocco predefinito di Engine Driver per le posizioni non del roster, anziché i valori predefiniti forniti da WiThrottle</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Visualizza le etichette delle funzioni predefinite invece delle etichette delle voci dell\'elenco.                                                               \\nQuesto DEVE essere abilitato per utilizzare gli stili di regola di seguito \\\'Speciale\\\'.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Visualizza le etichette delle funzioni predefinite invece delle etichette delle voci dell\'elenco.\nQuesto DEVE essere abilitato per utilizzare gli stili di regola di seguito \'Speciale\'.</string>
     <string name="prefDecreaseLocoNumberHeightTitle">Diminuire altezza numero Locomotiva?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Usare pulsanti minori per Numero locomotiva, velocità e pulsanti di direzione.</string>
     <string name="prefNumOfThrottles">Numero di Controllori</string>
     <string name="prefNumOfThrottlesSummary">Scegli quanti Controllori visualizzare sullo schermo.</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipo di schermo del controllore</string>
-    <string name="prefThrottleScreenTypeSummary">Quale tipo di schermo del controllore usare.</string>
+    <string name="prefThrottleScreenTypeSummary">Quale tipo di schermo del controllore usare.\n(Il numero tra parentesi dopo il nome è il numero di acceleratori che il layout può supportare.)</string>
 
     <string name="prefMaximumThrottleTitle">Percentuale massima di controllo</string>
 
@@ -361,7 +359,7 @@
     <string name="prefDisplaySpeedArrowsTitle">Mostrare pulsanti di velocità?</string>
     <string name="prefDisplaySpeedArrowsSummary">Mostrare pulsanti accanto al controllo di velocità per cambiare la velocità della locomotiva?</string>
 
-    <string name="prefSelectedLocoIndicatorTitle">Indicatore Addizionale della Locomotiva Selezionata </string>
+    <string name="prefSelectedLocoIndicatorTitle">Indicatore Addizionale della Locomotiva Selezionata</string>
     <string name="prefSelectedLocoIndicatorSummary">Evidenziatore addizionale del pulsante Selezione Locomotiva basato sul metodo di selezione.</string>
 
     <string name="prefDisableVolumeKeysTitle">Disabilita tasti Volume</string>
@@ -446,7 +444,7 @@
     <string name="prefDirectionButtonLongPressDelaySummary">Quanti millisecondi costituiscono una pressione prolungata per i pulsanti di direzione.</string>
 
     <string name="prefThemeTitle">Tema/Stile</string>
-    <string name="prefThemeSummary">Tema App. ATTENZIONE! Engine Driver si riavvierà immediatamente.\nRichiede Android Honeycomb o successivo.</string>
+    <string name="prefThemeSummary">Tema App.</string>
 
     <string name="prefHideDemoServerTitle">Nascondere Server Demo</string>
     <string name="prefHideDemoServerSummary">Nascondere il server demo \'jmri.mstevetodd.com\' dalla lista di connessioni.</string>
@@ -492,19 +490,19 @@
     <string name="gamepadTestCompleteLabel">Status test:\s\s</string>
     <string name="gamepadTestHelp">Scorrere verso il basso per leggere le istruzioni complete&#8230;\n\bPremere  Dpad E TUTTI i quattro pulsanti principali NON FUNZIONERÀ.\n\Se non riesci ad attivare tutti i pulsanti, cambia il modo del tuo gamepad (leggi le istruzioni del gamepad per come fare) o prova a cambiare il tipo di  gamepad (alto).\n\n\'RITORNARE\' ou \'CANCELLARE\' uscirá dal test ma il  gamepad NON FUNZIONERÀ.\n\'SALTARE\', o premere il pulsante del gamepad \'Diminuire Velocità\' tre volte, forzerà test a passare, anche se il gamepad non funziona correttamente.\n\'RESET\' comunicherà a ED che nessun gamepad è stato usato.\nSe il test \'SEMPLICE\' è stato selezionato, una unica pressione del pulsante  \'Diminuire Velocità\' salterà il test.\n\nUsa l\'opzione \'Test Gamepad\' nel menu per tornare a questa pagina.</string>
     <string name="gamepadTestHelpNonForced">\Se non riesci ad attivare tutti i pulsanti, cambia il modo del tuo gamepad (leggi le istruzioni del gamepad per come fare) o prova a cambiare il tipo di  gamepad (alto).\n Potrà essere necessario ritestare il gamepad quando sará usato per la prima volta dallo schermo del controllore.</string>
-    <string name="gamepadTestIncomplete">"Test Incompleto"</string>
-    <string name="gamepadTestComplete">"Test Completo"</string>
-    <string name="gamepadTestCompleteToast">"Gamepad testato completamente con successo"</string>
-    <string name="gamepadTestInvalidKeycode">"Codice tasto invalido per questo modo"</string>
-    <string name="gamepadTestReset">"Ripristinare"</string>
-    <string name="gamepadTestCancel">"Cancellare"</string>
-    <string name="gamepadTestCancelNonForced">"Chiudere"</string>
-    <string name="gamepadTestSkip">"Saltare"</string>
+    <string name="gamepadTestIncomplete">Test Incompleto</string>
+    <string name="gamepadTestComplete">Test Completo</string>
+    <string name="gamepadTestCompleteToast">Gamepad testato completamente con successo</string>
+    <string name="gamepadTestInvalidKeycode">Codice tasto invalido per questo modo</string>
+    <string name="gamepadTestReset">Ripristinare</string>
+    <string name="gamepadTestCancel">Cancellare</string>
+    <string name="gamepadTestCancelNonForced">Chiudere</string>
+    <string name="gamepadTestSkip">Saltare</string>
 
-    <string name="gamepadTestKeyCodesUpCode">"Su"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Giu"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Sin"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Des"</string>
+    <string name="gamepadTestKeyCodesUpCode">Su</string>
+    <string name="gamepadTestKeyCodesDownCode">Giu</string>
+    <string name="gamepadTestKeyCodesLeftCode">Sin</string>
+    <string name="gamepadTestKeyCodesRightCode">Des</string>
     <string name="prefGamepadTestNowTitle">Test impostazioni Gamepad Adesso!</string>
     <string name="prefGamepadTestNowSummary">Permette la conferma chele impostazioni scelte funzionano correttamente.\nLa pagina di Test sará lanciata IMMEDIATAMENTE dopo la selezione.</string>
     <string name="toastDoubleBackButtonToExit">Premere di nuovo \"Indietro\" per uscire da Engine Driver</string>
@@ -552,7 +550,7 @@
     <string name="toastConnectRemoveDemoHostError">Il server demo può essere rimosso solo modificando le preferenze.</string>
     <string name="toastConnectRemoved">Server rimosso dalla lista.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Comando inviato per selezionare la Rotta"</string>-->
+<!--    <string name="toastRoutesCommandSent">Comando inviato per selezionare la Rotta</string>-->
     <string name="toastImportExportExportSucceeded">Esportazione preferenze in \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' realizzata com successo.</string>
     <string name="toastImportExportImportSucceeded">Importazione preferenze da \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' realizzata com successo.</string>
     <string name="toastImportExportExportFailed">Esportazione preferenze in \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' fallita!</string>
@@ -719,6 +717,15 @@
 
     <string name="prefLimitSpeedButtonTitle">pulsante Show \'limite di velocità\'</string>
     <string name="prefLimitSpeedButtonSummary">Opzione per mostrare un pulsante che limita la velocità massima di una locomotiva.</string>
+    <string name="prefPauseAlternateButtonTitle">Pulsante alternativo \'Pausa\'</string>
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Cambio di direzione a fine corsa</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Consentire alla locomotiva di cambiare direzione quando la manopola di controllo è in posizione di finecorsa in senso antiorario.</string>
+    <string name="prefEsuMc2KnobButtonTitle">Cambio di direzione a fine corsa</string>
+    <string name="prefEsuMc2KnobButtonSummary">Consentire la disattivazione della manopola di controllo tramite un pulsante di azione sulla schermata dell\'acceleratore.</string>
+    <string name="EsuMc2KnobAction">Abilita/Disabilita manopola</string>
+    <string name="toastThreadedAppNotWIFI">Utilizzando %1$s rete, non WIFI.\nVerificare le impostazioni Wi-Fi.\n</string>
+    <string name="prefEsuMc2StopButtonShortPressTitle">Abilita la pressione breve</string>
+    <string name="prefPauseAlternateButtonSummary">Mostra il pulsante alternativo \'Pausa\' accanto al pulsante \'Stop\'. (Solo layout verticale)</string>
     <string name="prefLimitSpeedPercentTitle">\'Limite di velocità\' a \%</string>
     <string name="prefLimitSpeedPercentSummary">Impostare il \% della valvola a farfalla che la velocità sarà limitata a.</string>
     <string name="limitSpeedButtonLabel">limite di velocità</string>
@@ -732,7 +739,7 @@
     <string name="RecentsNameEditText">Inserire un nome per il Loco</string>
     <string name="infoSaveLogFile">Accesso a: %s</string>
     <string name="RecentsNameEditTitle">Recenti Nome Loco</string>
-    <string name="rosterDetailsDialogTitle">"Selezionare tra Roster / Consistono Entries "</string>
+    <string name="rosterDetailsDialogTitle">Selezionare tra Roster / Consistono Entries </string>
     <string name="toastRecentCleared">Loco rimosso dalla lista</string>
     <string name="toastRecentConsistCleared">Consistono rimosso dalla lista</string>
     <string name="editConsistButtonLabel">Modifica ordine e la direzione</string>
@@ -813,7 +820,7 @@
     <string name="prefFunctionConsistLocosDefaultValue">condurre</string>
     <string name="functionConsistHelpText">Utilizzato solo per il \'Special\' costituito opzioni seguente funzione + DCC-EX. Selezionare come il testo di ciascuna funzione verrà cercato nelle etichette funzione per ogni loco nel consistere.</string>
     <string name="functionConsistHeader">Azioni di funzione</string>
-    <string name="app_name_consist_functions">Consistono Impostazioni delle funzioni - macchinista</string>
+    <string name="app_name_consist_functions">Consistono Impostazioni delle funzioni</string>
     <string name="prefShowTimeOnLogEntryTitle">Mostra timestamp su Log</string>
     <string name="prefShowTimeOnLogEntrySummary">Mostra Data Ora per ogni voce nella schermata di log.</string>
     <string name="prefVerticalStopButtonMarginSummary">Numero di pixel per compensare margine del pulsante di arresto dai pulsanti di velocità e inferiore dello schermo.</string>
@@ -841,7 +848,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Quanto tempo tra le ripetizioni del passo di velocità di accelerazione (in millisecondi). Più piccolo è più veloce.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Ritardo ripetizione passo velocità decelerazione</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Intervallo di tempo tra le ripetizioni del passo di velocità di decelerazione (in millisecondi). Più piccolo è più veloce.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Passo di velocità "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Passo di velocità </string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Di quanto la velocità effettiva salta ad ogni passo rispetto alla velocità target.  Più grande è più veloce.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Tacche dell\'acceleratore</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Regola l\'acceleratore in percentuale o in base a un numero specifico di passi/tacche</string>
@@ -849,7 +856,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Regola il numero di passaggi nel cursore del freno</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Valuta l\'aggiornamento dei freni ad aria compressa</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Regola la velocità con cui i freni ad aria compressa si aggiorneranno/riempiranno (in millisecondi). Più piccolo è più veloce.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Numero di carico "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Numero di carico </string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Regola il numero di passaggi nel cursore Carica</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Moltiplicatore percentuale di carico</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Regola l\'effetto del cursore del carico sulle variazioni di velocità. &gt;100% = carico maggiore</string>
@@ -874,6 +881,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Opzioni per fendenti agli schermi di cambiamento</string>
     <string name="prefHapticFeedbackDurationTitle">Haptic feedback Durata</string>
     <string name="prefHapticFeedbackDurationSummary">Durata di ogni vibrazione (in millisecondi).</string>
+    <string name="prefHapticFeedbackButtonsTitle">Durata di ciascuna vibrazione (in millisecondi).</string>
+    <string name="prefHapticFeedbackButtonsSummary">Feedback tattile sulla pressione dei pulsanti</string>
     <string name="LocoSelectMethodIDNGo">Richiedi Loco ID</string>
     <string name="idngo_label">Richiedi Loco ID</string>
     <string name="idngo_button">Richiedi Loco ID</string>
@@ -907,6 +916,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Ritardo (slancio) per cambio di passo in millisecondi (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">Nel momento del telefono</string>
     <string name="deviceSoundsMuteButton">Muto</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 e F2 attivano anche il campanello e il clacson IPLS</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 e F2 attivano il campanello e il clacson?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Nascondi il pulsante di disattivazione IPLS sulle manette</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Nascondi il pulsante di disattivazione audio</string>
     <string name="prefDeviceSoundsButtonSummary">Mostra un pulsante della barra di azione per modificare le opzioni dei suoni del telefono del telefono</string>
     <string name="prefDeviceSoundsButtonTitle">Nel pulsante dei suoni del telefono</string>
     <string name="deviceSoundsMenu">Loco Sounds</string>
@@ -920,7 +933,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bell pulsante chiaggiatore / momentatore</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Il pulsante Bell è momentaneo. (Chiusura se non controllata.)</string>
 <!--    <string name="permissionsReadLegacyFiles">Il driver del motore ha bisogno di autorizzazioni di archiviazione per caricare le impostazioni legacy (Posizione vecchia).</string>-->
-    <string name="permissionsReadPhoneState">Il driver del motore ha bisogno di autorizzazioni telefoniche per mettere in pausa le operazioni quando su una chiamata.</string>
+    <string name="permissionsReadPhoneState">Engine Driver ha bisogno di autorizzazioni telefoniche per mettere in pausa le operazioni quando su una chiamata.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Ulteriori preferenze</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Ulteriori preferenze del telefono dei suoni del telefono</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco Step Sounds giocherà fino alla fine quando cambiano il passaggio. L\'importo dello slancio (sopra) diventa solo un tempo minimo.</string>
@@ -957,10 +970,10 @@
     <string name="usingProtocolDCCEX">Utilizzando il protocollo DCC-EX. Sconcensione \"Usa comandi DCC-EX nativi\" Preferenza per utilizzare il protocollo Withrottle.</string>
     <string name="prefDccexConnectionOptionSummary">Mostra l\'opzione per passare tra i protocolli Withrottle e DCC-EX nella schermata di connessione.</string>
     <string name="prefDccexConnectionOptionTitle">Mostra l\'opzione protocollo</string>
-    <string name="prefActionBarShowDccExButtonSummary">Mostra il pulsante nella barra di azione per accedere allo schermo ECC-EX. (Solo per connessioni DCC-Ex native.)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Mostra il pulsante nella barra di azione per accedere allo schermo DCC-EX. (Solo per connessioni DCC-Ex native.)</string>
     <string name="prefActionBarShowDccExButtonTitle">Pulsante DCC-EX?</string>
     <string name="DCCEXactionTypeLabel">Azione</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(esclude \'&lt;\' e \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(esclude \'&lt;\' e \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Chiaro</string>
     <string name="DccexConnectionOptionTitle">Protocollo di connessione</string>
     <string name="DccexFailed">L\'azione non è riuscita</string>
@@ -972,10 +985,10 @@
     <string name="DccexSendCommandButtonLabel">Inviare</string>
     <string name="witActionTypeLabel">Azione</string>
     <string name="witWriteAddressLabel">Indirizzo DCC</string>
-    <string name="witPomWarning">Note: - Questo non funzionerà su alcuni sistemi DCC. - Il cambio dell\'indirizzo della locomotiva è impedito - CV 1, 17 e amp; 18 e bit 5 del CV 29. \\n\\nUtilizzare con cautela.</string>
+    <string name="witPomWarning">Note: - Questo non funzionerà su alcuni sistemi DCC. - Il cambio dell\'indirizzo della locomotiva è impedito - CV 1, 17 e amp; 18 e bit 5 del CV 29.\n\nUtilizzare con cautela.</string>
     <string name="witPomMaxValueWarning">Il valore \'%1$s\' supera il massimo supportato (\'%2$s\')</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">CMD comuni</string>
+    <string name="DCCEXcommonCommandsLabel">CMD comuni</string>
     <string name="DCCEXsetTrackButtonLabel">Impostare</string>
     <string name="DccexSucceeded">L\'azione è riuscita</string>
     <string name="DCCEXturnoutClosed">Chiuso</string>
@@ -1015,5 +1028,30 @@
     <string name="order">Ordinare</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Mostra sempre Lancia/Chiudi?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Mostra sempre entrambi i pulsanti Lancia e Chiudi per gli scambi, mai il pulsante Attiva/disattiva.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Giuntura</string>
+    <string name="prefDoubleBackButtonToExitTitle">Doppio pulsante Indietro per uscire?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Premendo due volte entro 3 secondi il pulsante \"Indietro\" di Android sulla schermata \"Accelerazione\" o \"Connessione\" si uscirà da Engine Driver</string>
+    <string name="prefHeartbeatResponseFactorTitle">Fattore di risposta del battito cardiaco</string>
+    <string name="prefHeartbeatResponseFactorSummary">Percentuale del periodo di heartbeat in cui inviare l\'heartbeat (50%-90%). Avrà effetto alla prossima connessione.</string>
+    <string name="server">Server</string>
+    <string name="toastWaitingForConnection">Timeout in attesa del messaggio WiThrottle \'VN\' da %1$s:%2$s. Disconnessione</string>
+    <string name="toastWaitingForConnectionDccEx">Timeout in attesa del messaggio DCC-EX \'iDCCEX...\' da %1$s:%2$s. Disconnessione</string>
+    <string name="toastAddressExceedsMax">L\'indirizzo \'%1$s\' supera il massimo supportato (\'%2$s\')</string>
+
+    <string name="air_reservoir">Serbatoio dell\'aria</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Tipo di freno del decodificatore</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Activar las funciones de freno en el decodificador.</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Número de función baja de ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU: qué función de decodificador activar en un valor de freno bajo</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Número de función media de ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU: qué función de decodificador activar en el valor medio del freno</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">Número de función alta de ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU: qué función de decodificador activar en un valor de freno alto</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Valor de freno bajo de ESU (porcentaje)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU: qué porcentaje de freno activar el número de función bajo</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">Valor del freno medio ESU (porcentaje)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU: qué porcentaje de freno activar el número de función media</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Valor de freno alto de ESU (porcentaje)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU: qué porcentaje de freno activar el número de función alto</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values-pt/arrays.xml
+++ b/EngineDriver/src/main/res/values-pt/arrays.xml
@@ -67,11 +67,11 @@
         <item >Switching &#8211; (2)</item>
         <item >Switching &#8211; Esquerda (1)</item>
         <item >Switching &#8211; Direita (1)</item>
-        <item >Switching &#8211; Horizontal (3)</item>
+        <item >Comutação horizontal (1-3)</item>
         <item >Simples &#8211; Tablet Recomendado (1&#8211;6)</item>
         <item tools:ignore="TypographyDashes">Tablet Switching Esquerda (1-6)</item>
         <item tools:ignore="TypographyDashes">Tablet Vertical Esquerda (1-6)</item>
-        <item >Semi-Realistic Left (1)</item>
+        <item >Esquerda Semi-Realista (1)</item>
     </string-array>
 
     <string-array name="DisplayClockEntries">
@@ -86,7 +86,7 @@
         <item >2</item>
     </string-array>
     -->
-    <string-array name="prefGamePadKeyEntries">
+    <string-array name="prefGamePadKeyEntries">  <!-- display version -->
         <item>Para Tudo</item>
         <item>Para</item>
         <item>Frente</item>
@@ -134,11 +134,11 @@
         <item>Buzina (IPLS)</item>
         <item>Chifre Curta (IPLS)</item>
         <item>Fale a velocidade atual</item>
-        <item >Neutral</item>
-        <item >Increase Brake</item>
-        <item >Decrease Brake</item>
-        <item >Increase Load</item>
-        <item >Decrease Load</item>
+        <item>Neutro</item>
+        <item>Aumentar o freio</item>
+        <item>Diminuir Freio</item>
+        <item>Aumentar carga</item>
+        <item>Diminuir carga</item>
     </string-array>
     <string-array name="prefImportExportEntries">  <!-- display version -->
         <item>Nada</item>
@@ -201,12 +201,17 @@
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Usar a configuração global do telefone</item>
         <item>Inglês (EUA) - padrão do Engine Driver</item>
+        <item>Inglês (Austrália)</item>
+        <item>Inglês (Canadá)</item>
+        <item>Inglês (Nova Zelândia)</item>
+        <item>Inglês (Reino Unido)</item>
         <item>Italiano</item>
         <item>Português</item>
         <item>Alemão</item>
         <item>Espanhol</item>
         <item>Catalão</item>
         <item>Francês</item>
+        <item>Francês (Canadá)</item>
         <item>Tcheco</item>
     </string-array>
 
@@ -215,7 +220,7 @@
         <item>Complexo de correspondência de texto - loco Chumbo sempre activado, Trail segue as regras abaixo</item>
         <item>Especial Exact - Chumbo e Tudo Trail activado se eles correspondem exactamente às etiquetas de função</item>
         <item>Especial Parcial - Chumbo e Tudo Trail ativado se eles correspondem parcialmente os rótulos de função</item>
-        <item>Special Partial Contains Only  - Activated if function label contains Default Label</item>
+        <item>Parcial especial contém apenas - ativado se o rótulo da função contiver rótulo padrão</item>
     </string-array>
 
     <string-array name="prefConsistFollowEntries">  <!-- display version -->

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -22,19 +22,18 @@
 <!--    <string name="function_buttons">botões_função</string>-->
     <string name="introMenu">Introdução</string>
 
-    <string name="app_description">Engine Driver - Controlador para o seu fone Android. Este aplicativo pode conectaro ao JMRI, MRC ou servidor Digitrax WiThrottle, e controlar seus desvios e locomotivas. Velocidade, direção, e até 29 funcções DCC são suportadas para uma ou duas locomotivas.</string>
+    <string name="app_description">Engine Driver - Controlador para o seu fone Android. Este aplicativo pode conectaro ao JMRI, DCC-EX, MRC ou servidor Digitrax WiThrottle, e controlar seus desvios e locomotivas. Velocidade, direção, e até 32 funcções DCC são suportadas para uma ou duas locomotivas.</string>
     <string name="app_name_intro">Introdução</string>
     <string name="app_name_connect">Conexão ao Servidor</string>
     <string name="app_name_throttle">Controlador</string>
     <string name="app_name_throttle_long">Engine Driver - Controlador</string>
-    <string name="app_name_throttle_short">Controlador  </string>
+    <string name="app_name_throttle_short">Controlador</string>
     <string name="app_name_power_control">Controle de Energia</string>
     <string name="app_name_reconnect_status">Status Re-conexão</string>
     <string name="app_name_routes">Rotas</string>
     <string name="app_name_routes_long">Engine Driver - Rotas</string>
     <string name="app_name_routes_short">Rotas</string>
-    <string name="app_name_turnouts">Desvios</string>
-    <string name="app_name_turnouts_long">Engine Driver - Desvios</string>
+    <string name="app_name_turnouts">Engine Driver - Desvios</string>
     <string name="app_name_turnouts_short">Desvios</string>
     <string name="app_name_about">Sobre</string>
     <string name="app_name_functions">Configuração Funções Padrão</string>
@@ -55,9 +54,9 @@
     <string name="recent_connections">Conexões Recentes</string>
     <string name="select_loco_heading">Adquira Loco, Método - Controlador %1$s</string>
     <string name="select_loco">Inserir Endereço Locomotiva a Adquirir</string>
-    <string name="select_loco_address">Endereço  </string>
+    <string name="select_loco_address">Endereço</string>
     <string name="acquire_button">Adquirir</string>
-    <string name="roster_list">Selecionar da Lista/Comboios</string>
+    <string name="roster_list">Selecionar da Lista / Comboios</string>
     <string name="recent_engines">Selecionar das Locomotivas Recentes</string>
 <!--    <string name="direction">Frente</string>-->
 <!--    <string name="speed">Velocidade:</string>-->
@@ -82,11 +81,10 @@
 
     <string name="consist_help">Clicar uma locomotiva para mudar sua direção em relação à cabeça do comboio. Manter apertado para remover uma locomotiva do comboio. Apertar a seta Voltar quando for pronto.</string>
     <string name="about">Sobre</string>
-    <string name="web">Web</string>
     <string name="mrc_settings">Configuração MRC</string>
     <string name="dccesp_settings">Configurações DCC ESP</string>
-    <string name="loco_direction_left_extra">"\u00B7F\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7T\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7F\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7T\u00B7</string>
     <string name="locoPressToSelect">Selecionar</string>
     <string name="powerWillNotWorkTitle">Não funcionará!</string>
     <string name="powerWillNotWork">JMRI tem regulado o controle de energia WiThrottle para desligado.\nremoverá agora o Ícone de Energia.\nMostrará de novo quando a regulagem JMRI estará ligada.</string>
@@ -133,7 +131,7 @@
     <string name="exit_text">Sair de Engine Driver?</string>
     <string name="exit_title">Sair</string>
     <string name="steal_text">Apropriar-se do endereço %1$s?</string>
-    <string name="steal_title">Apropriar-se </string>
+    <string name="steal_title">Apropriar-se</string>
 
     <string name="lightsTextOff">Desligado</string>
     <string name="lightsTextFollow">Bt Função Seguinte</string>
@@ -149,7 +147,7 @@
     <string name="prefSwipeUpDownSummary">Opções deslizamento cima-baixo na tela Controlador</string>
     <string name="prefThrottleNameTitle">Nome Controlador</string>
 
-    <string name="prefThrottleNameSummary">Definir nome para este dispositivo (mostrado na tela WiThrottle)</string>
+    <string name="prefThrottleNameSummary">Definir nome para este dispositivo (mostrado na tela JMRI WiThrottle)</string>
     <string name="prefThrottleOrientationTitle">Orientação da tela</string>
 
     <string name="prefThrottleOrientationSummary">Orientação tela (exceto Web)</string>
@@ -250,14 +248,14 @@
 
     <string name="prefOverrideWiThrottlesFunctionLatchingTitle">Substituir o travamento da função WiThrottle</string>
     <string name="prefOverrideWiThrottlesFunctionLatchingSummary">Use o travamento padrão do Engine Driver para locais não escalados, em vez dos padrões fornecidos pelo WiThrottle</string>
-    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Exiba os rótulos de função padrão em vez dos rótulos das entradas da lista.                                                               \\nIsso DEVE ser habilitado para usar os estilos de regras de acompanhamento \\\'Especial\\\'.</string>
+    <string name="prefAlwaysUseDefaultFunctionLabelsSummary2">Exiba os rótulos de função padrão em vez dos rótulos das entradas da lista.\nIsso DEVE ser habilitado para usar os estilos de regras de acompanhamento \'Especial\'.</string>
     <string name="prefDecreaseLocoNumberHeightTitle" tools:ignore="Typos">Diminuir altura numero Locomotiva?</string>
     <string name="prefDecreaseLocoNumberHeightSummary">Utilizar botões menores para o Número da locomotiva, velocidade e botões de direção.</string>
     <string name="prefNumOfThrottles">Número de Controladores</string>
     <string name="prefNumOfThrottlesSummary">Escolha quantos Controladores quer visualizar na tela.</string>
 
     <string name="prefThrottleScreenTypeTitle">Tipo de tela do controlador</string>
-    <string name="prefThrottleScreenTypeSummary">Que tipo de tela de controlador usar.</string>
+    <string name="prefThrottleScreenTypeSummary">Que tipo de tela de controlador usar.\n(O número entre colchetes após o nome é o número de aceleradores que o layout pode suportar.)</string>
 
     <string name="prefMaximumThrottleTitle">Porcentagem máxima Controle</string>
 
@@ -361,7 +359,7 @@
     <string name="prefDisplaySpeedArrowsTitle">Mostrar botões de velocidade?</string>
     <string name="prefDisplaySpeedArrowsSummary">Mostrar botões ao lado do controle de velocidade para mudar a velocidade da locomotiva?</string>
 
-    <string name="prefSelectedLocoIndicatorTitle">Indicador Adicional da Locomotiva Selecionada </string>
+    <string name="prefSelectedLocoIndicatorTitle">Indicador Adicional da Locomotiva Selecionada</string>
     <string name="prefSelectedLocoIndicatorSummary">Destaque adicional do botão de Seleção Locomotiva baseado no método de seleção.</string>
 
     <string name="prefDisableVolumeKeysTitle">Desabilita teclas Volume</string>
@@ -441,11 +439,11 @@
     <string name="prefTickMarksOnSlidersTitle">Mostrar Tick marcas na Melocidade Sliders</string>
     <string name="prefTickMarksOnSlidersSummary">Mostrar ou ocultar as marcas no fundo dos controles deslizantes de velocidade.</string>
 
-    <string name="prefDirectionButtonLongPressDelayTitle">Atraso Pressão Prolongada Botão Direcional </string>
+    <string name="prefDirectionButtonLongPressDelayTitle">Atraso Pressão Prolongada Botão Direcional</string>
     <string name="prefDirectionButtonLongPressDelaySummary">Quantos milissegundos constituem um toque longo para os botões de direção.</string>
 
     <string name="prefThemeTitle">Tema/Estilo</string>
-    <string name="prefThemeSummary">Tema App.\nNecessita Android Honeycomb ou sucessivo.</string>
+    <string name="prefThemeSummary">Tema App.</string>
 
     <string name="prefHideDemoServerTitle">Esconder Servidor Demo</string>
     <string name="prefHideDemoServerSummary">Esconder o servidor demo \'jmri.mstevetodd.com\' na lista de conexões.</string>
@@ -496,19 +494,19 @@
         \n\'RESET\' dirá ao ED que nenhum gamepad foi usado ainda.\nSe um teste \'SIMPLES\' foi selecionado, um unico aperto do botão \'Diminuir Velocidade\' saltará o teste.\n\nUse a opção \'Teste Gamepad\' no menu para voltar a esta página.</string>
     <string name="gamepadTestHelpNonForced">\Se não conseguir ativar todos os botões, mude o modo do gamepad (vide instruções do seu gamepad) ou tente outro tipo de gamepad (acima).
         \n Poderá ser necessário testar de novo o gamepad quando será usado pela primeira vez a partir da tela do controlador.</string>
-    <string name="gamepadTestIncomplete">"Teste Incompleto"</string>
-    <string name="gamepadTestComplete">"Teste Completo"</string>
-    <string name="gamepadTestCompleteToast">"Gamepad testado completamente com sucesso"</string>
-    <string name="gamepadTestInvalidKeycode">"Código tecla inválido para este modo"</string>
-    <string name="gamepadTestReset">"Reiniciar"</string>
-    <string name="gamepadTestCancel">"Cancelar"</string>
-    <string name="gamepadTestCancelNonForced">"Fechar"</string>
-    <string name="gamepadTestSkip">"Saltar"</string>
+    <string name="gamepadTestIncomplete">Teste Incompleto</string>
+    <string name="gamepadTestComplete">Teste Completo</string>
+    <string name="gamepadTestCompleteToast">Gamepad testado completamente com sucesso</string>
+    <string name="gamepadTestInvalidKeycode">Código tecla inválido para este modo</string>
+    <string name="gamepadTestReset">Reiniciar</string>
+    <string name="gamepadTestCancel">Cancelar</string>
+    <string name="gamepadTestCancelNonForced">Fechar</string>
+    <string name="gamepadTestSkip">Saltar</string>
 
-    <string name="gamepadTestKeyCodesUpCode">"Alt"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Bxo"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Esq"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Dir"</string>
+    <string name="gamepadTestKeyCodesUpCode">Alt</string>
+    <string name="gamepadTestKeyCodesDownCode">Bxo</string>
+    <string name="gamepadTestKeyCodesLeftCode">Esq</string>
+    <string name="gamepadTestKeyCodesRightCode">Dir</string>
     <string name="prefGamepadTestNowTitle">Testando Configuração Gamepad Agora!</string>
     <string name="prefGamepadTestNowSummary">Permite confirmar que a configuração escolhida funciona corretamente.\nA Página de Teste será rodada IMEDIATAMENTE após a seleção.</string>
     <string name="toastDoubleBackButtonToExit">Pressione \'Voltar\' novamente para sair do Engine Driver</string>
@@ -556,7 +554,7 @@
     <string name="toastConnectRemoveDemoHostError">O servidor de demonstração só pode ser removido modificando as preferências.</string>
     <string name="toastConnectRemoved">Servidor removido da lista.</string>
 
-<!--    <string name="toastRoutesCommandSent">"Comando enviado para escolher Rota"</string>-->
+<!--    <string name="toastRoutesCommandSent">Comando enviado para escolher Rota</string>-->
     <string name="toastImportExportExportSucceeded">Exportação preferências para \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' realizada com sucesso.</string>
     <string name="toastImportExportImportSucceeded">Importação preferências de \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' realizada com sucesso.</string>
     <string name="toastImportExportExportFailed">Exportação preferências para \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' falhou!</string>
@@ -719,6 +717,15 @@
 
     <string name="prefLimitSpeedButtonTitle">botão Show \'Limite de velocidade\'</string>
     <string name="prefLimitSpeedButtonSummary">Opção para mostrar um botão que limita a velocidade máxima de um loco.</string>
+    <string name="prefPauseAlternateButtonTitle">Botão alternativo \'Pausar\'</string>
+    <string name="prefEsuMc2EndStopDirectionChangeTitle">Mudança de direção no ponto final</string>
+    <string name="prefEsuMc2EndStopDirectionChangeSummary">Permita que a direção do Loco mude quando o botão de controle estiver na posição de parada final no sentido anti-horário.</string>
+    <string name="prefEsuMc2KnobButtonTitle">Mudança de direção no ponto final</string>
+    <string name="prefEsuMc2KnobButtonSummary">Permita que o botão de controle seja desativado por um botão de ação na tela do acelerador.</string>
+    <string name="EsuMc2KnobAction">Botão Ativar/Desativar</string>
+    <string name="toastThreadedAppNotWIFI">Usando da rede %1$s, não WIFI.\nVerifique suas configurações de Wi-Fi.\n</string>
+    <string name="prefEsuMc2StopButtonShortPressTitle">Ativar toque curto</string>
+    <string name="prefPauseAlternateButtonSummary">Mostrar o botão alternativo \'Pausar\' próximo ao botão \'Parar\'. (Somente layouts verticais)</string>
     <string name="prefLimitSpeedPercentTitle">\'Limite de velocidade\' para \%</string>
     <string name="prefLimitSpeedPercentSummary">Defina o \% do acelerador que a velocidade será limitada a.</string>
     <string name="limitSpeedButtonLabel">limite de velocidade</string>
@@ -732,7 +739,7 @@
     <string name="RecentsNameEditText">Digite um nome para o Loco</string>
     <string name="infoSaveLogFile">Registrando em: %s</string>
     <string name="RecentsNameEditTitle">Recentes Nome Loco</string>
-    <string name="rosterDetailsDialogTitle">"Seleccione a partir Roster / Consistem Entradas "</string>
+    <string name="rosterDetailsDialogTitle">Seleccione a partir Roster / Consistem Entradas</string>
     <string name="toastRecentCleared">Loco removido da lista</string>
     <string name="toastRecentConsistCleared">Consistem removido da lista</string>
     <string name="editConsistButtonLabel">Editar ordem e direção</string>
@@ -817,7 +824,7 @@
     <string name="prefFunctionConsistLocosDefaultValue">conduzir</string>
     <string name="functionConsistHelpText">Apenas usada para o \'especial \' consistem de função seguintes opções + DCC-EX. Escolha como o texto de cada função será procurado nos rótulos de função para cada loco no composto.</string>
     <string name="functionConsistHeader">Consistem Ações de função</string>
-    <string name="app_name_consist_functions">Consistem configurações de funções - Driver Motor</string>
+    <string name="app_name_consist_functions">Consistem configurações de funções</string>
     <string name="prefShowTimeOnLogEntryTitle">Mostrar Timestamps em Log</string>
     <string name="prefShowTimeOnLogEntrySummary">Mostrar Data Hora para cada entrada na tela de log.</string>
     <string name="prefVerticalStopButtonMarginTitle">Margens verticais botão STOP</string>
@@ -845,7 +852,7 @@
     <string name="prefSemiRealisticThrottleAccelerationRepeatSummary">Quanto tempo entre as repetições da etapa de velocidade de aceleração (em milissegundos). Menor é mais rápido.</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatTitle">Atraso de repetição da etapa de velocidade de desaceleração</string>
     <string name="prefSemiRealisticThrottleDecelerationRepeatSummary">Quanto tempo entre as repetições da etapa de velocidade de desaceleração (em milissegundos). Menor é mais rápido.</string>
-    <string name="prefSemiRealisticThrottleSpeedStepTitle">"Etapa de velocidade "</string>
+    <string name="prefSemiRealisticThrottleSpeedStepTitle">Etapa de velocidade</string>
     <string name="prefSemiRealisticThrottleSpeedStepSummary">Quanto a velocidade real salta a cada passo até a velocidade alvo.  Maior é mais rápido.</string>
     <string name="prefSemiRealisticThrottleNotchesTitle">Entalhes do acelerador</string>
     <string name="prefSemiRealisticThrottleNotchesSummary">Ajuste o acelerador como porcentagem ou por um número específico de etapas/entalhes</string>
@@ -853,7 +860,7 @@
     <string name="prefSemiRealisticThrottleNumberOfBrakeStepsSummary">Ajuste o número de etapas no controle deslizante do freio</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateTitle">Avalie a atualização dos freios a ar</string>
     <string name="prefSemiRealisticThrottleAirRefreshRateSummary">Ajuste a taxa de atualização/reabastecimento dos freios a ar (em milissegundos). Menor é mais rápido.</string>
-    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">"Número de carga "</string>
+    <string name="prefSemiRealisticThrottleNumberOfLoadStepsTitle">Número de carga</string>
     <string name="prefSemiRealisticThrottleNumberOfLoadStepsSummary">Ajuste o número de etapas no Load Slider</string>
     <string name="prefSemiRealisticThrottleLoadPcntTitle">Multiplicador de porcentagem de carga</string>
     <string name="prefSemiRealisticThrottleLoadPcntSummary">Ajuste o efeito do controle deslizante de carga nas mudanças de velocidade. >100% = mais carga</string>
@@ -878,6 +885,8 @@
     <string name="prefLeftRightSwipePreferencesSummary">Opções para furtos a telas de mudança</string>
     <string name="prefHapticFeedbackDurationTitle">Haptic feedback Duração</string>
     <string name="prefHapticFeedbackDurationSummary">Duração de cada vibração (em milissegundos).</string>
+    <string name="prefHapticFeedbackButtonsTitle">Duração de cada vibração (em milissegundos).</string>
+    <string name="prefHapticFeedbackButtonsSummary">Feedback tátil ao pressionar botões</string>
     <string name="LocoSelectMethodIDNGo">Solicitar Loco ID</string>
     <string name="idngo_label">Solicitar Loco ID</string>
     <string name="idngo_button">Solicitar Loco ID</string>
@@ -911,6 +920,10 @@
     <string name="prefDeviceSoundsMomentumSummary" tools:ignore="TypographyDashes">Atraso (Momentum) por mudança de passo em milissegundos (0-2000)</string>
     <string name="prefDeviceSoundsMomentumTitle">No momento do telefone</string>
     <string name="deviceSoundsMuteButton">Mudo</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornSummary">F1 e F2 também ativam campainha e buzina IPLS</string>
+    <string name="prefDeviceSoundsF1F2ActivateBellHornTitle">F1 e F2 ativam campainha e buzina?</string>
+    <string name="prefDeviceSoundsHideMuteButtonSummary">Ocultar o botão de mudo IPLS nos aceleradores</string>
+    <string name="prefDeviceSoundsHideMuteButtonTitle">Ocultar botão mudo</string>
     <string name="prefDeviceSoundsButtonSummary">Mostrar um botão de barra de ação para alterar as opções de sons de loco no telefone</string>
     <string name="prefDeviceSoundsButtonTitle">No botão de sons do telefone</string>
     <string name="deviceSoundsMenu">Loco sons</string>
@@ -924,7 +937,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Botão de sino travamento / momentâneo</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botão Bell é momentâneo. (Travamento se desmarcado.)</string>
 <!--    <string name="permissionsReadLegacyFiles">O driver do motor precisa de permissões de armazenamento para carregar as configurações legadas (local de localização).</string>-->
-    <string name="permissionsReadPhoneState">O driver do motor precisa de permissões de telefone para pausar as operações quando estiver em uma chamada.</string>
+    <string name="permissionsReadPhoneState">Engine Driver precisa de permissões de telefone para pausar as operações quando estiver em uma chamada.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferências adicionais</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Preferências adicionais em Telefone Loco Sounds</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Os sons de passo de loco jogarão até o fim ao mudar de passo. A quantidade de momentum (acima) se torna apenas um tempo mínimo.</string>
@@ -962,10 +975,10 @@
     <string name="usingProtocolDCCEX">Usando o protocolo DCC-EX. Desmarcar \"Use comandos nativos DCC-EX\" Preferência para usar o protocolo Withrottle.</string>
     <string name="prefDccexConnectionOptionSummary">Mostre a opção para alternar entre os protocolos Withrottle e DCC-EX na tela de conexão.</string>
     <string name="prefDccexConnectionOptionTitle">Mostrar opção de protocolo</string>
-    <string name="prefActionBarShowDccExButtonSummary">Mostrar botão na barra de ação para acessar a tela ECC-EX. (Somente para conexões nativas do DCC-EX.)</string>
+    <string name="prefActionBarShowDccExButtonSummary">Mostrar botão na barra de ação para acessar a tela DCC-EX. (Somente para conexões nativas do DCC-EX.)</string>
     <string name="prefActionBarShowDccExButtonTitle">Botão dcc-ex?</string>
     <string name="DCCEXactionTypeLabel">Ação</string>
-    <string name="DccexSendCommandLabel">DCC-EX CMD <small><small>\n(exclui \'&lt;\' e \'&gt;\')</small></small></string>
+    <string name="DccexSendCommandLabel">DCC-EX Cmd\n<small><small>(exclui \'&lt;\' e \'&gt;\')</small></small></string>
     <string name="DCCEXclearCommands">Claro</string>
     <string name="DccexConnectionOptionTitle">Protocolo de conexão</string>
     <string name="DccexFailed">Ação: falhou</string>
@@ -977,10 +990,10 @@
     <string name="DccexSendCommandButtonLabel">Mandar</string>
     <string name="witActionTypeLabel">Ação</string>
     <string name="witWriteAddressLabel">Endereço DCC</string>
-    <string name="witPomWarning">Observações: - Isso não funcionará em alguns sistemas DCC. - A alteração do endereço do Loco é evitada - CVs 1, 17 &amp; 18 e bit 5 do CV 29. \\n\\nUse com cuidado.</string>
+    <string name="witPomWarning">Observações: - Isso não funcionará em alguns sistemas DCC. - A alteração do endereço do Loco é evitada - CVs 1, 17 &amp; 18 e bit 5 do CV 29.\n\nUse com cuidado.</string>
     <string name="witPomMaxValueWarning">O valor \'%1$s\' excede o máximo suportado (\'%2$s\')</string>
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel">TMC comuns</string>
+    <string name="DCCEXcommonCommandsLabel">TMC comuns</string>
     <string name="DCCEXsetTrackButtonLabel">Definir</string>
     <string name="DccexSucceeded">A ação foi bem -sucedida</string>
     <string name="DCCEXturnoutClosed">Fechadas</string>
@@ -1020,5 +1033,30 @@
     <string name="order">Organizar</string>
     <string name="prefTurnoutsShowThrowCloseButtonsTitle">Sempre mostrar Lançar/Fechar?</string>
     <string name="prefTurnoutsShowThrowCloseButtonsSummary">Sempre mostre os botões Lançar e Fechar para Turnouts, nunca o botão Alternar.</string>
+    <string name="DCCEXJoinTrackButtonLabel">Juntar</string>
+    <string name="prefDoubleBackButtonToExitTitle">Botão Voltar duplo para sair?</string>
+    <string name="prefDoubleBackButtonToExitSummary">Pressionar o botão \'Voltar\' do Android duas vezes em 3 segundos na tela \'Acelerador\' ou \'Conexão\' sairá do Engine Driver</string>
+    <string name="prefHeartbeatResponseFactorTitle">Fator de resposta de batimento cardíaco</string>
+    <string name="prefHeartbeatResponseFactorSummary">Porcentagem do período de batimento cardíaco para quando enviar o batimento cardíaco (50%-90%). Entrará em vigor na próxima conexão.</string>
+    <string name="server">Servidor</string>
+    <string name="toastWaitingForConnection">Tempo limite de espera pela mensagem \'VN\' do WiThrottle de %1$s:%2$s. Desconectando</string>
+    <string name="toastWaitingForConnectionDccEx">Tempo limite aguardando mensagem DCC-EX \'iDCCEX...\' de %1$s:%2$s. Desconectando</string>
+    <string name="toastAddressExceedsMax">O endereço \'%1$s\' excede o máximo suportado (\'%2$s\')</string>
+
+    <string name="air_reservoir">Reservatório de Ar</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeTitle">Tipo de freio do decodificador</string>
+    <string name="prefDisplaySemiRealisticThrottleDecoderBrakeTypeSummary">Activer les fonctions Frein sur le décodeur</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuTitle">Numéro de fonction faible ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowFunctionEsuSummary">ESU - Quelle fonction de décodeur activer en cas de faible valeur de freinage</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuTitle">Numéro de fonction intermédiaire ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidFunctionEsuSummary">ESU - Quelle fonction de décodeur activer à la valeur de freinage intermédiaire</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuTitle">Numéro de fonction élevé ESU</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighFunctionEsuSummary">ESU - Quelle fonction de décodeur activer à une valeur de freinage élevée</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuTitle">Valeur de freinage faible ESU (pour cent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeLowValueEsuSummary">ESU - Quel pourcentage de freinage pour activer le numéro de fonction bas</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuTitle">Valeur de freinage intermédiaire ESU (pour cent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeMidValueEsuSummary">ESU - Quel pourcentage de freinage pour activer le numéro de fonction intermédiaire</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuTitle">Valeur de freinage élevée ESU (pour cent)</string>
+    <string name="prefSemiRealisticThrottleDecoderBrakeTypeHighValueEsuSummary">ESU - Quel pourcentage de freinage pour activer le numéro de fonction élevé</string>
 
 </resources>

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -1587,7 +1587,7 @@
         <item>Colorful</item>
     </string-array>
     <string-array name="prefThemeEntries">  <!-- display version -->
-        <item>Default</item>
+        <item>Original (Checker plate)</item>
         <item>High Contrast</item>
         <item>Outline</item>
         <item>Dark</item>
@@ -1690,23 +1690,33 @@
     <string-array name="prefLocaleEntryValues" translatable="false">  <!-- DO NOT TRANSLATE -->
         <item>Default</item>
         <item>en_US</item>
+        <item>en_AU</item>
+        <item>en_CA</item>
+        <item>en_NZ</item>
+        <item>en_GB</item>
         <item>it</item>
         <item>pt</item>
         <item>de</item>
         <item>es</item>
         <item>ca</item>
         <item>fr</item>
+        <item>fr_CA</item>
         <item>cs</item>
     </string-array>
     <string-array name="prefLocaleEntries">  <!-- display version -->
         <item>Use Phone\'s global setting</item>
-        <item>English (US) - Engine Driver\'s default </item>
+        <item>English (US) - Engine Driver\'s default</item>
+        <item>English (Australia)</item>
+        <item>English (Canada)</item>
+        <item>English (New Zealand)</item>
+        <item>English (United Kingdom)</item>
         <item>Italian</item>
         <item>Portuguese</item>
         <item>German</item>
         <item>Spanish</item>
         <item>Catalan</item>
         <item>French</item>
+        <item>Canadian French</item>
         <item>Czech</item>
     </string-array>
 

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="functionConsistHeader">Function Actions</string>
 
     <string name="app_name" translatable="false">Engine Driver</string>  <!-- DO NOT TRANSLATE -->
-    <string name="app_description">Engine Driver - Throttle for your Android phone.  This application can connect to a JMRI, DCC-EX, MRC or DigiTrax WiThrottle server, or DCC-EX native server, and in turn control your locomotives. Speed, direction, and up to 29 DCC functions are supported for one to six locomotives. </string>
+    <string name="app_description">Engine Driver - Throttle for your Android phone.  This application can connect to a JMRI, DCC-EX, MRC or DigiTrax WiThrottle server, or DCC-EX native server, and in turn control your locomotives. Speed, direction, and up to 32 DCC functions are supported for one to six locomotives.</string>
     <string name="app_name_intro">Introduction</string>
     <string name="app_name_connect">Connect to Server</string>
     <string name="app_name_throttle">Throttle</string>
@@ -50,8 +50,7 @@
     <string name="app_name_routes">Routes</string>
     <string name="app_name_routes_long">Engine Driver - Routes</string>
     <string name="app_name_routes_short">Routes</string>
-    <string name="app_name_turnouts">Turnouts</string>
-    <string name="app_name_turnouts_long">Engine Driver - Turnouts</string>
+    <string name="app_name_turnouts">Engine Driver - Turnouts</string>
     <string name="app_name_turnouts_short">Turnouts</string>
     <string name="app_name_about">❔About</string>
     <string name="app_name_web" translatable="false">Web</string>
@@ -82,8 +81,8 @@
     <string name="select_loco">Enter Locomotive Address to Acquire</string>
     <string name="select_loco_address">Address</string>
     <string name="acquire_button">Acquire</string>
-    <string name="roster_list">Select from Roster/Consist Entries</string>
-    <string name="rosterDetailsDialogTitle">"Roster details for "</string>
+    <string name="roster_list">Select from Roster / Consist Entries</string>
+    <string name="rosterDetailsDialogTitle">Roster details for</string>
     <string name="recent_engines">Select from Recent Locomotives</string>
     <string name="recent_consists">Select from Recent Consists</string>
 <!--    <string name="direction">Fwd</string>-->
@@ -124,8 +123,8 @@
     <string name="mrc_settings">MRC Settings</string>
     <string name="dccesp_settings">DCC ESP Settings</string>
     <string name="loco">Loco:</string>
-    <string name="loco_direction_left_extra">"\u00B7F\u00B7"</string>
-    <string name="loco_direction_right_extra">"\u00B7R\u00B7"</string>
+    <string name="loco_direction_left_extra">\u00B7F\u00B7</string>
+    <string name="loco_direction_right_extra">\u00B7R\u00B7</string>
     <string name="locoPressToSelect">Select</string>
     <string name="powerWillNotWorkTitle">Will Not Work!</string>
     <string name="powerWillNotWork">Server has the WiThrottle power control setting to off.\nWill now remove Power Icon.\nWill display again when Server setting is on.</string>
@@ -156,7 +155,7 @@
     <string name="press_to_toggle">Press button to toggle layout power state.</string>
     <string name="power_control_not_allowed">Power Control not allowed.  Change in Preferences/Settings on server.</string>
     <string name="reconnect_label">Reconnect Attempt Status</string>
-    <string name="reconnect_help">Attempting to Reconnect automatically.  Wait for Reconnection or press BackArrow to Exit.</string>
+    <string name="reconnect_help">Attempting to Reconnect automatically.  Wait for Reconnection or press \'Back\' to Exit.</string>
     <string name="reconnect_success">RECONNECTED.  Resuming normal operation.</string>
     <string name="fs_edit_notice">WARNING: changes to Default Functions Settings will be lost on exit - No SD card found.</string>
     <string name="ca_recent_conn_notice">Recent Connections unavailable - No SD card found.</string>
@@ -170,8 +169,8 @@
     <string name="volume_indicator" translatable="false">v</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
-    <string name="ok">"OK"</string>
-    <string name="cancel">"Cancel"</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
     <string name="exit_text">Exit Engine Driver?</string>
     <string name="exit_title">Exit</string>
     <string name="steal_text">Steal address %1$s?</string>
@@ -199,7 +198,7 @@
     <string name="prefSwipeUpDownSummary">Options for swipe up or down on the Throttle screen</string>
     <string name="prefThrottleNameTitle">Throttle Name</string>
     <string name="prefThrottleNameDefaultValue" translatable="false">Engine Driver</string>  <!-- DO NOT TRANSLATE -->
-    <string name="prefThrottleNameSummary">Set a name for this device (shown on WiThrottle Server)</string>
+    <string name="prefThrottleNameSummary">Set a name for this device (shown on JMRI WiThrottle Server)</string>
     <string name="prefThrottleOrientationTitle">Screen orientation</string>
     <string name="prefThrottleOrientationDefaultValue" translatable="false">Portrait</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefThrottleOrientationSummary">Screen orientation (except Web)</string>
@@ -221,7 +220,8 @@
     <string name="prefHideSliderSummary">Do not show speed slider, use speed buttons instead</string>
 
     <string name="prefHideSliderAndSpeedButtonsTitle">Hide Slider AND Speed Buttons?</string>
-    <string name="prefHideSliderAndSpeedButtonsSummary">Show neither speed slider nor speed buttons</string>
+    <string name="prefHideSliderAndSpeedButtonsSummary">Show neither speed slider nor speed buttons.
+        \nNote: Overrides the \'Hide Slider\', \'Slider Height\' and \'Display Speed buttons\' options.</string>
 
     <string name="prefDirChangeWhileMovingTitle">Direction change while moving?</string>
     <string name="prefDirChangeWhileMovingSummary">Allow direction changes when moving</string>
@@ -447,13 +447,13 @@
 
     <string name="prefRosterFilterTitle">Filter Roster</string>
     <string name="prefRosterFilterSummary">Only show roster entries containing…</string>
-    <string name="prefRosterFilterDefaultValue" translatable="false"> </string>
+    <string name="prefRosterFilterDefaultValue" translatable="false"></string>
 <!--    <string name="FilterRosterList">Filter</string>-->
     <string name="FilterRosterListHint">Contains…</string>
     <string name="FilterRosterListFilterOwnerLabel" translatable="false">👤</string>
     <string name="FilterRosterListDownloadLabel">Download</string>
     <string name="FilterRosterListFilterByLabel" translatable="false">🔎</string>
-    <string name="rosterEmpty">Unable to find any entries in the Server roster.  Use either the \'DCC Address\' or \'Recent\' option instead.</string>
+    <string name="rosterEmpty">Unable to find any entries in the WiThrottle Server roster.  Use either the \'DCC Address\' or \'Recent\' option instead.</string>
     <string name="prefRosterOwnersFilterShowOptionTitle">Filter by Roster Owner</string>
     <string name="prefRosterOwnersFilterShowOptionSummary">Show an option to Filter the Roster by Owner</string>
     <string name="prefRosterOwnersFilterDefaultOwner">All</string>
@@ -492,7 +492,7 @@
     <string name="prefSocketTimeoutMsSummary">Set socket read timeout in milliseconds</string>
     <string name="prefSocketTimeoutMsDefaultValue" translatable="false">500</string>  <!-- DO NOT TRANSLATE -->
     <string name="prefHeartbeatResponseFactorTitle">Heartbeat Response Factor</string>
-    <string name="prefHeartbeatResponseFactorSummary">Percentage of the heartbeat period for when to send the heartbeat (50%-90%).\nWill take effect on next connection.</string>
+    <string name="prefHeartbeatResponseFactorSummary">Percentage of the heartbeat period for when to send the heartbeat (50%-90%). Will take effect on next connection.</string>
     <string name="prefHeartbeatResponseFactorDefaultValue" translatable="false">80</string>  <!-- DO NOT TRANSLATE -->
 
     <string name="prefTurnoutsTitle">Turnouts and Routes Preferences</string>
@@ -509,7 +509,7 @@
 
     <string name="prefScreenBrightnessDimTitle">Screen Dimming \% Value</string>
     <string name="prefScreenBrightnessDimSummary">Brightness setting to use when dimming the screen (0%-99%). Disables Auto or Adaptive Brightness if set.</string>
-    <string name="prefScreenBrightnessDimDefaultValue" translatable="false">"5"</string>  <!-- DO NOT TRANSLATE -->
+    <string name="prefScreenBrightnessDimDefaultValue" translatable="false">5</string>  <!-- DO NOT TRANSLATE -->
 
     <string name="deviceSoundsMenu">Loco Sounds</string>
 
@@ -826,23 +826,23 @@
 \n
 \nFailure to follow the \'F\', \'S\' or \'L\' with the correct number of digits will ignore the command</string>
     <string name="gamepadTestHelpNonForced">If you can\'t activate all buttons, change the gamepad mode (see the instructions that came with your device) or try a different gamepad Type (above).\nYou may be required to re-test the gamepad when you first use it from the throttle screen.</string>
-    <string name="gamepadTestIncomplete">"Test Incomplete"</string>
-    <string name="gamepadTestComplete">"Test Complete"</string>
-    <string name="gamepadTestCompleteToast">"Gamepad test completed successfully"</string>
-    <string name="gamepadTestInvalidKeycode">"Invalid Keycode for this mode"</string>
+    <string name="gamepadTestIncomplete">Test Incomplete</string>
+    <string name="gamepadTestComplete">Test Complete</string>
+    <string name="gamepadTestCompleteToast">Gamepad test completed successfully</string>
+    <string name="gamepadTestInvalidKeycode">Invalid Keycode for this mode</string>
 
-    <string name="gamepadTestReset">"Reset"</string>
-    <string name="gamepadTestCancel">"Cancel"</string>
-    <string name="gamepadTestCancelNonForced">"Close"</string>
-    <string name="gamepadTestSkip">"Skip"</string>
+    <string name="gamepadTestReset">Reset</string>
+    <string name="gamepadTestCancel">Cancel</string>
+    <string name="gamepadTestCancelNonForced">Close</string>
+    <string name="gamepadTestSkip">Skip</string>
 
-    <string name="gamepadTestKeyCodesUpAction" translatable="false">"\u2191"</string>
-    <string name="gamepadTestKeyCodesDownAction" translatable="false">"\u2193"</string>
+    <string name="gamepadTestKeyCodesUpAction" translatable="false">\u2191</string>
+    <string name="gamepadTestKeyCodesDownAction" translatable="false">\u2193</string>
 
-    <string name="gamepadTestKeyCodesUpCode">"Up"</string>
-    <string name="gamepadTestKeyCodesDownCode">"Dn"</string>
-    <string name="gamepadTestKeyCodesLeftCode">"Lf"</string>
-    <string name="gamepadTestKeyCodesRightCode">"Rt"</string>
+    <string name="gamepadTestKeyCodesUpCode">Up</string>
+    <string name="gamepadTestKeyCodesDownCode">Dn</string>
+    <string name="gamepadTestKeyCodesLeftCode">Lf</string>
+    <string name="gamepadTestKeyCodesRightCode">Rt</string>
 
     <!--    Gamepad test page -->
 
@@ -926,7 +926,7 @@
     <string name="toastPreferencesChangedForceWiFi">\'Allow Mobile Data\' preference changed.</string>
 
     <!--    Toast messages for the Routes Activity -->
-<!--    <string name="toastRoutesCommandSent">"Command sent to Set route "</string>-->
+<!--    <string name="toastRoutesCommandSent">Command sent to Set route </string>-->
 
     <!--    Toast messages for the Import/Export -->
     <string name="toastImportExportExportSucceeded">Preferences export to \'\\Android\\data\\jmri.enginedriver\\files\\%1$s\' succeeded.</string>
@@ -990,16 +990,16 @@
     <string name="prefTtsThrottleSpeedDefaultValue" translatable="false">Zero + Max</string>  <!-- DO NOT TRANSLATE -->
 
     <string name="prefTtsGamepadTestTitle">On Gamepad Test start</string>
-    <string name="prefTtsGamepadTestSummary">When the gamepad test screen is launched </string>
+    <string name="prefTtsGamepadTestSummary">When the gamepad test screen is launched</string>
 
     <string name="prefTtsGamepadTestKeysTitle">On Gamepad Test key press</string>
     <string name="prefTtsGamepadTestKeysSummary">When each buttons is pressed in the gamepad test screen</string>
 
     <string name="prefTtsGamepadTestCompleteTitle">On Gamepad Test complete</string>
-    <string name="prefTtsGamepadTestCompleteSummary">When the gamepad test screen is finished </string>
+    <string name="prefTtsGamepadTestCompleteSummary">When the gamepad test screen is finished</string>
 
 <!--    <string name="prefTurnMobileDataOnOffTitle">Mobile Data</string>-->
-<!--    <string name="prefTurnMobileDataOnOffSummary">Turn Mobile Data off at start of Engine Driver and back on at close </string>-->
+<!--    <string name="prefTurnMobileDataOnOffSummary">Turn Mobile Data off at start of Engine Driver and back on at close</string>-->
 
     <string name="TtsVolumeThrottle">Throttle</string>
     <string name="TtsGamepadThrottle">Throttle</string>
@@ -1069,10 +1069,10 @@
 
     <string name="prefConsistFollowString1DefaultValue">LIGHT</string>
     <string name="prefConsistFollowString2DefaultValue">WHISTLE,HORN,BELL</string>
-    <string name="prefConsistFollowStringOtherDefaultValue" />
+    <string name="prefConsistFollowStringOtherDefaultValue" translatable="false" />
     <string name="prefConsistFollowAction1DefaultValue" translatable="false">lead</string>
     <string name="prefConsistFollowAction2DefaultValue" translatable="false">lead</string>
-    <string name="prefConsistFollowActionOtherDefaultValue">lead</string>
+    <string name="prefConsistFollowActionOtherDefaultValue" translatable="false">lead</string>
 
     <string name="prefConsistFollowDefaultActionTitle">If All matches Fail Action</string>
     <string name="prefConsistFollowDefaultActionSummary">Which locos in the consist should react to the function buttons if none of the rules below are meet. (\'Complex\' matching rule only)</string>
@@ -1401,7 +1401,7 @@ if \'discovered\', or manually enter the ip address and port.</string> -->
     <string name="prefAlwaysUseFunctionsFromServerTitle">Always use function labels from server</string>
     <string name="prefAlwaysUseFunctionsFromServerSummary">When disabled, use EngineDriver default labels for locos selected by address (not Roster), ignoring server default labels.</string>
 
-    <string name="useProtocolDCCEX">Use WiThrottle or DCC-EX protocol?"</string>
+    <string name="useProtocolDCCEX">Use WiThrottle or DCC-EX protocol?</string>
     <string name="useProtocolDCCEXplusAutoHint">WiThrottle or DCC-EX protocol? (\'Auto\' looks for \"DCCEX\", \"DCC-EX\" or port 2560)</string>
     <string name="usingProtocolDCCEX">Using the DCC-EX protocol.\nUncheck \"Use native DCC-EX commands\" preference to use the WiThrottle protocol.</string>
 
@@ -1414,7 +1414,7 @@ if \'discovered\', or manually enter the ip address and port.</string> -->
 
     <string name="prefHapticFeedbackTitle">Haptic Feedback (Vibration)</string>
     <string name="prefHapticFeedbackSummary">Haptic feedback (vibrate) on speed changes</string>
-    <string name="prefHapticFeedbackDefaultValue" translatable="false">"None"</string>  <!-- DO NOT TRANSLATE -->
+    <string name="prefHapticFeedbackDefaultValue" translatable="false">None</string>  <!-- DO NOT TRANSLATE -->
 
     <string name="prefFullScreenSwipeAreaTitle">Disable full screen Swipe?</string>
     <string name="prefFullScreenSwipeAreaSummary">If checked, only the toolbar can be swiped to change screens</string>
@@ -1424,11 +1424,11 @@ if \'discovered\', or manually enter the ip address and port.</string> -->
 
     <!--    <string name="prefHapticFeedbackStepsTitle">Haptic Feedback Steps</string>-->
     <!--    <string name="prefHapticFeedbackStepsSummary">Number of steps for slider haptic feedback</string>-->
-    <!--    <string name="prefHapticFeedbackStepsDefaultValue" translatable="false">"10"</string>  &lt;!&ndash; DO NOT TRANSLATE &ndash;&gt;-->
+    <!--    <string name="prefHapticFeedbackStepsDefaultValue" translatable="false">10</string>  &lt;!&ndash; DO NOT TRANSLATE &ndash;&gt;-->
 
     <string name="prefHapticFeedbackDurationTitle">Haptic Feedback Duration</string>
     <string name="prefHapticFeedbackDurationSummary">Duration of each vibration (in milliseconds).</string>
-    <string name="prefHapticFeedbackDurationDefaultValue" translatable="false">"25"</string>
+    <string name="prefHapticFeedbackDurationDefaultValue" translatable="false">25</string>
     <string name="prefHapticFeedbackButtonsTitle">Haptic Feedback on Button Presses</string>
     <string name="prefHapticFeedbackButtonsSummary">Haptic feedback (vibrate) on button presses.</string>
     <string name="LocoSelectMethodIDNGo">Request Loco ID</string>
@@ -1466,9 +1466,10 @@ if \'discovered\', or manually enter the ip address and port.</string> -->
     <string name="witPomMaxValueWarning">Value \'%1$s\' exceeds max supported (\'%2$s\')</string>
 
     <string name="DCCEXcommonCvsLabel">NMRA CVs</string>
-    <string name="DCCEXcommonCommnadsLabel" >Common CMDs</string>
+    <string name="DCCEXcommonCommandsLabel" >Common CMDs</string>
 
     <string name="DCCEXsetTrackButtonLabel">Set</string>
+    <string name="DCCEXJoinTrackButtonLabel">Join</string>
 
     <string name="DccexSucceeded">Action Succeeded</string>
     <string name="DccexFailed">Action Failed</string>

--- a/EngineDriver/src/main/res/values/styles.xml
+++ b/EngineDriver/src/main/res/values/styles.xml
@@ -261,10 +261,12 @@
   </style>
 
   <style name="loco_label_style" parent="@android:style/Widget.TextView">
-    <item name="android:shadowColor">@color/black</item>
+    <item name="android:shadowColor">@color/solidWhite</item>
     <item name="android:shadowDx">1</item>
     <item name="android:shadowDy">1</item>
     <item name="android:shadowRadius">3</item>
+    <item name="android:textColor">@color/darkGrey</item>
+    <item name="android:textSize">10sp</item>
   </style>
 
   <style name="fn_scrollview_style"> <!-- dummy so that the other themes can alter the spacing without impacting the default theme -->
@@ -714,7 +716,8 @@
 
   <style name="loco_label_style_outline" parent="@android:style/Widget.TextView">
     <item name="android:background">@color/transparent</item>
-    <item name="android:textColor">@color/lightGrey</item>
+    <item name="android:textColor">@color/secondary_text</item>
+    <item name="android:textSize">10sp</item>
   </style>
 
   <style name="floating_text_style_outline" parent="@android:style/Widget.TextView">
@@ -1074,6 +1077,7 @@
   <style name="loco_label_style_colorful" parent="@android:style/Widget.TextView">
     <item name="android:background">@color/transparent</item>
     <item name="android:textColor">@color/darkTint</item>
+    <item name="android:textSize">10sp</item>
   </style>
 
   <style name="fn_scrollview_style_colorful">

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -16,6 +16,10 @@
  * Minor improvements on screen layouts when using German Langauge
  * Update to Gradle 8.4.2
  * Cleanup of the Power screen
+ * Cleanup of the translation files
+ * Return missing label on the Select Button.  It was there but in background.
+ * Add missing sort-by-position (order received) for the roster
+ * Roster sort order remembered between selects
 **Version 2.38.187
  * Preference to always show the Throw and Close buttons for Turnouts/Points
  * Improvement for non-roster locos saved to recents


### PR DESCRIPTION
 * Cleanup of the translation files
 * Start of the French Canadian translations by by Yvéric Patry (incomplete)
 * Minor improvement to the Consist page and Consist lights page
 * Fix for the exported log file not dealing well with the HTML version of the system info line (now includes both versions)
 * Return missing label on the Select Button.  It was there but in background.
 * Add missing sort-by-position (order received) for the roster
 * Roster sort order remembered between selects