### PR TITLE
Tidy up of the AppIntro permissions

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_thread.java
@@ -1358,7 +1358,7 @@ public class comm_thread extends Thread {
                             }
                             break;
 
-                        case 'H': //Turnout change
+                        case 'H': // Turnout/points change
                             if (args.length==3) {
                                 responseStr = "PTA" + (((args[2].equals("T")) || (args[2].equals("1"))) ? 4 : 2) + args[1];
                                 processTurnoutChange(responseStr);

--- a/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/connection_activity.java
@@ -689,7 +689,7 @@ public class connection_activity extends AppCompatActivity implements Permission
         }
 
         getWifiInfo();
-        getPhoneInfo();
+//        getPhoneInfo();
 
         mainapp.setActivityOrientation(this);  //set screen orientation based on prefs
         //start up server discovery listener
@@ -785,7 +785,8 @@ public class connection_activity extends AppCompatActivity implements Permission
                 warningTextBuilder.append(getString(R.string.statusThreadedAppServerDiscoverySsidUnavailable));
                 discoveredServersWarning.setText(warningTextBuilder.toString());
             }
-            discoveredServersWarning.setVisibility(VISIBLE);
+            threaded_application.safeToast(warningTextBuilder.toString(), Toast.LENGTH_LONG);
+//            discoveredServersWarning.setVisibility(VISIBLE);
         } else {
             discoveredServersWarning.setVisibility(GONE);
         }
@@ -801,27 +802,27 @@ public class connection_activity extends AppCompatActivity implements Permission
         }
     }
 
-    void getPhoneInfo() {
-        Log.d("Engine_Driver", "c_a: NetworkRequest.getPhoneInfo()");
-
-        PermissionsHelper phi = PermissionsHelper.getInstance();
-        if (!phi.isPermissionGranted(connection_activity.this, PermissionsHelper.READ_PHONE_STATE)) {
-            if (prefs.getBoolean("stop_on_phonecall_preference", mainapp.getResources().getBoolean(R.bool.prefStopOnPhonecallDefaultValue))) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    // how many times have we asked for this before?
-                    int count = prefs.getInt("prefStopOnPhonecallCount", 0);
-                    if (count < 5) {  // this is effectively counted twice each startup
-                        phi.requestNecessaryPermissions(connection_activity.this, PermissionsHelper.READ_PHONE_STATE);
-                        count++;
-                    } else {
-                        prefs.edit().putBoolean("stop_on_phonecall_preference", false).apply();
-                        count = 0;
-                    }
-                    prefs.edit().putInt("prefStopOnPhonecallCount", count).apply();
-                }
-            }
-        }
-    }
+//    void getPhoneInfo() {
+//        Log.d("Engine_Driver", "c_a: NetworkRequest.getPhoneInfo()");
+//
+//        PermissionsHelper phi = PermissionsHelper.getInstance();
+//        if (!phi.isPermissionGranted(connection_activity.this, PermissionsHelper.READ_PHONE_STATE)) {
+//            if (prefs.getBoolean("stop_on_phonecall_preference", mainapp.getResources().getBoolean(R.bool.prefStopOnPhonecallDefaultValue))) {
+//                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+//                    // how many times have we asked for this before?
+//                    int count = prefs.getInt("prefStopOnPhonecallCount", 0);
+//                    if (count < 5) {  // this is effectively counted twice each startup
+//                        phi.requestNecessaryPermissions(connection_activity.this, PermissionsHelper.READ_PHONE_STATE);
+//                        count++;
+//                    } else {
+//                        prefs.edit().putBoolean("stop_on_phonecall_preference", false).apply();
+//                        count = 0;
+//                    }
+//                    prefs.edit().putInt("prefStopOnPhonecallCount", count).apply();
+//                }
+//            }
+//        }
+//    }
 
 
     /**

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
@@ -251,11 +251,11 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
         }
 
         if (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.WRITE_SETTINGS)) {
-            args = new Bundle();
-            args.putString("id", Integer.toString(PermissionsHelper.WRITE_SETTINGS));
-            args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsWriteSettings));
-            fragment = new intro_permissions();
-            fragment.setArguments(args);
+//            args = new Bundle();
+//            args.putString("id", Integer.toString(PermissionsHelper.WRITE_SETTINGS));
+//            args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsWriteSettings));
+            fragment = new intro_write_settings();
+//            fragment.setArguments(args);
             addSlide(fragment);
         }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_finish.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_finish.java
@@ -20,6 +20,7 @@ Derived from the samples for AppIntro at https://github.com/paolorotolo/AppIntro
 
 package jmri.enginedriver.intro;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -28,7 +29,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Objects;
+
 import jmri.enginedriver.R;
+import jmri.enginedriver.util.PermissionsHelper;
 
 public class intro_finish extends Fragment {
 
@@ -44,4 +48,16 @@ public class intro_finish extends Fragment {
         return inflater.inflate(R.layout.intro_finish, container, false);
     }
 
+
+    @Override
+    public void setUserVisibleHint(boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        if (isVisibleToUser) {
+            PermissionsHelper phi = PermissionsHelper.getInstance();
+            if (!phi.isPermissionGranted(this.getActivity(), PermissionsHelper.READ_PHONE_STATE)) {
+                SharedPreferences prefs = Objects.requireNonNull(this.getActivity()).getSharedPreferences("jmri.enginedriver_preferences", 0);
+                prefs.edit().putBoolean("stop_on_phonecall_preference", false).apply();
+            }
+        }
+    }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -1016,11 +1016,17 @@ public class threaded_application extends Application {
         sHtml += String.format("<small>, DeviceID: </small><b>%s</b>", getFakeDeviceId());
         s += String.format(", DeviceID: %s", getFakeDeviceId());
 
+        String ssid = client_ssid;
+        PermissionsHelper phi = PermissionsHelper.getInstance();
+        if ( (!mainapp.clientLocationServiceEnabled) || (!phi.isPermissionGranted(this, PermissionsHelper.ACCESS_FINE_LOCATION))) {
+            ssid = "[DECLINED]";
+        }
+
         if (client_address_inet4 != null) {
             sHtml += String.format("<small>, IP: </small><b>%s</b>", client_address_inet4.toString().replaceAll("/", ""));
-            sHtml += String.format("<small>, SSID: </small><b>%s</b> <small>Net: </small><b>%s</b>", client_ssid, client_type);
+            sHtml += String.format("<small>, SSID: </small><b>%s</b> <small>Net: </small><b>%s</b>", ssid, client_type);
             s += String.format(", IP: %s", client_address_inet4.toString().replaceAll("/", ""));
-            s += String.format(", SSID: %s Net: %s", client_ssid, client_type);
+            s += String.format(", SSID: %s Net: %s", ssid, client_type);
         }
 
         // ED version info

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
@@ -317,7 +317,7 @@ public class PermissionsHelper {
                         isDialogOpen = false;
                     }
                 })
-                .setNegativeButton(context.getResources().getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                .setNegativeButton(context.getResources().getString(R.string.permissionsDeclineButton), new DialogInterface.OnClickListener() {
                     @Override public void onClick(DialogInterface dialogInterface, int i) {
                         isDialogOpen = false;
                     }

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -761,6 +761,7 @@
     <string name="permissionsConnectToServer">Engine Driver necessita permisos D\'EMMAGATZEMATGE per emmagatzemar les connexions recents i els permisos del TELÈFON per aturar les operacions en una trucada</string>
 <!--    <string name="permissionsGotoAppSettings">Permet aquests permisos de la configuració de l\'aplicació</string>-->
     <string name="permissionsAppSettingsButton">Configuració de l\'aplicació</string>
+    <string name="permissionsDeclineButton">Declinar</string>
     <string name="permissionsSystemSettingsButton">Configuració del sistema</string>
     <string name="permissionsRetryButton">Torneu a provar</string>
     <string name="permissionsRequestTitle">Permisos</string>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -886,6 +886,7 @@
     <string name="permissionsConnectToServer">Engine Driver potřebuje oprávnění STORAGE pro uložení nedávných připojení a oprávnění PHONE pro pozastavení provozu během hovoru.</string>
 <!--    <string name="permissionsGotoAppSettings">Prosím povolte tato oprávnění z nastavení aplikace.</string>-->
     <string name="permissionsAppSettingsButton">Nastavení aplikace</string>
+    <string name="permissionsDeclineButton">Pokles</string>
     <string name="permissionsSystemSettingsButton">Nastavení systému</string>
     <string name="permissionsRetryButton">Opakovat</string>
     <string name="permissionsRequestTitle">Oprávnění</string>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -719,6 +719,7 @@
     <string name="permissionsConnectToServer">Engine Driver benötigt STORAGE-Berechtigungen zum Speichern der letzten Verbindungen und PHONE-Berechtigungen, um Vorgänge während eines Anrufs anzuhalten.</string>
 <!--    <string name="permissionsGotoAppSettings">Bitte aktivieren Sie diese Berechtigungen in den App-Einstellungen.</string>-->
     <string name="permissionsAppSettingsButton">App Einstellungen</string>
+    <string name="permissionsDeclineButton">Abfall</string>
     <string name="permissionsRetryButton">Wiederholen</string>
     <string name="permissionsRequestTitle">Berechtigungen</string>
     <string name="permissionsRetryTitle">Berechtigungen abgelehnt</string>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -751,6 +751,7 @@
     <string name="permissionsConnectToServer">Engine Driver necesita permisos de ALMACENAMIENTO para almacenar conexiones recientes y permisos de TELÉFONO para pausar las operaciones durante una llamada</string>
 <!--    <string name="permissionsGotoAppSettings">Por favor habilite estos permisos desde la configuración de la aplicación</string>-->
     <string name="permissionsAppSettingsButton">Ajustes de aplicacion</string>
+    <string name="permissionsDeclineButton">Rechazar</string>
     <string name="permissionsRetryButton">Procesar de nuevo</string>
     <string name="permissionsRequestTitle">Permisos</string>
     <string name="permissionsRetryTitle">Permisos rechazados</string>

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -682,6 +682,7 @@
     <string name="permissionsConnectToServer">Engine Driver nécessite un accès au STOCKAGE pour sauver les connexions récentes et un accès TELEPHONE pour se mettre en pause lors de communications téléphoniques.</string>
 <!--    <string name="permissionsGotoAppSettings">Merci de valider ces permissions depuis le paramétrage APPLICATION</string>-->
     <string name="permissionsAppSettingsButton">Paramètres APPLICATION</string>
+    <string name="permissionsDeclineButton">Déclin</string>
     <string name="permissionsSystemSettingsButton">Paramètres Système</string>
     <string name="permissionsRetryButton">Recommencer</string>
     <string name="permissionsRequestTitle">Permissions</string>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -670,6 +670,7 @@
     <string name="permissionsConnectToServer">Engine Driver ha bisogno delle autorizzazioni di STORAGE per memorizzare le connessioni recenti e le autorizzazioni PHONE per mettere in pausa le operazioni durante una chiamata.</string>
 <!--    <string name="permissionsGotoAppSettings">Si prega di abilitare queste autorizzazioni dalle impostazioni dell\'app.</string>-->
     <string name="permissionsAppSettingsButton">Impostazioni dell\'app</string>
+    <string name="permissionsDeclineButton">Declino</string>
     <string name="permissionsRetryButton">Riprova</string>
     <string name="permissionsRequestTitle">Autorizzazioni</string>
     <string name="permissionsRetryTitle">Autorizzazioni rifiutate</string>

--- a/EngineDriver/src/main/res/values-ja/strings.xml
+++ b/EngineDriver/src/main/res/values-ja/strings.xml
@@ -335,7 +335,7 @@
     <string name="permissionsACCESS_WIFI_STATE">エンジン ドライバーには、現在の Wi-Fi SSID を取得するための ACCESS_WIFI_STATE 権限が必要です。</string>
     <string name="permissionsINTERNET">エンジン ドライバーには、現在の Wi-Fi SSID を取得するための INTERNET 権限が必要です。</string>
     <string name="permissionsAppSettingsButton">アプリの設定</string>
-
+    <string name="permissionsDeclineButton">衰退</string>
 
 
     <string name="permissionsConnectToServer">エンジン ドライバーには、最近の接続を保存するための STORAGE アクセス許可と、通話中に操作を一時停止するための PHONE アクセス許可が必要です。</string>

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -675,6 +675,7 @@
     <string name="permissionsConnectToServer">Engine Driver precisa de permissões STORAGE para armazenar conexões recentes e permissões PHONE para pausar operações quando em uma chamada.</string>
 <!--    <string name="permissionsGotoAppSettings">Por favor ative estas permissões nas configurações do aplicativo.</string>-->
     <string name="permissionsAppSettingsButton">Configurações do aplicativo</string>
+    <string name="permissionsDeclineButton">Declínio</string>
     <string name="permissionsRetryButton">Tente novamente</string>
     <string name="permissionsRequestTitle">Permissões</string>
     <string name="permissionsRetryTitle">Permissões recusadas</string>

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1200,6 +1200,7 @@
 
 <!--    <string name="permissionsGotoAppSettings">Please enable these permissions from the app settings.</string>-->
     <string name="permissionsAppSettingsButton">App settings</string>
+    <string name="permissionsDeclineButton">Decline</string>
     <string name="permissionsSystemSettingsButton">System settings</string>
     <string name="permissionsRetryButton">Retry</string>
     <string name="permissionsRequestTitle">Permissions</string>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,4 +1,6 @@
 **Version 2.40.198
+ * Tidy up of the AppIntro permissions
+ * Chnnge the location permission wanrnings to a toast message
 **Version 2.40.196
  * Only redraw Route list if actually changed
  * Avoid a few crashes reported to Play Store


### PR DESCRIPTION
- location permission denied only shows a toast message now on the connection screen
- AppIntro disables the "Phone call" permission on the last page if PHONE permission not granted  
- Fixed the "Write System" permissions page in AppIntro  (was using the wrong layout)