### PR TITLE
JMRI sends the DCC-EX turnouts/points before they are requested

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -68,7 +68,6 @@ import jmri.enginedriver.type.consist_function_rule_style_type;
 import jmri.enginedriver.R;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.threaded_application;
-import jmri.enginedriver.type.requested_received_type;
 import jmri.enginedriver.type.source_type;
 import jmri.enginedriver.type.heartbeat_interval_type;
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -68,6 +68,7 @@ import jmri.enginedriver.type.consist_function_rule_style_type;
 import jmri.enginedriver.R;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.threaded_application;
+import jmri.enginedriver.type.requested_received_type;
 import jmri.enginedriver.type.source_type;
 import jmri.enginedriver.type.heartbeat_interval_type;
 
@@ -332,8 +333,6 @@ public class comm_thread extends Thread {
             if (mainapp.DCCEXlistsRequested < 0) { // if we haven't received all the lists go ask for them
                 wifiSend("<s>");
                 sendRequestRoster();
-
-//                // these request are now delayed and sen only when the previous list is complete
                 sendRequestTurnouts();
                 sendRequestRoutes();
                 sendRequestTracks();
@@ -1719,8 +1718,6 @@ public class comm_thread extends Thread {
 
 //                            mainapp.dccexRosterFullyReceived = true;
                             mainapp.safeToastInstructional(R.string.LocoSelectMethodRoster, LENGTH_SHORT);
-//                            // now ask for the Turnouts
-//                            sendRequestTurnouts();
                         }
                     }
 
@@ -1857,7 +1854,7 @@ public class comm_thread extends Thread {
                         }
                     }
                 }
-                if (ready) {
+                if ((ready) && (!mainapp.dccexTurnoutsFullyReceived) ) {
                     mainapp.dccexTurnoutString = "PTL";
                     if (!noTurnouts) {
                         for (int i = 0; i < mainapp.dccexTurnoutIDs.length; i++) {
@@ -1881,10 +1878,8 @@ public class comm_thread extends Thread {
                     Log.d("Engine_Driver", "comm_thread.processDccexTurnouts: Turnouts complete. Count: " + count);
                     mainapp.dccexTurnoutsBeingProcessed = false;
 
-//                    mainapp.dccexTurnoutsFullyReceived = true;
+                    mainapp.dccexTurnoutsFullyReceived = true;
                     mainapp.safeToastInstructional(R.string.turnouts, LENGTH_SHORT);
-//                    // now ask for the Routes
-//                    sendRequestRoutes();
                 }
 
             } else { // turnouts list  <jT id1 id2 id3 ...>
@@ -1982,8 +1977,6 @@ public class comm_thread extends Thread {
 
 //                    mainapp.dccexRoutesFullyReceived = true;
                     mainapp.safeToastInstructional(R.string.routes, LENGTH_SHORT);
-//                    //now ask for the Tracks
-//                    sendRequestTracks();
                 }
 
             } else { // routes list   <jA id1 id2 id3 ...>   or <jA> for empty

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -249,7 +249,7 @@ public class threaded_application extends Application {
 
     public boolean dccexTurnoutsBeingProcessed = false;
 //    public boolean dccexTurnoutsRequested = false;
-//    public boolean dccexTurnoutsFullyReceived = false;
+    public boolean dccexTurnoutsFullyReceived = false;
     public String dccexTurnoutString = ""; // used to process the turnout list
     public int [] dccexTurnoutIDs;  // used to process the turnout list
     public String [] dccexTurnoutNames;  // used to process the turnout list
@@ -1095,7 +1095,7 @@ public class threaded_application extends Application {
 
         dccexTurnoutsBeingProcessed = false;
 //        dccexTurnoutsRequested = false;
-//        dccexTurnoutsFullyReceived = false;
+        dccexTurnoutsFullyReceived = false;
 
         dccexRoutesBeingProcessed = false;
 //        dccexRoutesRequested = false;

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -7,6 +7,7 @@
  * fix bug where the bottom of the last function was chopped off in the scroll region
  * play a tone and vibrate when a system alert/message is received.
  * fix bug where DCC-EX Routes and Turnouts may not load if ED is not removed from memory by Android
+ * attempt to address anomaly where JMRI sends the DCC-EX turnouts/points before they are actually requested
 **Version 2.38.190
  * Bug fix for IPLS when linked to the F1 F2 DCC functions
  * Added parnoid check for permissions that should be automatically granted


### PR DESCRIPTION
- Address anomaly where JMRI sends the DCC-EX turnouts/points before they are actually requested