### PR TITLE
Make the PHONE permission more obviously 'optional'

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
@@ -145,7 +145,10 @@ public class comm_handler extends Handler {
 
                commThread.sendThrottleName();
                mainapp.sendMsgDelay(mainapp.comm_msg_handler, 5000L, message_type.CONNECTION_COMPLETED_CHECK);
-               commThread.phone = new comm_thread.PhoneListener();
+
+               if (prefs.getBoolean("stop_on_phonecall_preference", mainapp.getResources().getBoolean(R.bool.prefStopOnPhonecallDefaultValue))) {
+                  commThread.phone = new comm_thread.PhoneListener();
+               }
             } else {
                mainapp.host_ip = null;  //clear vars if failed to connect
                mainapp.port = 0;

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -688,6 +688,7 @@ public class connection_activity extends AppCompatActivity implements Permission
         }
 
         getWifiInfo();
+        getPhoneInfo();
 
         mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
         //start up server discovery listener
@@ -782,6 +783,29 @@ public class connection_activity extends AppCompatActivity implements Permission
                     "");
         }
     }
+
+    void getPhoneInfo() {
+        Log.d("Engine_Driver", "c_a: NetworkRequest.getPhoneInfo()");
+
+        PermissionsHelper phi = PermissionsHelper.getInstance();
+        if (!phi.isPermissionGranted(connection_activity.this, PermissionsHelper.READ_PHONE_STATE)) {
+            if (prefs.getBoolean("stop_on_phonecall_preference", mainapp.getResources().getBoolean(R.bool.prefStopOnPhonecallDefaultValue))) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    // how many times have we asked for this before?
+                    int count = prefs.getInt("prefStopOnPhonecallCount", 0);
+                    if (count < 5) {  // this is effectively counted twice each startup
+                        phi.requestNecessaryPermissions(connection_activity.this, PermissionsHelper.READ_PHONE_STATE);
+                        count++;
+                    } else {
+                        prefs.edit().putBoolean("stop_on_phonecall_preference", false).apply();
+                        count = 0;
+                    }
+                    prefs.edit().putInt("prefStopOnPhonecallCount", count).apply();
+                }
+            }
+        }
+    }
+
 
     /**
      * retrieve some wifi details, stored in mainapp as client_ssid, client_address and client_address_inet4
@@ -1166,8 +1190,7 @@ public class connection_activity extends AppCompatActivity implements Permission
         } else {
             // Go to the correct handler based on the request code.
             // Only need to consider relevant request codes initiated by this Activity
-            //noinspection SwitchStatementWithTooFewBranches
-            switch (requestCode) {
+//            switch (requestCode) {
 //                    case PermissionsHelper.CLEAR_CONNECTION_LIST:
 //                        Log.d("Engine_Driver", "Got permission for CLEAR_CONNECTION_LIST - navigate to clearConnectionsListImpl()");
 //                        clearConnectionsListImpl();
@@ -1184,16 +1207,16 @@ public class connection_activity extends AppCompatActivity implements Permission
 //                        Log.d("Engine_Driver", "Got permission for READ_PREFERENCES - navigate to loadSharedPreferencesFromFileImpl()");
 //                        loadSharedPreferencesFromFileImpl();
 //                        break;
-                case PermissionsHelper.CONNECT_TO_SERVER:
-                    Log.d("Engine_Driver", "Got permission for READ_PHONE_STATE - navigate to connectImpl()");
-//                    connectImpl();
-                    checkIfDccexServerName(connected_hostname, connected_port);
-                    connect();
-                    break;
-                default:
+//                case PermissionsHelper.CONNECT_TO_SERVER:
+//                    Log.d("Engine_Driver", "Got permission for READ_PHONE_STATE - navigate to connectImpl()");
+////                    connectImpl();
+//                    checkIfDccexServerName(connected_hostname, connected_port);
+//                    connect();
+//                    break;
+//                default:
                     // do nothing
                     Log.d("Engine_Driver", "Unrecognised permissions request code: " + requestCode);
-            }
+//            }
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
@@ -41,7 +41,7 @@ public class PermissionsHelper {
 //            READ_FUNCTION_SETTINGS,
 //            STORE_FUNCTION_SETTINGS,
 //            STORE_LOG_FILES,
-            CONNECT_TO_SERVER,
+//            CONNECT_TO_SERVER,
             WRITE_SETTINGS,
             ACCESS_FINE_LOCATION,
 //            STORE_SERVER_AUTO_PREFERENCES,
@@ -70,7 +70,7 @@ public class PermissionsHelper {
 //    public static final int STORE_PREFERENCES = 37;
 //    public static final int READ_FUNCTION_SETTINGS = 38;
 //    public static final int STORE_FUNCTION_SETTINGS = 39;
-    public static final int CONNECT_TO_SERVER = 40;
+//    public static final int CONNECT_TO_SERVER = 40;
     public static final int WRITE_SETTINGS = 41;
     public static final int ACCESS_FINE_LOCATION = 42;
 //    public static final int STORE_SERVER_AUTO_PREFERENCES = 43;
@@ -180,8 +180,8 @@ public class PermissionsHelper {
 //                return context.getResources().getString(R.string.permissionsStoreFunctionSettings);
 //            case READ_FUNCTION_SETTINGS:
 //                return context.getResources().getString(R.string.permissionsReadFunctionSettings);
-            case CONNECT_TO_SERVER:
-                return context.getResources().getString(R.string.permissionsConnectToServer);
+//            case CONNECT_TO_SERVER:
+//                return context.getResources().getString(R.string.permissionsConnectToServer);
             case WRITE_SETTINGS:
                 return context.getResources().getString(R.string.permissionsWriteSettings);
             case ACCESS_FINE_LOCATION:
@@ -259,17 +259,12 @@ public class PermissionsHelper {
                                     Manifest.permission.ACCESS_FINE_LOCATION},
                             requestCode);
                     break;
-                case CONNECT_TO_SERVER:
-//                    Log.d("Engine_Driver", "Requesting PHONE and STORAGE permissions");
-                    Log.d("Engine_Driver", "Requesting PHONE permission");
+//                case CONNECT_TO_SERVER:
+//                    Log.d("Engine_Driver", "Requesting PHONE permission");
 //                    activity.requestPermissions(new String[]{
-//                                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-//                                    Manifest.permission.READ_EXTERNAL_STORAGE,
-//                    requestCode);
-                    activity.requestPermissions(new String[]{
-                                    Manifest.permission.READ_PHONE_STATE},
-                            requestCode);
-                    break;
+//                                    Manifest.permission.READ_PHONE_STATE},
+//                            requestCode);
+//                    break;
                 case WRITE_SETTINGS:
                     Log.d("Engine_Driver", "Requesting WRITE_SETTINGS permissions");
                     if (Build.VERSION.SDK_INT < 23) {
@@ -459,7 +454,7 @@ public class PermissionsHelper {
             case READ_IMAGES:
                 return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
             case READ_PHONE_STATE:
-            case CONNECT_TO_SERVER:
+//            case CONNECT_TO_SERVER:
                 return  ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
             case ACCESS_FINE_LOCATION :
                 return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION ) == PackageManager.PERMISSION_GRANTED;
@@ -532,7 +527,7 @@ public class PermissionsHelper {
             case READ_IMAGES:
                 return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_EXTERNAL_STORAGE);
             case READ_PHONE_STATE:
-            case CONNECT_TO_SERVER:
+//            case CONNECT_TO_SERVER:
                 return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_PHONE_STATE);
             case ACCESS_FINE_LOCATION:
                 return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -764,7 +764,7 @@
     <string name="permissionsAppSettingsButton">Configuració de l\'aplicació</string>
     <string name="permissionsSystemSettingsButton">Configuració del sistema</string>
     <string name="permissionsRetryButton">Torneu a provar</string>
-    <string name="permissionsRequestTitle">Permisos necessaris</string>
+    <string name="permissionsRequestTitle">Permisos</string>
     <string name="permissionsRetryTitle">Permisos rebutjats</string>
 
     <!-- Introduction / Setup Wizard -->
@@ -1012,7 +1012,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botó de campana és momentània. (Bloqueig si no està marcat.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bouth Button Botó / momentània</string>
 <!--    <string name="permissionsReadLegacyFiles">El controlador de motor necessita permisos d\'emmagatzematge per carregar la configuració del llegat (ubicació antiga).</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver necessita permisos de telèfon per aturar les operacions en una trucada.</string>
+    <string name="permissionsReadPhoneState">Engine Driver necessita permisos de telèfon per aturar les operacions en una trucada.\n\nSi no és necessari, desactiveu la preferència \"Aturar la trucada telefònica?\".</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferències addicionals</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Addicionals al telèfon Loco sona les preferències</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Els sons de pas de loco jugaran fins al final en canviar de pas. La quantitat d\'impuls (a dalt) només es converteix en un temps mínim.</string>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -884,7 +884,7 @@
     <string name="permissionsAppSettingsButton">Nastavení aplikace</string>
     <string name="permissionsSystemSettingsButton">Nastavení systému</string>
     <string name="permissionsRetryButton">Opakovat</string>
-    <string name="permissionsRequestTitle">Oprávnění vyžadováno</string>
+    <string name="permissionsRequestTitle">Oprávnění</string>
     <string name="permissionsRetryTitle">Oprávnění odmítnuta</string>
 
     <!-- Introduction / Setup Wizard -->
@@ -1114,7 +1114,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Tlačítko Bell je momentální. (Zabezpečení, pokud není zaškrtnuto.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bell Tlačítko Latching / Momentary</string>
 <!--    <string name="permissionsReadLegacyFiles">Ovladač motoru potřebuje oprávnění pro ukládání dat pro nastavení starší (staré umístění).</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver potřebuje oprávnění PHONE pro pozastavení provozu během hovoru.</string>
+    <string name="permissionsReadPhoneState">Engine Driver potřebuje oprávnění PHONE pro pozastavení provozu během hovoru.\n\nPokud to není vyžadováno, deaktivujte předvolbu \'Zastavit hovor?\'</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Další preference</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Další v telefonu Loco Sounds Preferences</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Zuny Loco Step bude hrát až do jejich konce při změně kroku. Částka hybnosti (výše) se stává minimálním časem.</string>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -720,7 +720,7 @@
 <!--    <string name="permissionsGotoAppSettings">Bitte aktivieren Sie diese Berechtigungen in den App-Einstellungen.</string>-->
     <string name="permissionsAppSettingsButton">App Einstellungen</string>
     <string name="permissionsRetryButton">Wiederholen</string>
-    <string name="permissionsRequestTitle">Erforderliche Berechtigungen</string>
+    <string name="permissionsRequestTitle">Berechtigungen</string>
     <string name="permissionsRetryTitle">Berechtigungen abgelehnt</string>
 
     <string name="introWelcomeTitle">Willkommen bei\nEngine Driver</string>
@@ -1017,7 +1017,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Die Bell-Taste ist momentan. (Verriegelung, wenn nicht markiert.)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Glockenknopfverriegelung / momentan</string>
 <!--    <string name="permissionsReadLegacyFiles">Der Engine-Treiber benötigt Speicherberechtigungen, um die Einstellungen der Alt- (alten Standort-) zu laden.</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver benötigt Telefonberechtigungen, um den Betrieb bei einem Anruf anzuhalten.</string>
+    <string name="permissionsReadPhoneState">Engine Driver benötigt Telefonberechtigungen, um den Betrieb bei einem Anruf anzuhalten.\n\nFalls nicht erforderlich, deaktivieren Sie die Einstellung „Beim Telefonanruf stoppen?“.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Zusätzliche Präferenzen</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Zusätzlich in Telefon Loco Sounds-Vorlieben</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco-Step-Sounds spielen bis zum Ende, wenn Sie den Schritt ändern. Der Momentummenge (oben) wird nur zu einer Mindestzeit.</string>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -752,7 +752,7 @@
 <!--    <string name="permissionsGotoAppSettings">Por favor habilite estos permisos desde la configuración de la aplicación</string>-->
     <string name="permissionsAppSettingsButton">Ajustes de aplicacion</string>
     <string name="permissionsRetryButton">Procesar de nuevo</string>
-    <string name="permissionsRequestTitle">Permisos requeridos</string>
+    <string name="permissionsRequestTitle">Permisos</string>
     <string name="permissionsRetryTitle">Permisos rechazados</string>
 
     <!-- Introduction / Setup Wizard -->
@@ -1009,7 +1009,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Botón de campana Latching / Momenty</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botón de campana es momentáneo. (Enganchando si no se controla).</string>
 <!--    <string name="permissionsReadLegacyFiles">El controlador del motor necesita permisos de almacenamiento para cargar la configuración de Legacy (antigua ubicación).</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver necesita permisos telefónicos para pausar las operaciones cuando se llame.</string>
+    <string name="permissionsReadPhoneState">Engine Driver necesita permisos telefónicos para pausar las operaciones cuando se llame.\n\nSi no es necesario, deshabilite la preferencia \"¿Detener en llamada telefónica?\".</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferencias adicionales</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Adicional en teléfono loco sonidas preferencias</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Los sonidos del paso de Loco jugarán hasta su final al cambiar el paso. La cantidad de impulso (arriba) se convierte en un tiempo mínimo solamente.</string>

--- a/EngineDriver/src/main/res/values-fr-rCA/strings.xml
+++ b/EngineDriver/src/main/res/values-fr-rCA/strings.xml
@@ -340,10 +340,10 @@
 
 
 
-    <string name="permissionsReadPhoneState">Engine Driver nécessite la permission PHONE pour suspendre l\'application à la réception d\'un appel.</string>
+    <string name="permissionsReadPhoneState">Engine Driver nécessite la permission PHONE pour suspendre l\'application à la réception d\'un appel.\n\nSi cela n\'est pas nécessaire, désactivez la préférence «Arrêter sur appel téléphonique?».</string>
 
 
-    <string name="permissionsRequestTitle">Permissions requises</string>
+    <string name="permissionsRequestTitle">Permissions</string>
 
 
 

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -681,7 +681,7 @@
     <string name="permissionsAppSettingsButton">Paramètres APPLICATION</string>
     <string name="permissionsSystemSettingsButton">Paramètres Système</string>
     <string name="permissionsRetryButton">Recommencer</string>
-    <string name="permissionsRequestTitle">Permissions nécessaires</string>
+    <string name="permissionsRequestTitle">Permissions</string>
     <string name="permissionsRetryTitle">Permissions refusées</string>
     <string name="introWelcomeTitle">Bienvenue sur \nEngine Driver</string>
     <string name="introWelcomeSummary">Cette application peut se connecter à un serveur WiThrottle JMRI, MRC ou DigiTrax pour controler vos locomotives et accessoires DCC. Les pages suivantes vous guideront pour le paramétrage initial.</string>
@@ -1005,7 +1005,7 @@
     <string name="prefDeviceSoundsBellIsMomentarySummary">Bouton Cloche temporaire (sinon verrouillé)</string>
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Verrouillage de bouton de cloche / momentané</string>
 <!--    <string name="permissionsReadLegacyFiles">Engine Driver nécessite accès au STOCKAGE pour charger les anciens paramètres..</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver nécessite accès au TELEPHONE pour se mettre en pause si appel telephoniques.</string>
+    <string name="permissionsReadPhoneState">Engine Driver nécessite accès au TELEPHONE pour se mettre en pause si appel telephoniques.\n\nSi cela n\'est pas nécessaire, désactivez la préférence «Arrêter sur appel téléphonique?».</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Préférences supplémentaires</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Préférences supplémentaires pour les sons via le telephone.</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Les sons liés a la vitesse de la loco joués en entier au changement de vitesse, le délai défini devient un minimum.</string>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -671,7 +671,7 @@
 <!--    <string name="permissionsGotoAppSettings">Si prega di abilitare queste autorizzazioni dalle impostazioni dell\'app.</string>-->
     <string name="permissionsAppSettingsButton">Impostazioni dell\'app</string>
     <string name="permissionsRetryButton">Riprova</string>
-    <string name="permissionsRequestTitle">Autorizzazioni richieste</string>
+    <string name="permissionsRequestTitle">Autorizzazioni</string>
     <string name="permissionsRetryTitle">Autorizzazioni rifiutate</string>
 
     <string name="introWelcomeTitle">Benvenuto in\nEngine Driver</string>
@@ -951,7 +951,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Bell pulsante chiaggiatore / momentatore</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Il pulsante Bell è momentaneo. (Chiusura se non controllata.)</string>
 <!--    <string name="permissionsReadLegacyFiles">Il driver del motore ha bisogno di autorizzazioni di archiviazione per caricare le impostazioni legacy (Posizione vecchia).</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver ha bisogno di autorizzazioni telefoniche per mettere in pausa le operazioni quando su una chiamata.</string>
+    <string name="permissionsReadPhoneState">Engine Driver ha bisogno di autorizzazioni telefoniche per mettere in pausa le operazioni quando su una chiamata.\n\nSe non è necessario, disabilita la preferenza "Interrompi alla chiamata?".</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Ulteriori preferenze</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Ulteriori preferenze del telefono dei suoni del telefono</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Loco Step Sounds giocherà fino alla fine quando cambiano il passaggio. L\'importo dello slancio (sopra) diventa solo un tempo minimo.</string>

--- a/EngineDriver/src/main/res/values-ja/strings.xml
+++ b/EngineDriver/src/main/res/values-ja/strings.xml
@@ -347,10 +347,10 @@
 
 
 
-    <string name="permissionsReadPhoneState">エンジン ドライバーには、通話中に操作を一時停止するには PHONE 権限が必要です。</string>
+    <string name="permissionsReadPhoneState">エンジン ドライバーには、通話中に操作を一時停止するには PHONE 権限が必要です。\n\n必要がない場合は、「通話時に停止しますか?」設定を無効にします。</string>
 
 
-    <string name="permissionsRequestTitle">必要な権限</string>
+    <string name="permissionsRequestTitle">権限</string>
     <string name="permissionsRetryButton">リトライ</string>
     <string name="permissionsRetryTitle">権限が拒否されました</string>
 

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -676,7 +676,7 @@
 <!--    <string name="permissionsGotoAppSettings">Por favor ative estas permissões nas configurações do aplicativo.</string>-->
     <string name="permissionsAppSettingsButton">Configurações do aplicativo</string>
     <string name="permissionsRetryButton">Tente novamente</string>
-    <string name="permissionsRequestTitle">Permissões necessárias</string>
+    <string name="permissionsRequestTitle">Permissões</string>
     <string name="permissionsRetryTitle">Permissões recusadas</string>
 
     <string name="introWelcomeTitle">Welcome to \nEngine Driver</string>
@@ -956,7 +956,7 @@
     <string name="prefDeviceSoundsBellIsMomentaryTitle">Botão de sino travamento / momentâneo</string>
     <string name="prefDeviceSoundsBellIsMomentarySummary">Botão Bell é momentâneo. (Travamento se desmarcado.)</string>
 <!--    <string name="permissionsReadLegacyFiles">O driver do motor precisa de permissões de armazenamento para carregar as configurações legadas (local de localização).</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver precisa de permissões de telefone para pausar as operações quando estiver em uma chamada.</string>
+    <string name="permissionsReadPhoneState">Engine Driver precisa de permissões de telefone para pausar as operações quando estiver em uma chamada.\n\nSe não for necessário, desative a preferência \'Parar na chamada telefônica?\'.</string>
     <string name="prefDeviceSoundsAdditionalPreferencesTitle">Preferências adicionais</string>
     <string name="prefDeviceSoundsAdditionalPreferencesSummary">Preferências adicionais em Telefone Loco Sounds</string>
     <string name="prefDeviceSoundsMomentumOverrideSummary">Os sons de passo de loco jogarão até o fim ao mudar de passo. A quantidade de momentum (acima) se torna apenas um tempo mínimo.</string>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -432,7 +432,7 @@
     <string name="prefSelectiveLeadSoundF1Summary">For the \'Selective Lead Unit Sound\' option</string>
     <string name="prefSelectiveLeadSoundF2Title">Always treat F2 as Sound?</string>
     <string name="prefSelectiveLeadSoundF2Summary">For the \'Selective Lead Unit Sound\' option</string>
-    <string name="prefStopOnPhonecallTitle">Stop on Phonecall?</string>
+    <string name="prefStopOnPhonecallTitle">Stop on Phone Call?</string>
     <string name="prefStopOnPhonecallSummary">Stop loco(s) when a phone call is answered or placed</string>
     <string name="prefStopOnReleaseTitle">Stop on Release?</string>
     <string name="prefStopOnReleaseSummary">Stop loco(s) when releasing from throttle</string>
@@ -1171,7 +1171,7 @@
 <!--    <string name="permissionsStorePreferences">Engine Driver needs STORAGE permissions to store preferences.</string>-->
 <!--    <string name="permissionsStoreAndReadPreferences">Engine Driver needs STORAGE permissions to store and read preferences.</string>-->
 <!--    <string name="permissionsClearPreferences">Engine Driver needs STORAGE permissions to clear preferences.</string>-->
-    <string name="permissionsReadPhoneState">Engine Driver needs PHONE permissions to pause operations when on a call.</string>
+    <string name="permissionsReadPhoneState">Engine Driver needs the PHONE permission to stop your locos when on a call.\n\nIf not required, Disable the \'Stop on Phone Call?\` preference.</string>
 <!--    <string name="permissionsReadFunctionSettings">Engine Driver needs STORAGE permissions to read function settings.</string>-->
 <!--    <string name="permissionsStoreFunctionSettings">Engine Driver needs STORAGE permissions to store function settings.</string>-->
     <string name="permissionsWriteSettings">Engine Driver needs ALLOW MODIFYING SYSTEM SETTINGS permissions to change screen brightness.</string>
@@ -1196,7 +1196,7 @@
     <string name="permissionsAppSettingsButton">App settings</string>
     <string name="permissionsSystemSettingsButton">System settings</string>
     <string name="permissionsRetryButton">Retry</string>
-    <string name="permissionsRequestTitle">Permissions Required</string>
+    <string name="permissionsRequestTitle">Permissions</string>
     <string name="permissionsRetryTitle">Permissions Declined</string>
 
 

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -6,6 +6,7 @@
  * Replace the deprecated functions in ImageDownloader, Throttle, ImportExportConnectionsList and LogViewerActivity
  * Replace the deprecated AsyncTask in LogViewer
  * Linting. Primarily in all the util classes
+ * Make the PHONE permission more clearly optional
 **Version 2.39.194
  * Toast message when the Roster, Turnouts/Points & Routes each have finished loading for DCC-EX (can be disabled with the Informational Toast preference)
  * When you change throttle layouts, and the new layout supports a range of throttles, ask for the number.


### PR DESCRIPTION
Previously it failed gracefully if the permission was not granted, but was not clear that the stop on phone call would not work.

Now it asks a couple of times before deliberately disabling the stop on phone call preference.