### PR TITLE
Added a new separate check for when the app is in background

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/SettingsActivity.java
@@ -89,6 +89,8 @@ import jmri.enginedriver.import_export.ImportExportPreferences;
 import jmri.enginedriver.util.LocaleHelper;
 
 public class SettingsActivity extends AppCompatActivity implements PreferenceFragmentCompat.OnPreferenceStartScreenCallback {
+    static final String activityName = "SettingsActivity";
+
     static public final int RESULT_GAMEPAD = RESULT_FIRST_USER;
     static public final int RESULT_ESUMCII = RESULT_GAMEPAD + 1;
     public static final int RESULT_LOAD_IMG = 1;
@@ -150,7 +152,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "Settings: onCreate()");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate()");
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.settings_activity);
@@ -191,7 +193,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     getApplicationContext().getResources().getString(R.string.app_name),
                     getApplicationContext().getResources().getString(R.string.app_name_preferences),
                     "");
-            Log.d("Engine_Driver", "Settings: Set toolbar");
+            Log.d(threaded_application.applicationName, activityName + ": onCreate(): Set toolbar");
         }
 
     } // end onCreate
@@ -199,7 +201,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     @Override
     public boolean onPreferenceStartScreen(PreferenceFragmentCompat preferenceFragmentCompat,
                                            PreferenceScreen preferenceScreen) {
-        Log.d("Engine_Driver", "callback called to attach the preference sub screen");
+        Log.d(threaded_application.applicationName, activityName + ": onPreferenceStartScreen(): callback called to attach the preference sub screen");
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         SettingsSubScreenFragment fragment = SettingsSubScreenFragment.newInstance("Advanced Settings Subscreen");
         Bundle args = new Bundle();
@@ -215,16 +217,23 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     protected void onResume() {
-        Log.d("Engine_Driver", "Settings: onResume()");
+        Log.d(threaded_application.applicationName, activityName + ": onResume()");
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.SETTINGS;
 
-        Log.d("Engine_Driver", "settings.onResume() called");
 //        try {
 //            dismissDialog(PROGRESS_BAR_TYPE);
 //        } catch (Exception e) {
-//            Log.d("Engine_Driver", "settings.onResume() no dialog to kill");
+//            Log.d(threaded_application.applicationName, activityName + ": onResume() no dialog to kill");
 //        }
 
         if (mainapp.isForcingFinish()) {     //expedite
@@ -254,7 +263,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     getApplicationContext().getResources().getString(R.string.app_name),
                     getApplicationContext().getResources().getString(R.string.app_name_preferences),
                     "");
-            Log.d("Engine_Driver", "Settings: Set toolbar");
+            Log.d(threaded_application.applicationName, activityName + ": onResume(): Set toolbar");
         }
 
         // save some values
@@ -264,19 +273,19 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
 //    @Override
 //    protected void onStart() {
-//        Log.d("Engine_Driver", "Settings: onStart()");
+//        Log.d(threaded_application.applicationName, activityName + ": onStart()");
 //        super.onStart();
 //    }
 
     @Override
     protected void onDestroy() {
-        Log.d("Engine_Driver", "settings.onDestroy() called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy()");
         super.onDestroy();
         if (mainapp.settings_msg_handler !=null) {
             mainapp.settings_msg_handler.removeCallbacksAndMessages(null);
             mainapp.settings_msg_handler = null;
         } else {
-            Log.d("Engine_Driver", "Preferences: onDestroy: mainapp.settings_msg_handler is null. Unable to removeCallbacksAndMessages");
+            Log.d(threaded_application.applicationName, activityName + ": onDestroy(): mainapp.settings_msg_handler is null. Unable to removeCallbacksAndMessages");
         }
         if (forceRestartAppOnPreferencesClose) {
             forceRestartApp(forceRestartAppOnPreferencesCloseReason);
@@ -288,7 +297,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void forceRestartApp(int forcedRestartReason) {
-        Log.d("Engine_Driver", "Settings: forceRestartApp() - forcedRestartReason: " + forcedRestartReason);
+        Log.d(threaded_application.applicationName, activityName + ": forceRestartApp() - forcedRestartReason: " + forcedRestartReason);
 
         String prefAutoImportExport = prefs.getString("prefAutoImportExport", getApplicationContext().getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
@@ -298,7 +307,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 writeSharedPreferencesToFile(prefs, exportedPreferencesFileName, false);
             }
         }
-        finish();
+        this.finish();
         connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
         Message msg = Message.obtain();
         msg.what = message_type.RESTART_APP;
@@ -308,9 +317,9 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void forceReLaunchApp(int forcedRestartReason) {
-        Log.d("Engine_Driver", "Settings: forceRelaunchApp() ");
+        Log.d(threaded_application.applicationName, activityName + ": forceRelaunchApp() ");
 
-        finish();
+        this.finish();
         connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
         Message msg = Message.obtain();
         msg.what = message_type.RELAUNCH_APP;
@@ -333,20 +342,20 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 startActivity(in);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             } catch (Exception ex) {
-                Log.d("Engine_Driver", "Settings: " + ex.getMessage());
+                Log.d(threaded_application.applicationName, activityName + ": start_gamepad_test_activity(): Settings: " + ex.getMessage());
             }
         }
     }
 
     public void reload() {
         // restart the activity so all the preferences show correctly based on what was imported / hidden
-        Log.d("Engine_Driver", "Settings: Forcing activity to recreate");
+        Log.d(threaded_application.applicationName, activityName + ": reload(): Forcing activity to recreate");
         recreate();
     }
 
     @SuppressLint("ApplySharedPref")
     private void writeSharedPreferencesToFile(SharedPreferences sharedPreferences, String exportedPreferencesFileName, boolean confirmDialog) {
-        Log.d("Engine_Driver", "Settings: Saving preferences to file");
+//        Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile(): Saving preferences to file");
         sharedPreferences.edit().putString("prefImportExport", import_export_option_type.NONE).commit();  //reset the preference
         if (!exportedPreferencesFileName.equals(".ed")) {
             File dst = new File(context.getExternalFilesDir(null), exportedPreferencesFileName);
@@ -389,7 +398,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void fixAndReloadImportExportPreference(SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "Settings: Fix and Loading saved preferences.");
+        Log.d(threaded_application.applicationName, activityName + ": fixAndReloadImportExportPreference()");
         sharedPreferences.edit().putString("prefImportExport", import_export_option_type.NONE).commit();  //reset the preference
         sharedPreferences.edit().putString("prefHostImportExport", import_export_option_type.NONE).commit();  //reset the preference
         reload();
@@ -423,7 +432,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void loadSharedPreferencesFromFile(SharedPreferences sharedPreferences, String exportedPreferencesFileName, String deviceId, int forceRestartReason) {
-        Log.d("Engine_Driver", "Settings: Loading saved preferences from file: " + exportedPreferencesFileName);
+        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): " + exportedPreferencesFileName);
         boolean result = importExportPreferences.loadSharedPreferencesFromFile(mainapp.getApplicationContext(), sharedPreferences, exportedPreferencesFileName, deviceId, false);
 
         if (!result) {
@@ -436,7 +445,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void resetPreferencesDialog() {
-        Log.d("Engine_Driver", "Settings: Resetting preferences");
+        Log.d(threaded_application.applicationName, activityName + ": resetPreferencesDialog()");
 
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             //@Override
@@ -467,7 +476,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         SharedPreferences.Editor prefEdit = prefs.edit();
         prefEdit.clear();
         prefEdit.commit();
-        Log.d("Engine_Driver", "Settings: Reset succeeded");
+        Log.d(threaded_application.applicationName, activityName + ": resetPreferences(): Reset succeeded");
         delete_settings_file("function_settings.txt");
         delete_settings_file("connections_list.txt");
         delete_settings_file("recent_engine_list.txt");
@@ -502,9 +511,9 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
             File settings_file = new File(context.getExternalFilesDir(null), file_name);
             if (settings_file.exists()) {
                 if (settings_file.delete()) {
-                    Log.d("Engine_Driver", "Settings: " + file_name + " deleted");
+                    Log.d(threaded_application.applicationName, activityName + ": delete_settings_file(): Settings: " + file_name + " deleted");
                 } else {
-                    Log.e("Engine_Driver", "Settings: " + file_name + " NOT deleted");
+                    Log.e(threaded_application.applicationName, activityName + ": delete_settings_file(): Settings: " + file_name + " NOT deleted");
                 }
             }
         }
@@ -541,11 +550,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                     }
                     break;
                 case message_type.IMPORT_SERVER_MANUAL_SUCCESS:
-                    Log.d("Engine_Driver", "Settings: Message: Import preferences from Server: File Found");
+                    Log.d(threaded_application.applicationName, activityName + ": handleMessage(): Settings: Message: Import preferences from Server: File Found");
                     loadSharedPreferencesFromFile(prefs, EXTERNAL_URL_PREFERENCES_IMPORT, deviceId, restart_reason_type.IMPORT_SERVER_MANUAL);
                     break;
                 case message_type.IMPORT_SERVER_MANUAL_FAIL:
-                    Log.d("Engine_Driver", "Settings: Message: Import preferences from Server: File not Found");
+                    Log.d(threaded_application.applicationName, activityName + ": handleMessage(): Settings: Message: Import preferences from Server: File not Found");
                     prefs.edit().putString("prefImportExport", import_export_option_type.NONE).commit();  //reset the preference
                     prefs.edit().putString("prefHostImportExport", import_export_option_type.NONE).commit();  //reset the preference
 //                    Toast.makeText(getApplicationContext(),
@@ -559,7 +568,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
                 case message_type.REOPEN_THROTTLE:
                     if (threaded_application.currentActivity == activity_id_type.SETTINGS)
-                        finish();  //end this activity
+                        endThisActivity();
                     break;
 
             }
@@ -597,14 +606,14 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 //        @SuppressLint("ApplySharedPref")
 //        @Override
 //        protected String doInBackground(String... f_url) {
-//            Log.d("Engine_Driver", "Settings: Import preferences from Server: start");
+//            Log.d(threaded_application.applicationName, activityName + ": importFromURL(): Import preferences from Server: start");
 //            int count;
 //            String n_url = f_url[0].trim();
 //
 //            if ((mainapp.connectedHostip != null)) {
 //                n_url = "http://" + mainapp.connectedHostip + ":" + mainapp.web_server_port + "/" + SERVER_ENGINE_DRIVER_DIR + "/" + f_url[0];
 //            } else {
-//                Log.d("Engine_Driver", "Settings: Import preferences from Server: Not currently connected");
+//                Log.d(threaded_application.applicationName, activityName + ": importFromURL(): Import preferences from Server: Not currently connected");
 //                return null;
 //            }
 //
@@ -655,7 +664,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 //                mainapp.sendMsgDelay(mainapp.settings_msg_handler, 1000L, message_type.IMPORT_SERVER_MANUAL_SUCCESS);
 //
 //            } catch (Exception e) {
-//                Log.e("Engine_Driver", "Settings: Import preferences from Server Failed: " + e.getMessage());
+//                Log.e(threaded_application.applicationName, activityName + ": importFromURL(): Import preferences from Server Failed: " + e.getMessage());
 //                try {
 //                    dismissDialog(PROGRESS_BAR_TYPE);
 //                } catch (Exception ignored) {
@@ -664,7 +673,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 //                mainapp.sendMsgDelay(mainapp.settings_msg_handler, 1000L, message_type.IMPORT_SERVER_MANUAL_FAIL);
 //            }
 //
-//            Log.d("Engine_Driver", "Settings: Import preferences from Server: End");
+//            Log.d(threaded_application.applicationName, activityName + ": importFromURL(): Import preferences from Server: End");
 //            return null;
 //        }
 //
@@ -695,18 +704,23 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     public boolean onKeyDown(int key, KeyEvent event) {
         mainapp.exitDoubleBackButtonInitiated = 0;
         if ((key == KeyEvent.KEYCODE_BACK) && (!isInSubScreen) ) {
-            setResult(result);
-            finish();  //end this activity
-            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            endThisActivity();
             return true;
         }
         isInSubScreen = false;
         return (super.onKeyDown(key, event));
     }
 
+    void endThisActivity() {
+        threaded_application.activityInTransition(activityName);
+        setResult(result);
+        this.finish();  //end this activity
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+    }
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        Log.d("Engine_Driver", "Settings: onCreateOptionsMenu()");
+        Log.d(threaded_application.applicationName, activityName + ": onCreateOptionsMenu()");
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.settings_menu, menu);
         SAMenu = menu;
@@ -746,7 +760,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     @SuppressLint("ApplySharedPref")
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.d("Engine_Driver", "Settings: onActivityResult()");
+        Log.d(threaded_application.applicationName, activityName + ": onActivityResult()");
         super.onActivityResult(requestCode, resultCode, data);
         try {
             // When an Image is picked
@@ -777,14 +791,14 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 threaded_application.safeToast(R.string.prefBackgroundImageFileNameNoImageSelected, Toast.LENGTH_LONG);
             }
         } catch (Exception e) {
-            Log.e("Engine_Driver", "Settings: Loading background image Failed: " + e.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": onActivityResult(): Loading background image Failed: " + e.getMessage());
         }
 
     }
 
     @SuppressLint("ApplySharedPref")
     protected void limitIntPrefValue(PreferenceScreen prefScreen, SharedPreferences sharedPreferences, String key, int minVal, int maxVal, String defaultVal) {
-        Log.d("Engine_Driver", "Settings: limitIntPrefValue()");
+        Log.d(threaded_application.applicationName, activityName + ": limitIntPrefValue()");
         EditTextPreference prefText = (EditTextPreference) prefScreen.findPreference(key);
         try {
             int newVal = Integer.parseInt(sharedPreferences.getString(key, defaultVal).trim());
@@ -813,7 +827,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     /** @noinspection SameParameterValue, SameParameterValue */
     @SuppressLint("ApplySharedPref")
     protected void limitIntArrayPrefValue(PreferenceScreen prefScreen, SharedPreferences sharedPreferences, String key, int minVal, int maxVal, String defaultVal) {
-        Log.d("Engine_Driver", "Settings: limitIntArraryPrefValue()");
+        Log.d(threaded_application.applicationName, activityName + ": limitIntArraryPrefValue()");
 
         String prefValue = sharedPreferences.getString(key, defaultVal).trim();
         String[] prefValues = threaded_application.splitByString(prefValue, " ");
@@ -860,7 +874,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     /** @noinspection SameParameterValue, SameParameterValue , SameParameterValue */
     @SuppressLint("ApplySharedPref")
     protected void limitFloatPrefValue(PreferenceScreen prefScreen, SharedPreferences sharedPreferences, String key, Float minVal, Float maxVal, String defaultVal) {
-        Log.d("Engine_Driver", "Settings: limitFloatPrefValue()");
+        Log.d(threaded_application.applicationName, activityName + ": limitFloatPrefValue()");
         EditTextPreference prefText = (EditTextPreference) prefScreen.findPreference(key);
         try {
             float newVal = Float.parseFloat(sharedPreferences.getString(key, defaultVal).trim());
@@ -888,7 +902,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void checkThrottleScreenType(SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "Settings: checkThrottleScreenType()");
+        Log.d(threaded_application.applicationName, activityName + ": checkThrottleScreenType()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
         if (prefThrottleScreenType.contains(throttle_screen_type.CONTAINS_SEMI_REALISTIC)) {
@@ -909,7 +923,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     @SuppressLint("ApplySharedPref")
     public void limitNumThrottles(PreferenceScreen prefScreen, SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "Settings: limitNumThrottles()");
+        Log.d(threaded_application.applicationName, activityName + ": limitNumThrottles()");
         int numThrottles = mainapp.Numeralise(sharedPreferences.getString("NumThrottle", getResources().getString(R.string.NumThrottleDefaultValue)));
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
@@ -922,7 +936,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         if ( ((fixed[index] == 1) && (numThrottles != max[index]))
                 || ((fixed[index] == 0) && (numThrottles > max[index])) ) {
-            Log.d("Engine_Driver", "Settings: limitNumThrottles: numThrottles " +  numThrottles + " fixed " + fixed[index] + " max " + max[index]);
+            Log.d(threaded_application.applicationName, activityName + ": limitNumThrottles: numThrottles " +  numThrottles + " fixed " + fixed[index] + " max " + max[index]);
 
             sharedPreferences.edit().putString("NumThrottle", textNumbers[max[index]-1]).commit();
             if (numThrottles > max[index]-1) { // only display the warning if the requested amount is lower than the max or fixed.
@@ -933,7 +947,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
             ListPreference p = (ListPreference) prefScreen.findPreference("NumThrottle");
             if (p != null) {
                 ignoreThisThrottleNumChange = true;
-                Log.d("Engine_Driver", "Settings: limitNumThrottles: textNumbers[max[index]-1]: " +  textNumbers[max[index]-1] + " index: " + index);
+                Log.d(threaded_application.applicationName, activityName + ": limitNumThrottles: textNumbers[max[index]-1]: " +  textNumbers[max[index]-1] + " index: " + index);
                 p.setValue(textNumbers[max[index]-1]);
                 p.setValueIndex(max[index]-1);
             }
@@ -990,7 +1004,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 for (int x = 0; x < childCount; x++) {
                     RadioButton btn = (RadioButton) group.getChildAt(x);
                     if (btn.getId() == checkedId) {
-                        Log.e("selected RadioButton->",btn.getText().toString());
+                        Log.e(threaded_application.applicationName, activityName + ": selected RadioButton-> " + btn.getText().toString());
                         setSharedPreferenceValueString(prefScreen, "NumThrottle", entryValueList.get(x));
                     }
                 }
@@ -1001,7 +1015,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     boolean throttleScreenTypeSupportsWebView(SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "Settings: throttleScreenTypeSupportsWebView()");
+        Log.d(threaded_application.applicationName, activityName + ": throttleScreenTypeSupportsWebView()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         boolean supportsWebView = false;
 
@@ -1017,7 +1031,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     int getThrottleScreenTypeArrayIndex(SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "Settings: getThrottleScreenTypeArrayIndex()");
+        Log.d(threaded_application.applicationName, activityName + ": getThrottleScreenTypeArrayIndex()");
         prefThrottleScreenType = sharedPreferences.getString("prefThrottleScreenType", getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
 
         int index = -1;
@@ -1104,13 +1118,13 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void enableDisablePreference(PreferenceScreen prefScreen, String key, boolean enable) {
-//        Log.d("Engine_Driver", "Settings: enableDisablePreference(): key: " + key);
+//        Log.d(threaded_application.applicationName, activityName + ": enableDisablePreference(): key: " + key);
         Preference p = prefScreen.findPreference(key);
         if (p != null) {
             p.setSelectable(enable);
             p.setEnabled(enable);
         } else {
-            Log.w("Engine_Driver", "Preference key '" + key + "' not found, not set to " + enable);
+            Log.w(threaded_application.applicationName, activityName + ": enableDisablePreference(): Preference key '" + key + "' not found, not set to " + enable);
         }
     }
 
@@ -1200,7 +1214,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     }
 
     private void showHideThrottleSwitchPreferences(PreferenceScreen prefScreen) {
-        Log.d("Engine_Driver", "Settings: showHideThrottleSwitchPreferences()");
+        Log.d(threaded_application.applicationName, activityName + ": showHideThrottleSwitchPreferences()");
         prefThrottleScreenType = prefs.getString("prefThrottleScreenType",
                 getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
         boolean enable = prefThrottleScreenType.equals(throttle_screen_type.SIMPLE);
@@ -1270,11 +1284,11 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 }
                 list_reader.close();
             } else {
-                Log.d("settingActivity", "getConnectionsList: Recent connections not found");
+                Log.d(threaded_application.applicationName, activityName + ": getConnectionsList(): Recent connections not found");
             }
         } catch (IOException except) {
             errMsg = except.getMessage();
-            Log.e("Engine_Driver", "Settings: Error reading recent connections list: " + errMsg);
+            Log.e(threaded_application.applicationName, activityName + ": getConnectionsList(): Error reading recent connections list: " + errMsg);
 //            Toast.makeText(getApplicationContext(), R.string.prefImportExportErrorReadingList + " " + errMsg, Toast.LENGTH_SHORT).show();
             threaded_application.safeToast(getApplicationContext().getResources().getString(R.string.prefImportExportErrorReadingList) + " " + errMsg, Toast.LENGTH_SHORT);
         }
@@ -1338,7 +1352,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-            Log.d("Engine_Driver", "Settings: SettingsFragment onCreatePreferences()");
+            Log.d(threaded_application.applicationName, activityName + ": onCreatePreferences()");
                 setPreferencesFromResource(R.xml.preferences, rootKey);
 
             Activity a = getActivity();
@@ -1351,8 +1365,10 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @Override
         public void onResume() {
-            Log.d("Engine_Driver", "Settings: SettingsFragment onResume()");
+            Log.d(threaded_application.applicationName, activityName + ": SettingsFragment onResume()");
             super.onResume();
+            threaded_application.activityResumed(activityName);
+
             threaded_application.currentActivity = activity_id_type.SETTINGS;
 
             getPreferenceScreen().getSharedPreferences()
@@ -1371,6 +1387,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         @Override
         public void onPause() {
             super.onPause();
+            threaded_application.activityPaused(activityName);
 
             getPreferenceScreen().getSharedPreferences()
                     .unregisterOnSharedPreferenceChangeListener(this);
@@ -1378,7 +1395,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @SuppressLint("ApplySharedPref")
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            Log.d("Engine_Driver", "Settings: onSharedPreferenceChanged(): key: " + key);
+            Log.d(threaded_application.applicationName, activityName + ": onSharedPreferenceChanged(): key: " + key);
             boolean prefForcedRestart = sharedPreferences.getBoolean("prefForcedRestart", false);
 
             if (!prefForcedRestart) {  // don't do anything if the preference have been loaded and we are about to reload the app.
@@ -1522,7 +1539,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @SuppressLint("ApplySharedPref")
         void setPreferencesUI() {
-            Log.d("Engine_Driver", "Settings: setPreferencesUI()");
+            Log.d(threaded_application.applicationName, activityName + ": setPreferencesUI()");
             prefs = parentActivity.prefs;
             defaultName = parentActivity.getApplicationContext().getResources().getString(R.string.prefThrottleNameDefaultValue);
 
@@ -1654,7 +1671,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 //        }
 
         private void showHideThrottleNumberPreference(SharedPreferences sharedPreferences) {
-            Log.d("Engine_Driver", "Settings: showHideThrottleNumberPreference()");
+            Log.d(threaded_application.applicationName, activityName + ": showHideThrottleNumberPreference()");
             boolean enable = true;
             parentActivity.prefThrottleScreenType = prefs.getString("prefThrottleScreenType", parentActivity.getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));
             int index = parentActivity.getThrottleScreenTypeArrayIndex(sharedPreferences);
@@ -1668,7 +1685,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         }
 
         private void showHideThrottleWebViewPreferences(SharedPreferences sharedPreferences) {
-            Log.d("Engine_Driver", "Settings: showHideThrottleWebViewPreferences()");
+            Log.d(threaded_application.applicationName, activityName + ": showHideThrottleWebViewPreferences()");
             boolean enable = parentActivity.throttleScreenTypeSupportsWebView(sharedPreferences);
             parentActivity.enableDisablePreference(getPreferenceScreen(), "throttle_webview_preference", enable);
             parentActivity.enableDisablePreference(getPreferenceScreen(), "prefWebViewButton", enable);
@@ -1696,7 +1713,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
 
         private void showHideThrottleTypePreferences() {
-            Log.d("Engine_Driver", "Settings: showHideThrottleTypePreferences()");
+            Log.d(threaded_application.applicationName, activityName + ": showHideThrottleTypePreferences()");
             boolean enable = (!parentActivity.prefThrottleScreenType.equals(throttle_screen_type.SIMPLE)) && (!parentActivity.prefThrottleScreenType.equals(throttle_screen_type.VERTICAL))
                     && (!parentActivity.prefThrottleScreenType.equals(throttle_screen_type.VERTICAL_LEFT)) && (!parentActivity.prefThrottleScreenType.equals(throttle_screen_type.VERTICAL_RIGHT))
                     && (!parentActivity.prefThrottleScreenType.equals(throttle_screen_type.SWITCHING))
@@ -1747,19 +1764,19 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 else //Doesn't have a parent
                     getPreferenceScreen().removePreference(preference);
             } catch (Exception except) {
-                Log.d("Engine_Driver", "Settings: removePreference: failed: " + preference);
+                Log.d(threaded_application.applicationName, activityName + ": removePreference(): failed: " + preference);
             }
         }
 
         private void hideAdvancedPreferences() {
             if (!prefs.getBoolean("prefShowAdvancedPreferences", parentActivity.getApplicationContext().getResources().getBoolean(R.bool.prefShowAdvancedPreferencesDefaultValue) ) ) {
                 for (String advancedPreference1 : advancedPreferences) {
-// //                Log.d("Engine_Driver", "Settings: hideAdvancedPreferences(): " + advancedPreference1);
+// //                Log.d(threaded_application.applicationName, activityName + ": hideAdvancedPreferences(): " + advancedPreference1);
                     Preference advancedPreference = findPreference(advancedPreference1);
                     if (advancedPreference != null) {
                         removePreference(advancedPreference);
                     } else {
-                        Log.d("Engine_Driver", "Settings: '" + advancedPreference1 + "' not found.");
+                        Log.d(threaded_application.applicationName, activityName + ": hideAdvancedPreferences(): '" + advancedPreference1 + "' not found.");
                     }
                 }
             }
@@ -1811,7 +1828,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
             // rootKey is the name of preference sub screen key name , here--customPrefKey
             setPreferencesFromResource(R.xml.preferences, rootKey);
-            Log.d(TAG, "onCreatePreferences of the sub screen " + rootKey);
+            Log.d(threaded_application.applicationName, activityName + ": onCreatePreferences(): of the sub screen " + rootKey);
 
             Activity a = getActivity();
             parentActivity = (SettingsActivity) a;
@@ -1863,8 +1880,10 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
         @Override
         public void onResume() {
-            Log.d("Engine_Driver", "Settings: SettingsFragment onResume()");
+            Log.d(threaded_application.applicationName, activityName + ": SettingsFragment onResume()");
             super.onResume();
+            threaded_application.activityResumed(activityName);
+
             threaded_application.currentActivity = activity_id_type.SETTINGS;
 
             getPreferenceScreen().getSharedPreferences()
@@ -1879,6 +1898,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         @Override
         public void onPause() {
             super.onPause();
+            threaded_application.activityPaused(activityName);
 
             getPreferenceScreen().getSharedPreferences()
                     .unregisterOnSharedPreferenceChangeListener(this);
@@ -1920,26 +1940,26 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
                 else //Doesn't have a parent
                     getPreferenceScreen().removePreference(preference);
             } catch (Exception except) {
-                Log.d("Engine_Driver", "Settings: removeSubPreference: failed: " + preference);
+                Log.d(threaded_application.applicationName, activityName + ": removeSubPreference: failed: " + preference);
             }
         }
 
         private void hideAdvancedSubPreferences() {
             if (!parentActivity.prefs.getBoolean("prefShowAdvancedPreferences", parentActivity.getApplicationContext().getResources().getBoolean(R.bool.prefShowAdvancedPreferencesDefaultValue) ) ) {
                 for (String advancedSubPreference1 : advancedSubPreferences) {
-// //                Log.d("Engine_Driver", "Settings: hideAdvancedPreferences(): " + advancedPreference1);
+// //                Log.d(threaded_application.applicationName, activityName + ": hideAdvancedPreferences(): " + advancedPreference1);
                     Preference advancedSubPreference = findPreference(advancedSubPreference1);
                     if (advancedSubPreference != null) {
                         removeSubPreference(advancedSubPreference);
                     } else {
-                        Log.d("Engine_Driver", "Settings: '" + advancedSubPreference1 + "' not found.");
+                        Log.d(threaded_application.applicationName, activityName + ": hideAdvancedSubPreferences(): '" + advancedSubPreference1 + "' not found.");
                     }
                 }
             }
         }
 
         private void showHideLeftRightSwipePreferences() {
-            Log.d("Engine_Driver", "Settings: showHideLeftRightSwipePreferences()");
+            Log.d(threaded_application.applicationName, activityName + ": showHideLeftRightSwipePreferences()");
             boolean enable = parentActivity.prefs.getBoolean("prefLeftRightSwipeChangesSpeed",
                     getResources().getBoolean(R.bool.prefLeftRightSwipeChangesSpeedDefaultValue));
             parentActivity.enableDisablePreference(getPreferenceScreen(), "prefFullScreenSwipeArea", !enable);

--- a/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/about_page.java
@@ -41,6 +41,7 @@ import jmri.enginedriver.type.activity_id_type;
 import jmri.enginedriver.type.message_type;
 
 public class about_page extends AppCompatActivity {
+    static final String activityName = "about_page";
 
     private threaded_application mainapp; // hold pointer to mainapp
     private Menu AMenu;
@@ -90,8 +91,16 @@ public class about_page extends AppCompatActivity {
     } //end onCreate
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.ABOUT;
         if (mainapp.isForcingFinish()) {        //expedite
             this.finish();
@@ -151,11 +160,16 @@ public class about_page extends AppCompatActivity {
     public boolean onKeyDown(int key, KeyEvent event) {
         mainapp.exitDoubleBackButtonInitiated = 0;
         if (key == KeyEvent.KEYCODE_BACK) {
-            this.finish();  //end this activity
-            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            endThisActivity();
             return true;
         }
         return (super.onKeyDown(key, event));
+    }
+
+    void endThisActivity() {
+        threaded_application.activityInTransition(activityName);
+        this.finish();  //end this activity
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
     }
 
     @SuppressLint("HandlerLeak")
@@ -181,7 +195,7 @@ public class about_page extends AppCompatActivity {
 
                 case message_type.REOPEN_THROTTLE:
                     if (threaded_application.currentActivity == activity_id_type.ABOUT)
-                        finish();  //end this activity
+                        endThisActivity();
                     break;
 
                 default:
@@ -193,7 +207,7 @@ public class about_page extends AppCompatActivity {
     public class CloseButtonListener implements View.OnClickListener {
         public void onClick(View v) {
             mainapp.buttonVibration();
-            finish();
+            endThisActivity();
         }
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/comm_handler.java
@@ -39,6 +39,8 @@ import jmri.enginedriver.threaded_application;
 import jmri.enginedriver.type.dccex_protocol_option_type;
 
 public class comm_handler extends Handler {
+   static final String activityName = "comm_handler";
+
    //All of the work of the communications thread is initiated from this function.
 
    private boolean initialised = false;
@@ -65,7 +67,7 @@ public class comm_handler extends Handler {
 
    @SuppressLint({"DefaultLocale", "ApplySharedPref", "WebViewApiAvailability"})
    public void handleMessage(Message msg) {
-//                Log.d("Engine_Driver", "comm_handler.handleMessage: message: " +msg.what);
+//                Log.d(threaded_application.applicationName, activityName + ": handleMessage(): message: " +msg.what);
       if (!initialised) return;
 
       switch (msg.what) {
@@ -76,21 +78,21 @@ public class comm_handler extends Handler {
          case message_type.SET_LISTENER:
             if (mainapp.client_ssid != null &&
                     mainapp.client_ssid.matches("DCCEX_[0-9a-fA-F]{6}$")) {
-               Log.d("Engine_Driver", "comm_handler.handleMessage: DCCEX SSID found");
+               Log.d(threaded_application.applicationName, activityName + ": handleMessage(): DCCEX SSID found");
                //add "fake" discovered server entry for DCCEX: DCCEX_123abc
                commThread.addFakeDiscoveredServer(mainapp.client_ssid, mainapp.client_address, "2560", "DCC-EX");
                mainapp.isDCCEX = (mainapp.prefUseDccexProtocol.equals(dccex_protocol_option_type.YES))
                        || (mainapp.prefUseDccexProtocol.equals(dccex_protocol_option_type.AUTO));
             } else if (mainapp.client_ssid != null &&
                     mainapp.client_ssid.matches("^Dtx[0-9]{1,2}-.*_[0-9,A-F]{4}-[0-9]{1,3}$")) {
-               Log.d("Engine_Driver", "comm_handler.handleMessage: LnWi SSID found");
+               Log.d(threaded_application.applicationName, activityName + ": handleMessage(): LnWi SSID found");
                //add "fake" discovered server entry for Digitrax LnWi: Dtx1-LnServer_0009-7
                commThread.addFakeDiscoveredServer(mainapp.client_ssid, mainapp.client_address, "12090", "LnWi");
             } else {
                if (mainapp.client_ssid == null)
-                  Log.d("Engine_Driver", "comm_handler.handleMessage: SSID is Null!");
+                  Log.d(threaded_application.applicationName, activityName + ": handleMessage(): SSID is Null!");
                else
-                  Log.d("Engine_Driver", "comm_handler.handleMessage: SSID: " + mainapp.client_ssid);
+                  Log.d(threaded_application.applicationName, activityName + ": handleMessage(): SSID: " + mainapp.client_ssid);
 
                //arg1= 1 to turn on, arg1=0 to turn off
                if (msg.arg1 == 0) {
@@ -107,16 +109,16 @@ public class comm_handler extends Handler {
                            commThread.multicast_lock.acquire();
                         } catch (Exception e) {
                            //log message, but keep going if this fails
-                           Log.d("Engine_Driver", "comm_handler.handleMessage: multicast_lock.acquire() failed");
+                           Log.d(threaded_application.applicationName, activityName + ": handleMessage(): multicast_lock.acquire() failed");
                         }
                         commThread.jmdns.addServiceListener(mainapp.JMDNS_SERVICE_WITHROTTLE, commThread.listener);
                         commThread.jmdns.addServiceListener(mainapp.JMDNS_SERVICE_JMRI_DCCPP_OVERTCP, commThread.listener);
-                        Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns listener added");
+                        Log.d(threaded_application.applicationName, activityName + ": handleMessage(): jmdns listener added");
                      } else {
-                        Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns not running, didn't start listener");
+                        Log.d(threaded_application.applicationName, activityName + ": handleMessage(): jmdns not running, didn't start listener");
                      }
                   } else {
-                     Log.d("Engine_Driver", "comm_handler.handleMessage: jmdns already running");
+                     Log.d(threaded_application.applicationName, activityName + ": handleMessage(): jmdns already running");
                   }
                }
             }
@@ -133,7 +135,7 @@ public class comm_handler extends Handler {
             //avoid duplicate connects, seen when user clicks address multiple times quickly
             if (comm_thread.socketWiT != null && comm_thread.socketWiT.SocketGood()
                     && new_host_ip.equals(mainapp.host_ip) && new_port == mainapp.port) {
-               Log.d("Engine_Driver", "comm_handler.handleMessage: Duplicate CONNECT message received.");
+               Log.d(threaded_application.applicationName, activityName + ": handleMessage(): Duplicate CONNECT message received.");
                break;
             }
 
@@ -235,9 +237,9 @@ public class comm_handler extends Handler {
 
          //Disconnect from the WiThrottle server and Shutdown
          case message_type.DISCONNECT: {
-            Log.d("Engine_Driver", "comm_handler.handleMessage: TA Disconnect");
+            Log.d(threaded_application.applicationName, activityName + ": handleMessage(): TA Disconnect");
             mainapp.doFinish = true;
-            Log.d("Engine_Driver", "comm_handler.handleMessage: TA alert all activities to shutdown");
+            Log.d(threaded_application.applicationName, activityName + ": handleMessage(): TA alert all activities to shutdown");
             mainapp.alert_activities(message_type.SHUTDOWN, "");     //tell all activities to finish()
             commThread.stoppingConnection();
 
@@ -547,7 +549,7 @@ public class comm_handler extends Handler {
             mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.KIDS_TIMER_TICK, "", msg.arg1);
             break;
          case message_type.IMPORT_SERVER_AUTO_AVAILABLE:
-            Log.d("Engine_Driver", "comm_handler.handleMessage: message: AUTO_IMPORT_URL_AVAILABLE " + msg.what);
+            Log.d(threaded_application.applicationName, activityName + ": handleMessage(): message: AUTO_IMPORT_URL_AVAILABLE " + msg.what);
             mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.IMPORT_SERVER_AUTO_AVAILABLE, "", 0);
             break;
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/dcc_ex.java
@@ -62,6 +62,7 @@ import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.util.LocaleHelper;
 
 public class dcc_ex extends AppCompatActivity {
+    static final String activityName = "dcc_ex";
 
     private threaded_application mainapp;  // hold pointer to mainapp
     private Menu menu;
@@ -236,7 +237,7 @@ public class dcc_ex extends AppCompatActivity {
 
                 case message_type.REOPEN_THROTTLE:
                     if (threaded_application.currentActivity == activity_id_type.DCC_EX)
-                        finish();  //end this activity
+                        endThisActivity();
                     break;
 
                 case message_type.WIT_CON_RETRY:
@@ -249,7 +250,7 @@ public class dcc_ex extends AppCompatActivity {
                 case message_type.RELAUNCH_APP:
                 case message_type.DISCONNECT:
                 case message_type.SHUTDOWN:
-                    disconnect();
+                    shutdown();
                     break;
                 case message_type.RESPONSE:    //handle messages from WiThrottle server
                     String s = msg.obj.toString();
@@ -998,8 +999,16 @@ public class dcc_ex extends AppCompatActivity {
     // ************************************************************************************************************* //
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.DCC_EX;
         if (mainapp.isForcingFinish()) { //expedite
             this.finish();
@@ -1034,7 +1043,7 @@ public class dcc_ex extends AppCompatActivity {
             mainapp.dcc_ex_msg_handler.removeCallbacksAndMessages(null);
             mainapp.dcc_ex_msg_handler = null;
         } else {
-            Log.d("Engine_Driver", "onDestroy: mainapp.dcc_ex_msg_handler is null. Unable to removeCallbacksAndMessages");
+            Log.d(threaded_application.applicationName, activityName + ": onDestroy(): mainapp.dcc_ex_msg_handler is null. Unable to removeCallbacksAndMessages");
         }
     }
 
@@ -1057,15 +1066,20 @@ public class dcc_ex extends AppCompatActivity {
     public boolean onKeyDown(int key, KeyEvent event) {
         mainapp.exitDoubleBackButtonInitiated = 0;
         if (key == KeyEvent.KEYCODE_BACK) {
-            mainapp.dccexScreenIsOpen = false;
-            this.finish();  //end this activity
-            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            endThisActivity();
             return true;
         }
         return (super.onKeyDown(key, event));
     }
 
-    private void disconnect() {
+    void endThisActivity() {
+        threaded_application.activityInTransition(activityName);
+        mainapp.dccexScreenIsOpen = false;
+        this.finish();  //end this activity
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+    }
+
+    private void shutdown() {
         this.finish();
     }
 
@@ -1077,7 +1091,7 @@ public class dcc_ex extends AppCompatActivity {
     public class CloseButtonListener implements View.OnClickListener {
         public void onClick(View v) {
             mainapp.buttonVibration();
-            finish();
+            endThisActivity();
         }
     }
 
@@ -1149,7 +1163,7 @@ public class dcc_ex extends AppCompatActivity {
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             if ((imm != null) && (view != null)) {
-                imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
+                mainapp.hideSoftKeyboard(view);
             }
 
             refreshDccexView();
@@ -1183,7 +1197,7 @@ public class dcc_ex extends AppCompatActivity {
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             if ((imm != null) && (view != null)) {
-                imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
+                mainapp.hideSoftKeyboard(view);
             }
 
             refreshDccexView();
@@ -1210,7 +1224,7 @@ public class dcc_ex extends AppCompatActivity {
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             if ((imm != null) && (view != null)) {
-                imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the softkeyboard to close
+                mainapp.hideSoftKeyboard(view);
             }
 
             dccCvsIndex = 0;
@@ -1256,7 +1270,7 @@ public class dcc_ex extends AppCompatActivity {
             InputMethodManager imm =
                     (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
             if ((imm != null) && (view != null)) {
-                imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS); // force the soft keyboard to close
+                mainapp.hideSoftKeyboard(view);
             }
 
             refreshDccexView();
@@ -1318,7 +1332,7 @@ public class dcc_ex extends AppCompatActivity {
                         + "</p>" + dccexResponsesStr;
 
             } catch (Exception e) {
-                Log.e("EX_Toolbox", "Error processing cv29: " + e.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": checkCv29(): Error processing cv29: " + e.getMessage());
             }
         }
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/function_consist_settings.java
@@ -62,6 +62,7 @@ import jmri.enginedriver.util.LocaleHelper;
 
 @SuppressLint("ApplySharedPref")
 public class function_consist_settings extends AppCompatActivity implements PermissionsHelper.PermissionsHelperGrantedCallback {
+    static final String activityName = "function_consist_settings";
 
     private threaded_application mainapp;
     private boolean orientationChange = false;
@@ -155,8 +156,16 @@ public class function_consist_settings extends AppCompatActivity implements Perm
     } //end onCreate
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.FUNCTION_CONSIST_SETTINGS;
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
@@ -181,10 +190,9 @@ public class function_consist_settings extends AppCompatActivity implements Perm
 
     @Override
     public void onDestroy() {
-        Log.d("Engine_Driver", "function_consist_settings.onDestroy() called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy()");
         mainapp.set_default_function_labels(false); // reload the preference in cases the display number is less than the total number
 
-        Log.d("Engine_Driver", "function_consist_settings.onDestroy() called");
         if (!orientationChange) {
             aLbl.clear();
             aFnc.clear();
@@ -431,14 +439,19 @@ public class function_consist_settings extends AppCompatActivity implements Perm
         mainapp.exitDoubleBackButtonInitiated = 0;
 
         if (key == KeyEvent.KEYCODE_BACK) {
-            move_view_to_settings();        //sync settings array to view
-            if (!settingsCurrent)
-                saveSettings();         //save function settings to the file
-            this.finish();  //end this activity
-            connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+            endThisActivity();
             return true;
         }
         return (super.onKeyDown(key, event));
+    }
+
+    void endThisActivity() {
+        threaded_application.activityInTransition(activityName);
+        move_view_to_settings();        //sync settings array to view
+        if (!settingsCurrent)
+            saveSettings();         //save function settings to the file
+        this.finish();  //end this activity
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
     }
 
     void saveSettings() {
@@ -471,7 +484,7 @@ public class function_consist_settings extends AppCompatActivity implements Perm
             settings_output.close();
         } catch (IOException except) {
             errMsg = except.getMessage();
-            Log.e("settings_activity", "Error creating a PrintWriter, IOException: " + errMsg);
+            Log.e(threaded_application.applicationName, activityName + ": saveSettings(): Error creating a PrintWriter, IOException: " + errMsg);
         }
         if (!errMsg.isEmpty())
 //            Toast.makeText(getApplicationContext(), "Save Settings Failed." + errMsg, Toast.LENGTH_LONG).show();
@@ -491,7 +504,7 @@ public class function_consist_settings extends AppCompatActivity implements Perm
 
     @SuppressLint("SwitchIntDef")
     public void navigateToHandler(@RequestCodes int requestCode) {
-        Log.d("Engine_Driver", "function_settings: navigateToHandler:" + requestCode);
+        Log.d(threaded_application.applicationName, activityName + ": navigateToHandler:" + requestCode);
         if (!PermissionsHelper.getInstance().isPermissionGranted(function_consist_settings.this, requestCode)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 PermissionsHelper.getInstance().requestNecessaryPermissions(function_consist_settings.this, requestCode);
@@ -499,16 +512,16 @@ public class function_consist_settings extends AppCompatActivity implements Perm
         } else {
 //            switch (requestCode) {
 //                case PermissionsHelper.STORE_FUNCTION_SETTINGS:
-//                    Log.d("Engine_Driver", "Got permission for STORE_FUNCTION_SETTINGS - navigate to saveSettingsImpl()");
+//                    Log.d(threaded_application.applicationName, activityName + ": navigateTohandler(): Got permission for STORE_FUNCTION_SETTINGS - navigate to saveSettingsImpl()");
 //                    saveSettingsImpl();
 //                    break;
 //                case PermissionsHelper.READ_FUNCTION_SETTINGS:
-//                    Log.d("Engine_Driver", "Got permission for READ_FUNCTION_SETTINGS - navigate to initSettingsImpl()");
+//                    Log.d(threaded_application.applicationName, activityName + ": navigateTohandler(): Got permission for READ_FUNCTION_SETTINGS - navigate to initSettingsImpl()");
 //                    initSettingsImpl();
 //                    break;
 //                default:
                     // do nothing
-                    Log.d("Engine_Driver", "Unrecognised permissions request code: " + requestCode);
+                    Log.d(threaded_application.applicationName, activityName + ": navigateTohandler(): Unrecognised permissions request code: " + requestCode);
 //            }
         }
     }
@@ -516,7 +529,7 @@ public class function_consist_settings extends AppCompatActivity implements Perm
     @Override
     public void onRequestPermissionsResult(@RequestCodes int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (!PermissionsHelper.getInstance().processRequestPermissionsResult(function_consist_settings.this, requestCode, permissions, grantResults)) {
-            Log.d("Engine_Driver", "Unrecognised request - send up to super class");
+            Log.d(threaded_application.applicationName, activityName + ": onRequestPermissionsResult(): Unrecognised request - send up to super class");
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
@@ -533,9 +546,11 @@ public class function_consist_settings extends AppCompatActivity implements Perm
     }
 
     void reopenThrottlePage() {
+        threaded_application.activityInTransition(activityName);
+
         move_view_to_settings();        //sync settings array to view
         if (!settingsCurrent)
             saveSettings();         //save function settings to the file
-        finish();  //end this activity
+        this.finish();  //end this activity
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportConnectionList.java
@@ -25,6 +25,8 @@ import jmri.enginedriver.R;
 import jmri.enginedriver.threaded_application;
 
 public class ImportExportConnectionList {
+    static final String activityName = "ImportExportConnectionList";
+
     public ArrayList<HashMap<String, String>> connections_list;
     private final SharedPreferences prefs;
     private final boolean prefHideDemoServer;
@@ -41,6 +43,7 @@ public class ImportExportConnectionList {
     public String failureReason = "";
 
     public ImportExportConnectionList(SharedPreferences p) {
+
         prefs = p;
         prefHideDemoServer = prefs.getBoolean("prefHideDemoServer", context.getResources().getBoolean(R.bool.prefHideDemoServerDefaultValue));
         connections_list = new ArrayList<>();
@@ -115,11 +118,11 @@ public class ImportExportConnectionList {
                 }
                 list_reader.close();
             } else {
-                Log.d("connection_activity", "Recent connections not found");
+                Log.d(threaded_application.applicationName, activityName + ": getConnectionsList(): Recent connections not found");
             }
         } catch (IOException except) {
             errMsg = except.getMessage();
-            Log.e("connection_activity", "Error reading recent connections list: " + errMsg);
+            Log.e(threaded_application.applicationName, activityName + ": getConnectionsList(): Error reading recent connections list: " + errMsg);
             failureReason = errMsg;
 //                    Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectErrorReadingRecentConnections) + " " + errMsg, Toast.LENGTH_SHORT).show();
         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportPreferences.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/import_export/ImportExportPreferences.java
@@ -58,6 +58,7 @@ import jmri.enginedriver.threaded_application;
 
 /** @noinspection CallToPrintStackTrace*/
 public class ImportExportPreferences {
+    static final String activityName = "ImportExportPreferences";
 
     public boolean currentlyImporting = false;
 
@@ -87,7 +88,7 @@ public class ImportExportPreferences {
     public ArrayList<String> recentTurnoutServerList;
 
     private void writeExportFile(Context context, SharedPreferences sharedPreferences, String exportedPreferencesFileName){
-        Log.d("Engine_Driver", "writeExportFile: ImportExportPreferences: Writing export file");
+        Log.d(threaded_application.applicationName, activityName + ": writeExportFile(): Writing export file");
         boolean result = false;
         ObjectOutputStream output = null;
 
@@ -99,7 +100,7 @@ public class ImportExportPreferences {
             @SuppressLint("StringFormatMatches") String m = context.getResources().getString(R.string.toastImportExportExportSucceeded,exportedPreferencesFileName);
 //            Toast.makeText(context, m, Toast.LENGTH_SHORT).show();
             threaded_application.safeToast(m, Toast.LENGTH_SHORT);
-            Log.d("Engine_Driver", m);
+            Log.d(threaded_application.applicationName, activityName + ": " + m);
             result = true;
         } catch (FileNotFoundException e) {
             e.printStackTrace();
@@ -116,17 +117,17 @@ public class ImportExportPreferences {
             }
         }
         if (!result) {
-            Log.e("Engine_Driver", "writeExportFile: ImportExportPreferences: Export Failed");
+            Log.e(threaded_application.applicationName, activityName + ": writeExportFile(): Export Failed");
 //            Toast.makeText(context, "Export failed!", Toast.LENGTH_LONG).show();
             threaded_application.safeToast(R.string.toastImportExportExportFailed, Toast.LENGTH_LONG);
         } else {
-            Log.d("Engine_Driver", "writeExportFile: ImportExportPreferences: Export succeeded");
+            Log.d(threaded_application.applicationName, activityName + ": writeExportFile(): Export succeeded");
 
         }
     }
 
     public void writeSharedPreferencesToFile(Context context, SharedPreferences sharedPreferences, String exportedPreferencesFileName) {
-        Log.d("Engine_Driver", "writeSharedPreferencesToFile: ImportExportPreferences: Saving preferences to file");
+        Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile(): Saving preferences to file");
 
         boolean prefImportExportLocoList = sharedPreferences.getBoolean("prefImportExportLocoList", context.getResources().getBoolean(R.bool.prefImportExportLocoListDefaultValue));
         if (prefImportExportLocoList) {
@@ -167,10 +168,10 @@ public class ImportExportPreferences {
         int prefCount;
         if (prefImportExportLocoList) {  // now clean out the preference data
 
-            Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Normal Cleanout of old Recent Locos preferences");
+            Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Normal Cleanout of old Recent Locos preferences");
             prefCount = removeExtraListDataFromPreferences(0,numberOfRecentLocosToWrite+1,"prefRecentLoco", sharedPreferences);
             if (prefCount == numberOfRecentLocosToWrite+1) {  // if there were that many, assume the worst
-                Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Extended Cleanout of old Recent Locos preferences");
+                Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Extended Cleanout of old Recent Locos preferences");
                 prefCount = removeExtraListDataFromPreferences(numberOfRecentLocosToWrite+1, 600, "prefRecentLoco", sharedPreferences);
             }
             removeExtraListDataFromPreferences(0, prefCount,"prefRecentLocoSize", sharedPreferences);
@@ -179,16 +180,16 @@ public class ImportExportPreferences {
 
             prefCount =removeExtraListDataFromPreferences(0,numberOfRecentLocosToWrite+1,"prefRecentConsistName", sharedPreferences);
             if (prefCount == numberOfRecentLocosToWrite+1) {  // if there were that many, look for more
-                Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Extended Cleanout of old Recent Locos preferences");
+                Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Extended Cleanout of old Recent Locos preferences");
                 prefCount = removeExtraListDataFromPreferences(numberOfRecentLocosToWrite+1, numberOfRecentLocosToWrite+20, "prefRecentConsistName", sharedPreferences);
 
                 if (prefCount == numberOfRecentLocosToWrite+20) {  // if there were that many, assume the worst
-                    Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Extended DEEP CLEAN of old Recent Locos preferences");
+                    Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Extended DEEP CLEAN of old Recent Locos preferences");
                     prefCount = removeExtraListDataFromPreferences(numberOfRecentLocosToWrite+1, 600, "prefRecentConsistName", sharedPreferences);
                 }
             }
 
-            Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Normal Cleanout of old Recent Consist preferences");
+            Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Normal Cleanout of old Recent Consist preferences");
             for (int i = 0; i < numberOfRecentLocosToWrite; i++) {
                 int subPrefCount = removeExtraListDataFromPreferences(0,10,"prefRecentConsistAddress_"+i, sharedPreferences);
                 removeExtraListDataFromPreferences(0,subPrefCount,"prefRecentConsistSize_"+i, sharedPreferences);
@@ -199,19 +200,19 @@ public class ImportExportPreferences {
             }
 
             if (sharedPreferences.contains("prefRecentTurnoutServer_0")) {  // there should not be any so assume the worst
-                Log.d("Engine_Driver", "writeSharedPreferencesToFile:  Extended Cleanout of old Recent turnouts preferences - these should not exist");
+                Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile():  Extended Cleanout of old Recent turnouts preferences - these should not exist");
                 prefCount = removeExtraListDataFromPreferences(0, 600, "prefRecentTurnout", sharedPreferences);
                 removeExtraListDataFromPreferences(0, prefCount, "prefRecentTurnoutName", sharedPreferences);
                 removeExtraListDataFromPreferences(0, prefCount, "prefRecentTurnoutSource", sharedPreferences);
                 removeExtraListDataFromPreferences(0, prefCount, "prefRecentTurnoutServer", sharedPreferences);
             }
         }
-        Log.d("Engine_Driver", "writeSharedPreferencesToFile: ImportExportPreferences: Saving preferences to file - Finished");
+        Log.d(threaded_application.applicationName, activityName + ": writeSharedPreferencesToFile(): ImportExportPreferences: Saving preferences to file - Finished");
     }
 
     @SuppressLint({"ApplySharedPref", "StringFormatMatches"})
     public boolean loadSharedPreferencesFromFile(Context context, SharedPreferences sharedPreferences, String exportedPreferencesFileName, String deviceId, boolean clearRecentsIfNoFile) {
-        Log.d("Engine_Driver", "loadSharedPreferencesFromFile: ImportExportPreferences: Loading saved preferences from file");
+        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Loading saved preferences from file");
         currentlyImporting = true;
         boolean res = false;
         boolean srcExists = false;
@@ -254,32 +255,32 @@ public class ImportExportPreferences {
 
                     int i = 0;
                     Map<String, ?> entries = (Map<String, ?>) input.readObject();
-                    Log.d("Engine_Driver", "loadSharedPreferencesFromFile: Key Count:" + entries.size());
+                    Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key Count:" + entries.size());
                     for (Map.Entry<String, ?> entry : entries.entrySet()) {
                         Object v = entry.getValue();
                         String key = entry.getKey();
 
-//                        Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key Start: " + key);
+//                        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key Start: " + key);
 
                         if (v instanceof Boolean) {
-//                            Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key End: " + key + " - boolean - " + v);
+//                            Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key End: " + key + " - boolean - " + v);
                             prefEdit.putBoolean(key, (Boolean) v);
                         } else if (v instanceof Float) {
-//                            Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key End: " + key + " - Float - " + v);
+//                            Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key End: " + key + " - Float - " + v);
                             prefEdit.putFloat(key, (Float) v);
                         } else if (v instanceof Integer) {
-//                            Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key End: " + key + " - Integer - " + v);
+//                            Log.d(threaded_application.applicationName, activityName + ":  loadSharedPreferencesFromFile(): Key End: " + key + " - Integer - " + v);
                             prefEdit.putInt(key, (Integer) v);
                         } else if (v instanceof Long) {
-//                            Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key End: " + key + " - Long - " + v);
+//                            Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key End: " + key + " - Long - " + v);
                             prefEdit.putLong(key, (Long) v);
                         } else if (v instanceof String) {
-//                            Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key End: " + key + " - String - " + v);
+//                            Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key End: " + key + " - String - " + v);
                             prefEdit.putString(key, ((String) v));
                             if (key.equals("prefAndroidId")) { restoredDeviceId = (String) v;}
                         }
 
-                        Log.d("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: Key " + i +" End: " + key + " - " + v);
+                        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Key " + i +" End: " + key + " - " + v);
                         i++;
                     }
                     res = true;
@@ -309,19 +310,19 @@ public class ImportExportPreferences {
 
                     @SuppressLint("StringFormatMatches") String m = context.getResources().getString(R.string.toastImportExportImportSucceeded, exportedPreferencesFileName);
 
-                    Log.d("Engine_Driver", "ImportExportPreferences: " + m);
+                    Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): " + m);
 //                    Toast.makeText(context, m, Toast.LENGTH_SHORT).show();
                     threaded_application.safeToast(m, Toast.LENGTH_SHORT);
 
                 } catch (FileNotFoundException e) {
                     e.printStackTrace();
-                    Log.e("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: " + e);
+                    Log.e(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Exception: " + e);
                 } catch (IOException e) {
                     e.printStackTrace();
-                    Log.e("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: " + e);
+                    Log.e(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Exception: " + e);
                 } catch (ClassNotFoundException e) {
                     e.printStackTrace();
-                    Log.e("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: " + e);
+                    Log.e(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Exception: " + e);
                 } finally {
                     try {
                         if (input != null) {
@@ -329,7 +330,7 @@ public class ImportExportPreferences {
                         }
                     } catch (IOException ex) {
                         ex.printStackTrace();
-                        Log.e("Engine_Driver", "ImportExportPreferences: loadSharedPreferencesFromFile: " + ex);
+                        Log.e(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Exception: " + ex);
                     }
                 }
                 prefEdit.apply();
@@ -404,12 +405,12 @@ public class ImportExportPreferences {
         }
 
         prefEdit.commit();
-        Log.d("Engine_Driver", "loadSharedPreferencesFromFile: ImportExportPreferences: Loading saved preferences from file - Finished");
+        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFile(): Loading saved preferences from file - Finished");
         return res;
     }
 
     public void loadRecentLocosListFromFile() {
-        Log.d("Engine_Driver", "loadRecentLocosListFromFile: ImportExportPreferences: Loading recent locos list from file");
+        Log.d(threaded_application.applicationName, activityName + ": loadRecentLocosListFromFile()): Loading recent locos list from file");
         if (recentLocoAddressList == null) { //make sure arrays are valid
             recentLocoAddressList = new ArrayList<>();
             recentLocoAddressSizeList = new ArrayList<>();
@@ -478,16 +479,16 @@ public class ImportExportPreferences {
                 }
                 list_reader.close();
             }
-            Log.d("Engine_Driver", "loadRecentLocosListFromFile: ImportExportPreferences: Read recent locos list from file complete successfully");
+            Log.d(threaded_application.applicationName, activityName + ": loadRecentLocosListFromFile(): Read recent locos list from file complete successfully");
 
         } catch (IOException except) {
-            Log.e("Engine_Driver", "loadRecentLocosListFromFile: ImportExportPreferences: select_loco - Error reading recent loco file. "
+            Log.e(threaded_application.applicationName, activityName + ": loadRecentLocosListFromFile(): select_loco - Error reading recent loco file. "
                     + except.getMessage());
         }
     }
 
     public void writeRecentLocosListToFile(SharedPreferences sharedPreferences) {
-        Log.d("Engine_Driver", "writeRecentLocosListToFile: ImportExportPreferences: Writing recent locos list to file");
+        Log.d(threaded_application.applicationName, activityName + ": writeRecentLocosListToFile(): Writing recent locos list to file");
 
         // write it out from the saved preferences to the file
         File engine_list_file = new File(context.getExternalFilesDir(null), RECENT_ENGINES_FILENAME);
@@ -509,24 +510,21 @@ public class ImportExportPreferences {
             }
             list_output.flush();
             list_output.close();
-            Log.d("Engine_Driver", "writeRecentLocosListToFile: ImportExportPreferences: Write recent locos list to file complete successfully");
+            Log.d(threaded_application.applicationName, activityName + ": writeRecentLocosListToFile(): Write recent locos list to file complete successfully");
         } catch (IOException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentLocosListToFile caught IOException: "
+            Log.e(threaded_application.applicationName, activityName + ":  writeRecentLocosListToFile(): caught IOException: "
                             + except.getMessage());
         } catch (NumberFormatException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentLocosListToFile caught NumberFormatException: "
+            Log.e(threaded_application.applicationName, activityName + ":  writeRecentLocosListToFile(): caught NumberFormatException: "
                             + except.getMessage());
         } catch (IndexOutOfBoundsException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentLocosListToFile caught IndexOutOfBoundsException: "
+            Log.e(threaded_application.applicationName, activityName + ":  writeRecentLocosListToFile(): caught IndexOutOfBoundsException: "
                             + except.getMessage());
         }
     }
 
     public void loadRecentConsistsListFromFile() {
-        Log.d("Engine_Driver", "loadRecentConsistsListFromFile: ImportExportPreferences: Loading recent consists list from file");
+        Log.d(threaded_application.applicationName, activityName + ": loadRecentConsistsListFromFile(): Loading recent consists list from file");
 
         recentConsistLocoAddressList = new ArrayList<>();
         recentConsistAddressSizeList = new ArrayList<>();
@@ -633,11 +631,11 @@ public class ImportExportPreferences {
                         }
                     }
                     list_reader.close();
-                    Log.d("Engine_Driver", "loadRecentConsistsListFromFile: ImportExportPreferences: Read recent consists list from file completed successfully");
+                    Log.d(threaded_application.applicationName, activityName + ": loadRecentConsistsListFromFile(): Read recent consists list from file completed successfully");
                 }
 
             } catch (IOException except) {
-                Log.e("Engine_Driver", "loadRecentConsistsListFromFile: ImportExportPreferences: Error reading recent consist file. "
+                Log.e(threaded_application.applicationName, activityName + ": loadRecentConsistsListFromFile(): Error reading recent consist file. "
                         + except.getMessage());
             }
         }
@@ -836,7 +834,7 @@ public class ImportExportPreferences {
 
 
     public void writeRecentConsistsListToFile(SharedPreferences sharedPreferences, int whichEntryIsBeingUpdated) {
-        Log.d("Engine_Driver", "writeRecentConsistsListToFile: ImportExportPreferences: Writing recent consists list to file");
+        Log.d(threaded_application.applicationName, activityName + ": writeRecentConsistsListToFile(): Writing recent consists list to file");
 
         // write it out from the saved preferences to the file
         File consist_list_file = new File(context.getExternalFilesDir(null), RECENT_CONSISTS_FILENAME);
@@ -878,10 +876,9 @@ public class ImportExportPreferences {
             }
             list_output.flush();
             list_output.close();
-            Log.d("Engine_Driver", "writeRecentConsistsListToFile: ImportExportPreferences: Write recent consists list to file completed successfully");
+            Log.d(threaded_application.applicationName, activityName + ": writeRecentConsistsListToFile(): Write recent consists list to file completed successfully");
         } catch (IOException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentConsistsListToFile: ImportExportPreferences: Error creating a PrintWriter, IOException: "
+            Log.e(threaded_application.applicationName, activityName + ": writeRecentConsistsListToFile(): Error creating a PrintWriter, IOException: "
                             + except.getMessage());
         }
     }
@@ -917,7 +914,7 @@ public class ImportExportPreferences {
         }
         sharedPreferences.edit().commit();
 
-//        Log.d("Engine_Driver", "writeRecentConsistsListToFile: removeExtraListDataFromPreferences: list: " +listName + " prefCount" + prefCount);
+//        Log.d(threaded_application.applicationName, activityName + ": writeRecentConsistsListToFile(): removeExtraListDataFromPreferences: list: " +listName + " prefCount" + prefCount);
 
         return prefCount;
     }
@@ -968,7 +965,7 @@ public class ImportExportPreferences {
                 engineAddressString = addressLengthString + addr.toString();  //e.g.  L1009
             }
         } catch (Exception e) {
-            Log.e("Engine_Driver", "locoAddressToString. ");
+            Log.e(threaded_application.applicationName, activityName + ":  locoAddressToString() Exception: " + e);
         }
         return engineAddressString;
     }
@@ -981,7 +978,7 @@ public class ImportExportPreferences {
 //            engineAddressHtml = String.format("<span>%s<small>(%s)</small>%s </span>", addr.toString(), addressLengthString, addressSourceString);
             engineAddressHtml = String.format("<span>%s<small>(%s)</small> </span>", addr.toString(), addressLengthString);
         } catch (Exception e) {
-            Log.e("Engine_Driver", "locoAddressToHtml. ");
+            Log.e(threaded_application.applicationName, activityName + ":  locoAddressToHtml() Exception: " + e);
         }
         return engineAddressHtml;
     }
@@ -990,7 +987,7 @@ public class ImportExportPreferences {
 //  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     public void writeRecentTurnoutsListToFile(SharedPreferences sharedPreferences) {
-//        Log.d("Engine_Driver", "writeRecentTurnoutsListToFile: ImportExportPreferences: Writing recent turnouts list to file");
+//        Log.d(threaded_application.applicationName, activityName + ": writeRecentTurnoutsListToFile(): Writing recent turnouts list to file");
 
         File engine_list_file = new File(context.getExternalFilesDir(null), RECENT_TURNOUTS_FILENAME);
 
@@ -1016,22 +1013,20 @@ public class ImportExportPreferences {
             }
             list_output.flush();
             list_output.close();
-            Log.d("Engine_Driver", "writeRecentTurnoutsListToFile: ImportExportPreferences: " +
+            Log.d(threaded_application.applicationName, activityName + ": writeRecentTurnoutsListToFile(): " +
                     "Write recent turnouts list to file completed successfully with " + recentTurnoutAddressList.size() + " entries.");
         } catch (IOException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentTurnoutsListToFile: ImportExportPreferences: Error creating a PrintWriter, IOException: "
+            Log.e(threaded_application.applicationName, activityName + ": writeRecentTurnoutsListToFile(): Error creating a PrintWriter, IOException: "
                             + except.getMessage());
         } catch (IndexOutOfBoundsException except) {
-            Log.e("Engine_Driver",
-                    "writeRecentTurnoutsListToFile: ImportExportPreferences: Error writing recent turnouts lists, IndexOutOfBoundsException: "
+            Log.e(threaded_application.applicationName, activityName + ": writeRecentTurnoutsListToFile(): Error writing recent turnouts lists, IndexOutOfBoundsException: "
                             + except.getMessage());
         }
     }
 
     /** @noinspection UnusedReturnValue*/
     public boolean deleteFile(String filename) {
-        Log.d("Engine_Driver", "deleteRecentTurnoutsListFile: ImportExportPreferences: delete file");
+        Log.d(threaded_application.applicationName, activityName + ": deleteFile():");
 
         File file = new File(context.getExternalFilesDir(null), filename);
         if (file.exists()) {
@@ -1039,8 +1034,7 @@ public class ImportExportPreferences {
                 file.delete();
                 return(true);
             } catch (Exception except) {
-                Log.e("Engine_Driver",
-                        "deleteRecentTurnoutsListFile: ImportExportPreferences: Error deleting : " + filename
+                Log.e(threaded_application.applicationName, activityName + ": deleteRecentTurnoutsListFile(): Error deleting : " + filename
                                 + except.getMessage());
             }
         }
@@ -1048,7 +1042,7 @@ public class ImportExportPreferences {
     }
 
         public void loadRecentTurnoutsListFromFile() {
-//        Log.d("Engine_Driver", "loadRecentTurnoutsListFromFile: ImportExportPreferences: Loading recent turnouts list from file");
+//        Log.d(threaded_application.applicationName, activityName + ": loadRecentTurnoutsListFromFile(): Loading recent turnouts list from file");
         try {
             // Populate the List with the recent engines saved in a file. This
             // will be stored in recent_engine_list.txt
@@ -1094,11 +1088,11 @@ public class ImportExportPreferences {
                 }
                 list_reader.close();
             }
-            Log.d("Engine_Driver", "loadRecentTurnoutsListFromFile: ImportExportPreferences: " +
+            Log.d(threaded_application.applicationName, activityName + ": loadRecentTurnoutsListFromFile(): " +
                     "Read recent turnouts list from file completed successfully with " + recentTurnoutAddressList.size() + " entries.");
 
         } catch (IOException except) {
-            Log.e("Engine_Driver", "loadRecentTurnoutsListFromFile: ImportExportPreferences: Error reading recent turnouts file. "
+            Log.e(threaded_application.applicationName, activityName + ": loadRecentTurnoutsListFromFile(): Error reading recent turnouts file. "
                     + except.getMessage());
         }
     }
@@ -1158,14 +1152,14 @@ public class ImportExportPreferences {
             // check if it is already in the list and remove it
             String keepFunctions = "";
             for (int i = 0; i < recentLocoAddressList.size(); i++) {
-                Log.d("Engine_Driver", "importExportPreferences: downloadRosterToRecents: locoName='"+locoName+"', address=" + locoAddress);
+                Log.d(threaded_application.applicationName, activityName + ": downloadRosterToRecents(): locoName='"+locoName+"', address=" + locoAddress);
                 if (locoAddress == recentLocoAddressList.get(i)
                         && locoAddressSize == recentLocoAddressSizeList.get(i)
                         && locoName.equals(recentLocoNameList.get(i))) {
 
                     keepFunctions = recentLocoFunctionsList.get(i);
                     removeRecentLocoFromList(i);
-                    Log.d("Engine_Driver", "importExportPreferences: downloadRosterToRecents: Loco '"+ locoName + "' removed from Recents");
+                    Log.d(threaded_application.applicationName, activityName + ": downloadRosterToRecents(): Loco '"+ locoName + "' removed from Recents");
                     break;
                 }
             }
@@ -1173,7 +1167,7 @@ public class ImportExportPreferences {
             // now append it to the end of the list
             addRecentLocoToList(locoAddress, locoAddressSize, locoName, source_type.ROSTER, keepFunctions);   // functions are blank for now
 
-            Log.d("Engine_Driver", "importExportPreferences: downloadRosterToRecents: Loco '"+ locoName + "' added to Recents");
+            Log.d(threaded_application.applicationName, activityName + ": downloadRosterToRecents(): Loco '"+ locoName + "' added to Recents");
 
             j++;
         }

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
@@ -41,6 +41,8 @@ import jmri.enginedriver.type.activity_id_type;
 import jmri.enginedriver.util.PermissionsHelper;
 
 public class intro_activity extends AppIntro2 implements PermissionsHelper.PermissionsHelperGrantedCallback {
+    static final String activityName = "intro_activity";
+
     private boolean introComplete = false;
     private SharedPreferences prefs;
     //    private String prefThrottleType  = "";
@@ -52,7 +54,7 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.d("Engine_Driver", "intro_activity.onCreate()");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate()");
 
         mainapp = (threaded_application) this.getApplication();
 
@@ -300,20 +302,20 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
 
     @SuppressLint("SwitchIntDef")
     public void navigateToHandler(@PermissionsHelper.RequestCodes int requestCode) {
-        Log.d("Engine_Driver", "introActivity: navigateToHandler:" + requestCode);
+        Log.d(threaded_application.applicationName, activityName + ": navigateToHandler:" + requestCode);
         if (!PermissionsHelper.getInstance().isPermissionGranted(this, requestCode)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 PermissionsHelper.getInstance().requestNecessaryPermissions(this, requestCode);
             }
         } else {
             // do nothing
-            Log.d("Engine_Driver", "introActivity: Unrecognised permissions request code: " + requestCode);
+            Log.d(threaded_application.applicationName, activityName + ": Unrecognised permissions request code: " + requestCode);
         }
     }
     @Override
     public void onRequestPermissionsResult(@PermissionsHelper.RequestCodes int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (!PermissionsHelper.getInstance().processRequestPermissionsResult(this, requestCode, permissions, grantResults)) {
-            Log.d("Engine_Driver", "introActivity: Unrecognised request - send up to super class");
+            Log.d(threaded_application.applicationName, activityName + ": onRequestPermissionsResult(): Unrecognised request - send up to super class");
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
@@ -358,9 +360,17 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
     }
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
         threaded_application.currentActivity = activity_id_type.INTRO;
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
 //        if (this.isFinishing()) {        //if finishing, expedite it
 //            return;
 //        }
@@ -369,7 +379,7 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
 
     @Override
     public void onDestroy() {
-        Log.d("Engine_Driver", "intro_activity: onDestroy() called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy()");
 
         mainapp.introIsRunning = false;
         if (!introComplete) {

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_alert.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_alert.java
@@ -29,12 +29,13 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 public class intro_alert extends Fragment {
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_alert");
+        Log.d(threaded_application.applicationName, "intro_alert: onActivityCreated()" );
         super.onActivityCreated(savedInstanceState);
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_buttons.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_buttons.java
@@ -35,12 +35,14 @@ import android.widget.TextView;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 /**
  * Created by andrew on 11/17/16.
  */
 
 public class intro_buttons extends Fragment {
+    static final String activityName = "intro_buttons";
 
     private SharedPreferences prefs;
     private boolean displaySpeedButtons = false;
@@ -48,7 +50,7 @@ public class intro_buttons extends Fragment {
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_buttons");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
         prefs = Objects.requireNonNull(this.getActivity()).getSharedPreferences("jmri.enginedriver_preferences", 0);
         boolean prefDisplaySpeedButtons = prefs.getBoolean("display_speed_arrows_buttons", false);

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_dccex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_dccex.java
@@ -34,19 +34,21 @@ import android.widget.RadioGroup;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 /**
  * Created by andrew on 11/17/16.
  */
 
 public class intro_dccex extends Fragment {
+    static final String activityName = "intro_dccex";
 
     private SharedPreferences prefs;
     private boolean dccexYes;
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_dccex");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
         prefs = Objects.requireNonNull(this.getActivity()).getSharedPreferences("jmri.enginedriver_preferences", 0);
         boolean prefDccexConnectionOption = prefs.getBoolean("prefDCCEXconnectionOption", getResources().getBoolean(R.bool.prefDccexConnectionOptionDefaultValue));

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_finish.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_finish.java
@@ -32,13 +32,15 @@ import android.view.ViewGroup;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 import jmri.enginedriver.util.PermissionsHelper;
 
 public class intro_finish extends Fragment {
+    static final String activityName = "intro_finish";
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_finish");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_permissions.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_permissions.java
@@ -34,6 +34,7 @@ import android.widget.TextView;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 import jmri.enginedriver.util.PermissionsHelper;
 
 /**
@@ -41,6 +42,7 @@ import jmri.enginedriver.util.PermissionsHelper;
  */
 
 public class intro_permissions extends Fragment {
+    static final String activityName = "intro_permissions";
 
     private boolean askedThisSession = false;
     int permissionId;
@@ -49,7 +51,7 @@ public class intro_permissions extends Fragment {
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_permissions");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
 
         introPermissionLabel = getView().findViewById(R.id.intro_permission_label);

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_theme.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_theme.java
@@ -35,16 +35,18 @@ import android.widget.TextView;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 
 public class intro_theme extends Fragment {
+    static final String activityName = "intro_theme";
 
     private SharedPreferences prefs;
     private String[] nameEntryValues;
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_theme");
+        Log.d(threaded_application.applicationName, activityName + ":");
 
         super.onActivityCreated(savedInstanceState);
         prefs = Objects.requireNonNull(this.getActivity()).getSharedPreferences("jmri.enginedriver_preferences", 0);

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_throttle_name.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_throttle_name.java
@@ -38,6 +38,7 @@ import jmri.enginedriver.threaded_application;
 
 
 public class intro_throttle_name extends Fragment {
+    static final String activityName = "intro_throttle_name";
 
     SharedPreferences prefs;
     String currentValue = "";
@@ -47,7 +48,7 @@ public class intro_throttle_name extends Fragment {
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_throttle_name");
+        Log.d(threaded_application.applicationName, activityName + ":");
 
         super.onActivityCreated(savedInstanceState);
         mainapp = (threaded_application) Objects.requireNonNull(this.getActivity()).getApplication();

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_throttle_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_throttle_type.java
@@ -35,15 +35,17 @@ import android.widget.TextView;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 public class intro_throttle_type extends Fragment {
+    static final String activityName = "intro_throttle_type";
 
     private SharedPreferences prefs;
     private String[] nameEntryValues;
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_throttle_type");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
         prefs = Objects.requireNonNull(this.getActivity()).getSharedPreferences("jmri.enginedriver_preferences", 0);
         String currentValue = prefs.getString("prefThrottleScreenType", this.getActivity().getApplicationContext().getResources().getString(R.string.prefThrottleScreenTypeDefault));

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_write_settings.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_write_settings.java
@@ -36,12 +36,14 @@ import android.widget.Button;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 public class intro_write_settings extends Fragment {
+    static final String activityName = "intro_write_settings";
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "intro_write_settings");
+        Log.d(threaded_application.applicationName, activityName + ":");
         super.onActivityCreated(savedInstanceState);
 
         Button settingsButton = Objects.requireNonNull(getView()).findViewById(R.id.intro_write_settings_launch);

--- a/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/logviewer/ui/LogViewerActivity.java
@@ -16,6 +16,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Objects;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.connection_activity;
 import jmri.enginedriver.type.activity_id_type;
 import jmri.enginedriver.type.message_type;
 import jmri.enginedriver.threaded_application;
@@ -50,6 +52,8 @@ import jmri.enginedriver.util.PermissionsHelper.RequestCodes;
 
 /** @noinspection CallToPrintStackTrace*/
 public class LogViewerActivity extends AppCompatActivity implements PermissionsHelper.PermissionsHelperGrantedCallback {
+    static final String activityName = "LogViewerActivity";
+
     private ArrayAdapter<String> adaptor = null;
     private LogReaderTask logReaderTask = null;
     private threaded_application mainapp;  // hold pointer to mainapp
@@ -65,6 +69,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
         super.onCreate(savedInstanceState);
         mainapp = (threaded_application) getApplication();
         if (mainapp.isForcingFinish()) {        // expedite
+            this.finish();
             return;
         }
 
@@ -128,14 +133,22 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
                     "");
         }
 
-        Log.d("Engine_Driver", mainapp.getAboutInfo());
-        Log.d("Engine_Driver", mainapp.getAboutInfo(false));
+        Log.d(threaded_application.applicationName, mainapp.getAboutInfo());
+        Log.d(threaded_application.applicationName, mainapp.getAboutInfo(false));
 
     } // end onCreate
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.LOG_VIEWER;
         if (mainapp.isForcingFinish()) {        //expedite
             this.finish();
@@ -190,7 +203,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 
     @Override
     protected void onDestroy() {
-        Log.d("Engine_Driver", "log_viewer.onDestroy() called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy()");
 
         if (logReaderTask != null ) {
             logReaderTask.stopTask();
@@ -206,7 +219,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
     public class CloseButtonListener implements View.OnClickListener {
         public void onClick(View v) {
             mainapp.buttonVibration();
-            finish();
+            endThisActivity();
         }
     }
 
@@ -215,6 +228,23 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 //
 //        }
 //    }
+
+    //Handle pressing of the back button to end this activity
+    @Override
+    public boolean onKeyDown(int key, KeyEvent event) {
+        mainapp.exitDoubleBackButtonInitiated = 0;
+        if (key == KeyEvent.KEYCODE_BACK) {
+            endThisActivity();
+            return true;
+        }
+        return (super.onKeyDown(key, event));
+    }
+
+    void endThisActivity() {
+        threaded_application.activityInTransition(activityName);
+        this.finish();  //end this activity
+        connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
+    }
 
     class logviewer_handler extends Handler {
 
@@ -241,7 +271,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
                     break;
                 }
                 case message_type.REOPEN_THROTTLE:
-                    finish();
+                    endThisActivity();
                     break;
 
                 default:
@@ -267,9 +297,9 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
             threaded_application.safeToast(getApplicationContext().getResources().getString(R.string.toastSaveLogFile, logFile.toString()), Toast.LENGTH_LONG);
             mainapp.logSaveFilename = logFile.toString();
             showHideSaveButton();
-            Log.d("Engine_Driver", "Logging started to: " + logFile);
-            Log.d("Engine_Driver", mainapp.getAboutInfo());
-            Log.d("Engine_Driver", mainapp.getAboutInfo(false));
+            Log.d(threaded_application.applicationName, "Logging started to: " + logFile);
+            Log.d(threaded_application.applicationName, mainapp.getAboutInfo());
+            Log.d(threaded_application.applicationName, mainapp.getAboutInfo(false));
         } catch ( IOException e ) {
             e.printStackTrace();
         }
@@ -289,7 +319,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
 
     @SuppressLint("SwitchIntDef")
     public void navigateToHandler(@PermissionsHelper.RequestCodes int requestCode) {
-        Log.d("Engine_Driver", "LogViewerActivity: navigateToHandler:" + requestCode);
+        Log.d(threaded_application.applicationName, activityName + ": navigateToHandler():" + requestCode);
         if (!PermissionsHelper.getInstance().isPermissionGranted(LogViewerActivity.this, requestCode)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 PermissionsHelper.getInstance().requestNecessaryPermissions(LogViewerActivity.this, requestCode);
@@ -300,12 +330,12 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
             //noinspection SwitchStatementWithTooFewBranches
             switch (requestCode) {
 //                case PermissionsHelper.STORE_LOG_FILES:
-//                    Log.d("Engine_Driver", "Preferences: Got permission for STORE_LOG_FILES - navigate to writeSharedPreferencesToFileImpl()");
+//                    Log.d(threaded_application.applicationName, activityName + ": navigateToHandler(): Got permission for STORE_LOG_FILES - navigate to writeSharedPreferencesToFileImpl()");
 //                    saveLogFileImpl();
 //                    break;
                 default:
                     // do nothing
-                    Log.d("Engine_Driver", "Preferences: Unrecognised permissions request code: " + requestCode);
+                    Log.d(threaded_application.applicationName, activityName + ": navigateToHandler(): Unrecognised permissions request code: " + requestCode);
             }
         }
     }
@@ -313,7 +343,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
     @Override
     public void onRequestPermissionsResult(@RequestCodes int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (!PermissionsHelper.getInstance().processRequestPermissionsResult(LogViewerActivity.this, requestCode, permissions, grantResults)) {
-            Log.d("Engine_Driver", "Unrecognised request - send up to super class");
+            Log.d(threaded_application.applicationName, activityName + ": onRequestPermissionsResult(): Unrecognised request - send up to super class");
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
@@ -452,7 +482,7 @@ public class LogViewerActivity extends AppCompatActivity implements PermissionsH
             adaptor.add(line);
             adaptor.notifyDataSetChanged();
         } catch (Exception e) {
-            Log.d("Engine_Driver", "LogViewerActivity: addLine: exception: " + e);
+            Log.d(threaded_application.applicationName, activityName + ": addLogEntryToView(): addLine: exception: " + e);
         }
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/select_loco.java
@@ -61,7 +61,6 @@ import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -113,6 +112,7 @@ import jmri.enginedriver.type.direction_type;
 import jmri.enginedriver.type.sub_activity_type;
 
 public class select_loco extends AppCompatActivity {
+    static final String activityName = "select_loco";
     static public final int RESULT_LOCO_EDIT = RESULT_FIRST_USER;
 
     String prefSelectLocoMethod = select_loco_method_type.FIRST;
@@ -208,6 +208,7 @@ public class select_loco extends AppCompatActivity {
     // populate the on-screen roster view from global hashmap
     @SuppressLint("DefaultLocale")
     public void refreshRosterList() {
+        Log.d(threaded_application.applicationName, activityName + ": refreshRosterList()");
         // clear and rebuild
         rosterList.clear();  // local list. For UI
         mainapp.rosterFullList.clear(); // full global list
@@ -219,7 +220,7 @@ public class select_loco extends AppCompatActivity {
 
             //only show this warning once, it will be skipped for each entry below
             if (mainapp.rosterJmriWeb == null) {
-                Log.w("Engine_Driver", "select_loco: refreshRosterList(): xml roster not available");
+                Log.w(threaded_application.applicationName, activityName + ": refreshRosterList(): xml roster not available");
             }
 
             int position = -1;
@@ -279,10 +280,10 @@ public class select_loco extends AppCompatActivity {
                                 if (iconPath != null) {
                                     hm.put("roster_icon", iconPath + "?maxHeight=52");  //include sizing instructions
                                 } else {
-                                    Log.d("Engine_Driver", "select_loco: refreshRosterList(): xml roster entry " + rostername + " found, but no icon specified.");
+                                    Log.d(threaded_application.applicationName, activityName + ": refreshRosterList(): xml roster entry " + rostername + " found, but no icon specified.");
                                 }
                             } else {
-                                Log.w("Engine_Driver", "select_loco: refreshRosterList(): WiThrottle roster entry " + rostername + " not found in xml roster.");
+                                Log.w(threaded_application.applicationName, activityName + ": refreshRosterList(): WiThrottle roster entry " + rostername + " not found in xml roster.");
                             }
                         }
                         // add temp hashmap to list which view is hooked to
@@ -380,6 +381,7 @@ public class select_loco extends AppCompatActivity {
     }
 
     private String getLocoIconUrlFromRoster(String engineAddress, String engineName) {
+//        Log.d(threaded_application.applicationName, activityName + ": getLocoIconUrlFromRoster()");
         if (prefRosterRecentLocoNames) {
             if ((mainapp.roster_entries != null) && (!mainapp.roster_entries.isEmpty()) && (mainapp.rosterJmriWeb != null)) {
                 for (String rostername : mainapp.roster_entries.keySet()) {  // loop thru roster entries,
@@ -413,6 +415,7 @@ public class select_loco extends AppCompatActivity {
 
     @SuppressLint("ApplySharedPref")
     void checkValidMethod(String whichMethod) {
+        Log.d(threaded_application.applicationName, activityName + ": checkValidMethod()");
         prefSelectLocoMethod = whichMethod;
 
         if (prefSelectLocoMethod.equals(select_loco_method_type.FIRST)) {
@@ -434,6 +437,7 @@ public class select_loco extends AppCompatActivity {
 
     // lookup and set values of various text labels
     protected void setLabels() {
+        Log.d(threaded_application.applicationName, activityName + ": setLabels()");
 
         refreshRosterList();
         showMethod(prefSelectLocoMethod);
@@ -569,10 +573,12 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void handleMessage(Message msg) {
+            Log.d(threaded_application.applicationName, activityName + ": handleMessage(): " + msg);
+
             switch (msg.what) {
                 case message_type.RESPONSE:
                     String response_str = msg.obj.toString();
-                    Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): RESPONSE - message <--:" + response_str);
+                    Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): RESPONSE - message <--:" + response_str);
                     if (response_str.length() >= 3) {
                         String comA = response_str.substring(0, 3);
                         //update power icon
@@ -592,7 +598,7 @@ public class select_loco extends AppCompatActivity {
                                 setLabels();
                             break;
                         } else { // ignore everything else
-                            Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): RESPONSE - ignoring message: " + response_str);
+                            Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): RESPONSE - ignoring message: " + response_str);
                             break;
                         }
                     }
@@ -600,11 +606,11 @@ public class select_loco extends AppCompatActivity {
                         setLabels();
                     break;
                 case message_type.WIT_CON_RETRY:
-                    Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): WIT_CON_RETRY");
+                    Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): WIT_CON_RETRY");
                     witRetry(msg.obj.toString());
                     break;
                 case message_type.ROSTER_UPDATE:
-                    Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): ROSTER_UPDATE");
+                    Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): ROSTER_UPDATE");
                     setLabels();
                     showMethod(prefSelectLocoMethod);
                     break;
@@ -613,14 +619,14 @@ public class select_loco extends AppCompatActivity {
                         reopenThrottlePage();
                     break;
                 case message_type.WIT_CON_RECONNECT:
-                    Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): WIT_CON_RECONNECT");
+                    Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): WIT_CON_RECONNECT");
                     rosterListAdapter.notifyDataSetChanged();
                     setLabels();
                     break;
                 case message_type.RESTART_APP:
                 case message_type.RELAUNCH_APP:
                 case message_type.DISCONNECT:
-                    Log.d("Engine_Driver", "select_loco: SelectLocoHandler(): DISCONNECT");
+                    Log.d(threaded_application.applicationName, activityName + ": SelectLocoHandler(): DISCONNECT");
                     endThisActivity();
                     break;
             }
@@ -628,6 +634,7 @@ public class select_loco extends AppCompatActivity {
     }
 
     private void witRetry(String s) {
+        Log.d(threaded_application.applicationName, activityName + ": witRetry()");
         Intent in = new Intent().setClass(this, reconnect_status.class);
         in.putExtra("status", s);
         startActivity(in);
@@ -636,6 +643,7 @@ public class select_loco extends AppCompatActivity {
 
     // request release of specified throttle
     void releaseLoco(int whichThrottle) {
+        Log.d(threaded_application.applicationName, activityName + ": releaseLoco()");
         mainapp.storeThrottleLocosForReleaseDCCEX(whichThrottle);
         mainapp.consists[whichThrottle].release();
         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.RELEASE, "", whichThrottle); // pass 0, 1 or 2 in message
@@ -645,7 +653,7 @@ public class select_loco extends AppCompatActivity {
     boolean newEngine;              // save value across ConsistEdit activity
 
     void acquireLoco(boolean bUpdateList, int numberInConsist) { // if numberInConsist is greater than -1 it is not from the recent consists list
-        Log.d("Engine_Driver", "select_loco: acquireLoco()");
+        Log.d(threaded_application.applicationName, activityName + ": acquireLoco()");
         String roster_name = "";
         String sAddr = importExportPreferences.locoAddressToString(locoAddress, locoAddressSize, true);
         Loco l = new Loco(sAddr);
@@ -662,9 +670,9 @@ public class select_loco extends AppCompatActivity {
         }
         if (mainapp.consists == null || mainapp.consists[whichThrottle] == null) {
             if (mainapp.consists == null)
-                Log.d("Engine_Driver", "select_loco: acquireLoco(): consists is null");
+                Log.d(threaded_application.applicationName, activityName + ": acquireLoco(): consists is null");
             else if (mainapp.consists[whichThrottle] == null)
-                Log.d("Engine_Driver", "select_loco: acquireLoco(): consists[" + whichThrottle + "] is null");
+                Log.d(threaded_application.applicationName, activityName + ": acquireLoco(): consists[" + whichThrottle + "] is null");
             endThisActivity();
             return;
         }
@@ -699,7 +707,7 @@ public class select_loco extends AppCompatActivity {
                 return;
             }
         }
-        Log.d("Engine_Driver", "select_loco: acquireLoco(): sAddr:'" + sAddr +"'");
+        Log.d(threaded_application.applicationName, activityName + ": acquireLoco(): sAddr:'" + sAddr +"'");
 
         if ((!consist.isActive()) && (numberInConsist < 1)) {               // if this is the only loco in consist then just tell WiT and exit
             consist.add(l);
@@ -748,7 +756,7 @@ public class select_loco extends AppCompatActivity {
     }
 
     void processRosterFunctionString(String responseStr, int whichThrottle) {
-        Log.d("Engine_Driver", "select_loco: processRosterFunctionString(): processing function labels for " + mainapp.throttleIntToString(whichThrottle));
+        Log.d(threaded_application.applicationName, activityName + ": processRosterFunctionString(): processing function labels for " + mainapp.throttleIntToString(whichThrottle));
         LinkedHashMap<Integer, String> functionLabelsMap = threaded_application.parseFunctionLabels(responseStr);
         mainapp.function_labels[whichThrottle] = functionLabelsMap; //set the appropriate global variable from the temp
     }
@@ -786,7 +794,7 @@ public class select_loco extends AppCompatActivity {
                     try {
                         image_file = new File(imgpath);
                     } catch (Exception e) {    // isBackward returns null if address is not in consist - should not happen since address was selected from consist list
-                        Log.d("Engine_Driver", "select_loco: onActivityResult(): Load image failed : " + imgpath);
+                        Log.d(threaded_application.applicationName, activityName + ": onActivityResult(): Load image failed : " + imgpath);
                     }
                     if ( (image_file != null) && (image_file.exists()) ) {
                         try {
@@ -856,7 +864,7 @@ public class select_loco extends AppCompatActivity {
         }
     }
     private void imageFileFoundButCannotBeLoaded() {
-        Log.d("Engine_Driver", "select_loco: onActivityResult(): load image - image file found but could not loaded");
+        Log.d(threaded_application.applicationName, activityName + ": onActivityResult(): load image - image file found but could not loaded");
     }
 
     /** @noinspection SameParameterValue*/ //write the recent locos to a file
@@ -872,8 +880,8 @@ public class select_loco extends AppCompatActivity {
             // check if it is already in the list and remove it
             String keepFunctions = "";
             for (int i = 0; i < importExportPreferences.recentLocoAddressList.size(); i++) {
-                Log.d("Engine_Driver", "select_loco: saveRecentLocosList(): vLocoName='"+locoName+"', address="+locoAddress+", size="+locoAddressSize);
-                Log.d("Engine_Driver", "select_loco: saveRecentLocosList(): sLocoName='"+importExportPreferences.recentLocoNameList.get(i)
+                Log.d(threaded_application.applicationName, activityName + ": saveRecentLocosList(): vLocoName='"+locoName+"', address="+locoAddress+", size="+locoAddressSize);
+                Log.d(threaded_application.applicationName, activityName + ": saveRecentLocosList(): sLocoName='"+importExportPreferences.recentLocoNameList.get(i)
                         + "', address=" + importExportPreferences.recentLocoAddressList.get(i)
                         + ", size="+importExportPreferences.recentLocoAddressSizeList.get(i));
                 if (locoAddress == importExportPreferences.recentLocoAddressList.get(i)
@@ -884,7 +892,7 @@ public class select_loco extends AppCompatActivity {
                     if ( (i==0) && (!keepFunctions.isEmpty()) ) { return; } // if it already at the start of the list, don't do anything
 
                     importExportPreferences.removeRecentLocoFromList(i);
-                    Log.d("Engine_Driver", "select_loco: saveRecentLocosList(): Loco '"+ locoName + "' removed from Recents");
+                    Log.d(threaded_application.applicationName, activityName + ": saveRecentLocosList(): Loco '"+ locoName + "' removed from Recents");
                     break;
                 }
             }
@@ -892,13 +900,14 @@ public class select_loco extends AppCompatActivity {
             // now append it to the beginning of the list
             importExportPreferences.addRecentLocoToList(0, locoAddress, locoAddressSize, locoName, source_type.ROSTER, keepFunctions);
 
-            Log.d("Engine_Driver", "select_loco: saveRecentLocosList(): Loco '"+ locoName + "' added to Recents");
+            Log.d(threaded_application.applicationName, activityName + ": saveRecentLocosList(): Loco '"+ locoName + "' added to Recents");
         }
 
         importExportPreferences.writeRecentLocosListToFile(prefs);
     }
 
     private void refreshRecentLocosList(boolean reload) {
+        Log.d(threaded_application.applicationName, activityName + ": refreshRecentLocosList()");
         importExportPreferences.recentLocoAddressList = new ArrayList<>();
         importExportPreferences.recentLocoAddressSizeList = new ArrayList<>();
         importExportPreferences.recentLocoNameList = new ArrayList<>();
@@ -989,6 +998,7 @@ public class select_loco extends AppCompatActivity {
 
 
     private void refreshRecentConsistsList(boolean reload) {
+        Log.d(threaded_application.applicationName, activityName + ": refreshRecentConsistsList()");
         RadioButton myRadioButton = findViewById(R.id.select_consists_method_recent_button);
 
         if (reload) {
@@ -1153,6 +1163,7 @@ public class select_loco extends AppCompatActivity {
     // listener for the Acquire button when entering a DCC Address
     public class AcquireButtonListener implements View.OnClickListener {
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": AcquireButtonListener(): onClick()");
             EditText entry = findViewById(R.id.loco_address);
             try {
                 locoAddress = Integer.parseInt(entry.getText().toString());
@@ -1167,7 +1178,7 @@ public class select_loco extends AppCompatActivity {
             locoSource = source_type.ADDRESS;
 
             acquireLoco(true, -1);
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             mainapp.buttonVibration();
         }
     }
@@ -1175,11 +1186,12 @@ public class select_loco extends AppCompatActivity {
     // listener for the ID 'n' Go button, when clicked, send the id request and return to Throttle
     public class IdngoButtonListener implements View.OnClickListener {
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": IdngoButtonListener(): onClick()");
             Consist consist = mainapp.consists[whichThrottle];
             consist.setWaitingOnID(true);
             mainapp.sendMsg(mainapp.comm_msg_handler, message_type.REQ_LOCO_ADDR, "*", whichThrottle);
             result = RESULT_OK;
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             endThisActivity();
             mainapp.buttonVibration();
         }
@@ -1193,11 +1205,12 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": ReleaseButtonListener(): onClick()");
             mainapp.buttonVibration();
 
             releaseLoco(_throttle);
             overrideThrottleName = "";
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             endThisActivity();
             mainapp.buttonVibration();
         }
@@ -1213,11 +1226,12 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": EditConsistButtonListener(): onClick()");
             Intent consistEdit = new Intent().setClass(_selectLocoActivity, ConsistEdit.class);
             consistEdit.putExtra("whichThrottle", mainapp.throttleIntToChar(whichThrottle));
             consistEdit.putExtra("saveConsistsFile", 'Y');
 
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             startActivityForResult(consistEdit, sub_activity_type.CONSIST);
             connection_activity.overridePendingTransition(_selectLocoActivity, R.anim.fade_in, R.anim.fade_out);
             mainapp.buttonVibration();
@@ -1234,10 +1248,11 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": EditConsistLightsButtonListener(): onClick()");
             Intent consistLightsEdit = new Intent().setClass(_selectLocoActivity, ConsistLightsEdit.class);
             consistLightsEdit.putExtra("whichThrottle", mainapp.throttleIntToChar(whichThrottle));
 
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             startActivityForResult(consistLightsEdit, sub_activity_type.CONSIST_LIGHTS);
             connection_activity.overridePendingTransition(_selectLocoActivity, R.anim.fade_in, R.anim.fade_out);
             mainapp.buttonVibration();
@@ -1253,6 +1268,7 @@ public class select_loco extends AppCompatActivity {
             DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
                 //@Override
                 public void onClick(DialogInterface dialog, int which) {
+                    Log.d(threaded_application.applicationName, activityName + ": DownloadRosterButtonListener(): onClick()");
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
 //                            downloadRosterToRecents();
@@ -1323,6 +1339,7 @@ public class select_loco extends AppCompatActivity {
         SortRecentConsistsButtonListener() {}
 
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": SortRecentConsistsButtonListener(): onClick()");
             switch (mainapp.recentConsistsOrder) {
                 case sort_type.NAME:
                     mainapp.recentConsistsOrder=sort_type.ID;
@@ -1349,11 +1366,12 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void onClick(View v) {
+            Log.d(threaded_application.applicationName, activityName + ": DeviceSoundsButtonListener(): onClick()");
             Intent deviceSounds = new Intent().setClass(_selectLocoActivity, device_sounds_settings.class);
             startActivityForResult(deviceSounds, ACTIVITY_DEVICE_SOUNDS_SETTINGS);
             connection_activity.overridePendingTransition(_selectLocoActivity, R.anim.fade_in, R.anim.fade_out);
             result = RESULT_OK;
-            hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
             endThisActivity();
             mainapp.buttonVibration();
         }
@@ -1363,6 +1381,7 @@ public class select_loco extends AppCompatActivity {
     public class RecentLocosItemListener implements AdapterView.OnItemClickListener {
         // When an item is clicked, acquire that engine.
         public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
+            Log.d(threaded_application.applicationName, activityName + ": RecentLocosItemListener(): onItemClick()");
             if (position >= recentLocosList.size()) return;
 
             if (recentsSwipeDetector.swipeDetected()) {
@@ -1405,6 +1424,7 @@ public class select_loco extends AppCompatActivity {
     public class RecentConsistItemListener implements AdapterView.OnItemClickListener {
         // When an item is clicked, acquire that consist.
         public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
+            Log.d(threaded_application.applicationName, activityName + ": RecentConsistItemListener(): onItemClick()");
             if (position >= recentConsistsList.size()) return;
 
             String sAddr;
@@ -1457,7 +1477,7 @@ public class select_loco extends AppCompatActivity {
 
                 result = RESULT_LOCO_EDIT;
                 mainapp.buttonVibration();
-                hideSoftKeyboard(v);
+                mainapp.hideSoftKeyboard(v, activityName);
                 endThisActivity();
             }
         }
@@ -1470,6 +1490,7 @@ public class select_loco extends AppCompatActivity {
             DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
                 //@Override
                 public void onClick(DialogInterface dialog, int which) {
+                    Log.d(threaded_application.applicationName, activityName + ": ClearLocoListButtonListner(): onClick()");
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
                             clearList();
@@ -1497,6 +1518,7 @@ public class select_loco extends AppCompatActivity {
             DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
                 //@Override
                 public void onClick(DialogInterface dialog, int which) {
+                    Log.d(threaded_application.applicationName, activityName + ": ClearConsistsListButtonListener(): onClick()");
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
                             clearConsistsList();
@@ -1523,6 +1545,7 @@ public class select_loco extends AppCompatActivity {
             AdapterView.OnItemClickListener {
         // When a roster item is clicked, send request to acquire that engine.
         public void onItemClick(AdapterView<?> parent, View v, int position, long id) {
+            Log.d(threaded_application.applicationName, activityName + ": RosterItemClickListener(): onItemClick()");
             //use clicked position in list to retrieve roster item object from roster_list
             HashMap<String, String> hm = rosterList.get(position);
             String rosterNameString = hm.get("roster_name");
@@ -1565,7 +1588,7 @@ public class select_loco extends AppCompatActivity {
 
                 overrideThrottleName = rosterNameString;
                 acquireLoco(bRosterRecent, -1);
-                hideSoftKeyboard(v);
+                mainapp.hideSoftKeyboard(v, activityName);
                 mainapp.buttonVibration();
             }
         }
@@ -1573,6 +1596,7 @@ public class select_loco extends AppCompatActivity {
 
     @SuppressLint("ApplySharedPref")
     private void filterRoster() {
+        Log.d(threaded_application.applicationName, activityName + ": filterRoster()");
         prefRosterFilter = filterRosterText.getText().toString().trim();
         prefs.edit().putString("prefRosterFilter", prefRosterFilter).commit();
         refreshRosterList();
@@ -1582,6 +1606,7 @@ public class select_loco extends AppCompatActivity {
     // Handle pressing of the back button to simply return to caller
     @Override
     public boolean onKeyDown(int key, KeyEvent event) {
+        Log.d(threaded_application.applicationName, activityName + ": onKeyDown()");
         mainapp.exitDoubleBackButtonInitiated = 0;
         if (key == KeyEvent.KEYCODE_BACK) {
             overrideThrottleName = "";
@@ -1597,6 +1622,7 @@ public class select_loco extends AppCompatActivity {
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        Log.d(threaded_application.applicationName, activityName + ": onCreate()");
 
         super.onCreate(savedInstanceState);
         mainapp = (threaded_application) getApplication();
@@ -1758,7 +1784,7 @@ public class select_loco extends AppCompatActivity {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 if ((actionId & EditorInfo.IME_MASK_ACTION) != 0) {
-                    hideSoftKeyboard(v);
+                    mainapp.hideSoftKeyboard(v, activityName);
                     return true;
                 } else
                     return false;
@@ -1906,6 +1932,7 @@ public class select_loco extends AppCompatActivity {
                     getApplicationContext().getResources().getString(R.string.app_name_select_loco),
                     "" );
         }
+        Log.d(threaded_application.applicationName, activityName + ": onCreate() end");
     } //end OnCreate
 
     private final Runnable showMethodTask = new Runnable() {
@@ -1916,6 +1943,7 @@ public class select_loco extends AppCompatActivity {
 
     @SuppressLint("ApplySharedPref")
     private void showMethod(String whichMethod) {
+        Log.d(threaded_application.applicationName, activityName + ": showMethod()");
         checkValidMethod(whichMethod);
 
         selectLocoMethodRadioButtonsGroup.setVisibility(prefSelectLocoByRadioButtons ? VISIBLE : GONE);
@@ -1979,7 +2007,7 @@ public class select_loco extends AppCompatActivity {
                     mainapp.safeToastInstructional(R.string.toastRosterHelp, Toast.LENGTH_LONG);
                     mainapp.shownToastRoster = true;
                 }
-                hideSoftKeyboard(rbAddress);
+                mainapp.hideSoftKeyboard(rbAddress, activityName);
                 break;
             }
             case select_loco_method_type.RECENT_LOCOS: {
@@ -1988,7 +2016,7 @@ public class select_loco extends AppCompatActivity {
                 rbRecent.setChecked(true);
                 selectMethodButton[2].setSelected(true);
                 mainapp.shownToastRecentLocos = mainapp.safeToastInstructionalShowOnce(R.string.toastRecentsHelp, Toast.LENGTH_LONG, mainapp.shownToastRecentLocos);
-                hideSoftKeyboard(rbAddress);
+                mainapp.hideSoftKeyboard(rbAddress, activityName);
                 break;
             }
             case select_loco_method_type.RECENT_CONSISTS: {
@@ -1997,14 +2025,14 @@ public class select_loco extends AppCompatActivity {
                 rbRecentConsists.setChecked(true);
                 selectMethodButton[3].setSelected(true);
                 mainapp.shownToastRecentConsists = mainapp.safeToastInstructionalShowOnce(R.string.toastRecentConsistsHelp, Toast.LENGTH_LONG, mainapp.shownToastRecentConsists);
-                hideSoftKeyboard(rbAddress);
+                mainapp.hideSoftKeyboard(rbAddress, activityName);
                 break;
             }
             case select_loco_method_type.IDNGO: {
                 rlIDnGo.setVisibility(View.VISIBLE);
                 rbIDnGo.setChecked(true);
                 selectMethodButton[4].setSelected(true);
-                hideSoftKeyboard(rbAddress);
+                mainapp.hideSoftKeyboard(rbAddress, activityName);
                 break;
             }
             case select_loco_method_type.ADDRESS:
@@ -2013,7 +2041,7 @@ public class select_loco extends AppCompatActivity {
                 dccAddressHelpText.setVisibility(View.VISIBLE);
                 rbAddress.setChecked(true);
                 selectMethodButton[0].setSelected(true);
-                hideSoftKeyboard(dccAddressLayout);
+                mainapp.hideSoftKeyboard(dccAddressLayout, activityName);
                 break;
             }
         }
@@ -2027,6 +2055,7 @@ public class select_loco extends AppCompatActivity {
 
     //Clears recent connection list of locos
     public void clearList() {
+        Log.d(threaded_application.applicationName, activityName + ": clearList()");
         File engineListFile = new File(context.getExternalFilesDir(null), "recent_engine_list.txt");
 
         if (engineListFile.exists()) {
@@ -2037,6 +2066,7 @@ public class select_loco extends AppCompatActivity {
     } // end clearList()
 
     public void clearConsistsList() {
+        Log.d(threaded_application.applicationName, activityName + ": clearConsistsList()");
         File consists_list_file = new File(context.getExternalFilesDir(null), "recent_consist_list.txt");
 
         if (consists_list_file.exists()) {
@@ -2053,9 +2083,18 @@ public class select_loco extends AppCompatActivity {
     } // end clearConsistsList()
 
     @Override
+    public void onPause() {
+        Log.d(threaded_application.applicationName, activityName + ": onPause():");
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "select_loco: onResume():");
+        Log.d(threaded_application.applicationName, activityName + ": onResume():");
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.SELECT_LOCO;
         if (mainapp.isForcingFinish()) {     //expedite
             this.finish();
@@ -2078,10 +2117,12 @@ public class select_loco extends AppCompatActivity {
             mainapp.displayPowerStateMenuButton(SMenu);
             mainapp.setPowerStateButton(SMenu);
         }
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): end");
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
+        Log.d(threaded_application.applicationName, activityName + ": onWindowFocusChanged():");
         super.onWindowFocusChanged(hasFocus);
 
         // adjust the current locos list if needed
@@ -2091,19 +2132,20 @@ public class select_loco extends AppCompatActivity {
 
     @Override
     public void onDestroy() {
-        Log.d("Engine_Driver", "select_loco: onDestroy(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy(): called");
         super.onDestroy();
 
         if (mainapp.select_loco_msg_handler != null) {
             mainapp.select_loco_msg_handler.removeCallbacksAndMessages(null);
             mainapp.select_loco_msg_handler = null;
         } else {
-            Log.d("Engine_Driver", "select_loco: onDestroy(): mainapp.select_loco_msg_handler is null. Unable to removeCallbacksAndMessages");
+            Log.d(threaded_application.applicationName, activityName + ": onDestroy(): mainapp.select_loco_msg_handler is null. Unable to removeCallbacksAndMessages");
         }
     } // end onDestroy()
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
+//        Log.d(threaded_application.applicationName, activityName + ": onCreateOptionsMenu()");
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.select_loco_menu, menu);
         SMenu = menu;
@@ -2118,6 +2160,7 @@ public class select_loco extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        Log.d(threaded_application.applicationName, activityName + ": onOptionsItemSelected():");
         // Handle all of the possible menu actions.
         if (item.getItemId() == R.id.EmerStop) {
             mainapp.sendEStopMsg();
@@ -2142,7 +2185,8 @@ public class select_loco extends AppCompatActivity {
 
     // end current activity
     void endThisActivity() {
-        Log.d("Engine_Driver", "select_loco: endThisActivity(): ending select_loco normally");
+        threaded_application.activityInTransition(activityName);
+        Log.d(threaded_application.applicationName, activityName + ": endThisActivity(): ending select_loco normally");
         Intent resultIntent = new Intent();
         resultIntent.putExtra("whichThrottle", sWhichThrottle.charAt(0));  //pass whichThrottle as an extra
         resultIntent.putExtra("overrideThrottleName", overrideThrottleName);
@@ -2210,8 +2254,8 @@ public class select_loco extends AppCompatActivity {
     }
 
     protected void showRosterDetailsDialog(RosterEntry re, String rosterNameString, String rosterAddressString, String iconURL) {
+//        Log.d(threaded_application.applicationName, activityName + ": showRosterDetailsDialog(): Showing details for roster entry " + rosterNameString);
         String res;
-        Log.d("Engine_Driver", "select_loco: showRosterDetailsDialog(): Showing details for roster entry " + rosterNameString);
         final Dialog dialog = new Dialog(select_loco.this, mainapp.getSelectedTheme());
         dialog.setTitle(getApplicationContext().getResources().getString(R.string.rosterDetailsDialogTitle) + rosterNameString);
         dialog.setContentView(R.layout.roster_entry);
@@ -2296,7 +2340,7 @@ public class select_loco extends AppCompatActivity {
                 re = mainapp.rosterJmriWeb.get(rosterEntryName);
             }
             if (re == null) {
-                Log.w("Engine_Driver", "select_loco: onLongRecentListItemClick(): Roster entry " + rosterEntryName + " not available.");
+                Log.w(threaded_application.applicationName, activityName + ": onLongRecentListItemClick(): Roster entry " + rosterEntryName + " not available.");
                 return true;
             }
             showRosterDetailsDialog(re, rosterEntryName, Integer.toString(rosterEntryAddress),"");
@@ -2308,6 +2352,7 @@ public class select_loco extends AppCompatActivity {
 
     //  Clears the entry from the list
     protected void clearRecentLocosListItem(final int onScreenPosition) {
+//        Log.d(threaded_application.applicationName, activityName + ": clearRecentLocosListItem()");
         if (onScreenPosition >= recentLocosList.size()) return;
 
         HashMap<String, String> hm = recentLocosList.get(onScreenPosition);
@@ -2349,6 +2394,7 @@ public class select_loco extends AppCompatActivity {
 
     // Clears the entry from the list
     protected void clearRecentConsistsListItem(final int onScreenPosition) {
+//        Log.d(threaded_application.applicationName, activityName + ": clearRecentConsistsListItem()");
         if (onScreenPosition >= recentConsistsList.size()) return;
 
         HashMap<String, String> hm = recentConsistsList.get(onScreenPosition);
@@ -2395,6 +2441,7 @@ public class select_loco extends AppCompatActivity {
 
         @SuppressLint("InflateParams")
         public View getView(int position, View convertView, ViewGroup parent) {
+            Log.d(threaded_application.applicationName, activityName + ": RosterSimpleAdapter(): getView()");
             if (position < 0 || position >= rosterList.size())
                 return convertView;
 
@@ -2450,6 +2497,7 @@ public class select_loco extends AppCompatActivity {
 
         @SuppressLint("InflateParams")
         public View getView(int position, View convertView, ViewGroup parent) {
+//            Log.d(threaded_application.applicationName, activityName + ": RecentSimpleAdapter(): getView()");
             if (position >= recentLocosList.size())
                 return convertView;
 
@@ -2486,6 +2534,7 @@ public class select_loco extends AppCompatActivity {
     }
 
     private void loadRosterOrRecentImage(String engineName, ImageView imageView, String iconURL) {
+//        Log.d(threaded_application.applicationName, activityName + ": loadRosterOrRecentImage()");
         //see if there is a saved file and preload it, even if it gets written over later
         boolean foundSavedImage = false;
         String imgFileName = mainapp.fixFilename(engineName) + ".png";
@@ -2495,7 +2544,7 @@ public class select_loco extends AppCompatActivity {
                 imageView.setImageBitmap(BitmapFactory.decodeFile(image_file.getPath()));
                 foundSavedImage = true;
             } catch (Exception e) {
-                Log.d("Engine_Driver", "select_loco: loadRosterOrRecentImage(): recent consists - image file found but could not loaded");
+                Log.d(threaded_application.applicationName, activityName + ": loadRosterOrRecentImage(): recent consists - image file found but could not loaded");
             }
         }
         hasLocalRosterImage = foundSavedImage;
@@ -2524,6 +2573,7 @@ public class select_loco extends AppCompatActivity {
 
         @SuppressLint("InflateParams")
         public View getView(int position, View convertView, ViewGroup parent) {
+//            Log.d(threaded_application.applicationName, activityName + ": RecentConsistsSimpleAdapter(): getView()");
             if (position >= recentConsistsList.size())
                 return convertView;
 
@@ -2643,6 +2693,7 @@ public class select_loco extends AppCompatActivity {
     // used to support the gamepad only   DPAD and key events
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent()");
 //        InputDevice idev = getDevice(event.getDeviceId());
         boolean rslt = mainapp.implDispatchKeyEvent(event);
         if (rslt) {
@@ -2705,10 +2756,11 @@ public class select_loco extends AppCompatActivity {
     }
 
     private void unableToSaveLocoImage() {
-        Log.d("Engine_Driver", "select_loco: writeLocoImageToFile(): Unable to save roster loco image");
+        Log.d(threaded_application.applicationName, activityName + ": writeLocoImageToFile(): Unable to save roster loco image");
     }
 
     private boolean deleteLocoImageFile(String rosterNameString) {
+//        Log.d(threaded_application.applicationName, activityName + ": deleteLocoImageFile()");
         try {
             File dir = new File(context.getExternalFilesDir(null), RECENT_LOCO_DIR);
             if (!dir.exists()) {
@@ -2733,7 +2785,7 @@ public class select_loco extends AppCompatActivity {
     }
 
     private void unableToDeleteLocoImage() {
-        Log.d("Engine_Driver", "select_loco: deleteLocoImageFile(): Unable to delete roster loco image");
+        Log.d(threaded_application.applicationName, activityName + ": deleteLocoImageFile(): Unable to delete roster loco image");
     }
 
 //    private void cropLocoImage() {
@@ -2774,22 +2826,11 @@ public class select_loco extends AppCompatActivity {
         return degree;
     }
 
-    public void hideSoftKeyboard(View view) {
-        // Check if no view has focus:
-        if (view != null) {
-            try {
-                InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
-            } catch (Exception e) {
-                Log.e("Engine_Driver", "select_loco: hideSoftKeyboard(): unable to hide the soft keyboard");
-            }
-        }
-    }
-
     public class OwnersFilterSpinnerListener implements AdapterView.OnItemSelectedListener {
         @SuppressLint("ApplySharedPref")
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            Log.d(threaded_application.applicationName, activityName + ": OwnersFilterSpinnerListener(): onItemSelected()");
             Spinner spinner = findViewById(R.id.roster_filter_owner);
             rosterOwnersFilterIndex = spinner.getSelectedItemPosition();
             rosterOwnersFilter = spinner.getSelectedItem().toString();
@@ -2805,6 +2846,7 @@ public class select_loco extends AppCompatActivity {
     public class SelectLocoMethodIndexSpinnerListener implements AdapterView.OnItemSelectedListener {
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            Log.d(threaded_application.applicationName, activityName + ": SelectLocoMethodIndexSpinnerListener(): onItemSelected()");
             selectLocoMethodIndex = selectLocoMethodSpinner.getSelectedItemPosition();
             showMethod(Integer.toString(selectLocoMethodIndex+1));
         }
@@ -2821,13 +2863,15 @@ public class select_loco extends AppCompatActivity {
         }
 
         public void onClick(View v) {
+//            Log.d(threaded_application.applicationName, activityName + ": SelectMethodButtonListener(): onClick()");
             mainapp.buttonVibration();
             showMethod(myMethod);
-            mainapp.hideSoftKeyboard(v);
+            mainapp.hideSoftKeyboard(v, activityName);
         }
     }
 
     void reopenThrottlePage() {
+        Log.d(threaded_application.applicationName, activityName + ": reopenThrottlePage()");
         endThisActivity();
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -122,6 +122,9 @@ import jmri.jmrit.roster.RosterLoader;
 //This thread will only act upon messages sent to it. The network communication needs to persist across activities, so that is why
 @SuppressLint("NewApi")
 public class threaded_application extends Application {
+    public static final String applicationName = "Engine_Driver";
+    public static final String activityName = "t_a";
+
     public static String INTRO_VERSION = "10";  // set this to a different string to force the intro to run on next startup.
 
     private final threaded_application mainapp = this;
@@ -484,6 +487,30 @@ public class threaded_application extends Application {
     public String witCvValue = "";
     public String witAddress = "";
 
+    static boolean activityVisible = false;
+    static boolean activityInTransition = false;
+
+    public static boolean isActivityVisible() {
+        Log.d(applicationName, "t_a: isActivityVisible(): " + ((activityVisible || activityInTransition) ? "True" : "False"));
+        return activityVisible || activityInTransition;
+    }
+
+    public static void activityResumed(String activityName) {
+        activityVisible = true;
+        activityInTransition = false;
+        Log.d(applicationName, "t_a: activityResumed("+activityName+")");
+    }
+
+    public static void activityPaused(String activityName) {
+        activityVisible = false;
+        Log.d(applicationName, "t_a: activityPaused("+activityName+")");
+    }
+
+    public static void activityInTransition(String activityName) {
+        activityInTransition = true;
+        Log.d(applicationName, "t_a: activityInTransition("+activityName+")");
+    }
+
     /**
      * Display OnGoing Notification that indicates EngineDriver is Running.
      * Should only be called when ED is going into the background.
@@ -554,14 +581,14 @@ public class threaded_application extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Log.d("Engine_Driver", "t_a: onCreate()");
+        Log.d(applicationName, "t_a: onCreate()");
         try {
             appVersion = "v" + getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException ignored) {
         }
         androidVersion = android.os.Build.VERSION.SDK_INT;
 
-        Log.i("Engine_Driver", "Engine Driver:" + appVersion + ", SDK:" + androidVersion);
+        Log.i(applicationName, "Engine Driver:" + appVersion + ", SDK:" + androidVersion);
 
         context = getApplicationContext();
 
@@ -670,7 +697,7 @@ public class threaded_application extends Application {
 
         @Override
         public void onTrimMemory(int level) {
-            Log.d("Engine_Driver", "t_a: onTrimMemory(): " + level);
+            Log.d(applicationName, "t_a: onTrimMemory(): " + level);
             if (level >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {   // if in background
                 if (!isInBackground) {                              // if just went into bkg
                     isInBackground = true;
@@ -681,9 +708,11 @@ public class threaded_application extends Application {
                 }
                 if (level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE) { // time to kill app
                     if (!exitConfirmed) {       // if TA is running in bkg
-                        // disconnect and shutdown
-                        sendMsg(comm_msg_handler, message_type.DISCONNECT, "", 1);
-                        exitConfirmed = true;
+                        if (!isActivityVisible()) {   // double check it is in background
+                            // disconnect and shutdown
+                            sendMsg(comm_msg_handler, message_type.DISCONNECT, "", 1);
+                            exitConfirmed = true;
+                        }
                     }
                 }
             }
@@ -775,9 +804,9 @@ public class threaded_application extends Application {
                 }
             }
         } catch (IOException except) {
-            Log.e("settings_activity", "Could not read file, error: " + except.getMessage());
+            Log.e(applicationName, activityName + ": Could not read file, error: " + except.getMessage());
         } catch (NumberFormatException except) {
-            Log.e("settings_activity", "NumberFormatException reading function_settings file: " + except.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": set_default_function_labels(): NumberFormatException reading function_settings file: " + except.getMessage());
         }
 
     }
@@ -788,9 +817,9 @@ public class threaded_application extends Application {
         void runMethod(Download dl) throws IOException {
             String rosterUrl = createUrl("roster/?format=xml");
             HashMap<String, RosterEntry> rosterTemp;
-            if (rosterUrl == null || rosterUrl.equals("") || dl.cancel)
+            if (rosterUrl == null || rosterUrl.isEmpty() || dl.cancel)
                 return;
-            Log.d("Engine_Driver", "t_a: Background loading roster from " + rosterUrl);
+            Log.d(applicationName, "t_a: Background loading roster from " + rosterUrl);
             int rosterSize;
             try {
                 RosterLoader rl = new RosterLoader(rosterUrl);
@@ -798,7 +827,7 @@ public class threaded_application extends Application {
                     return;
                 rosterTemp = rl.parse();
                 if (rosterTemp == null) {
-                    Log.w("Engine_Driver", "t_a: Roster parse failed.");
+                    Log.w(applicationName, "t_a: Roster parse failed.");
                     return;
                 }
                 rosterSize = rosterTemp.size();     //throws exception if still null
@@ -807,7 +836,7 @@ public class threaded_application extends Application {
             } catch (Exception e) {
                 throw new IOException();
             }
-            Log.d("Engine_Driver", "t_a: Loaded " + rosterSize + " entries from /roster/?format=xml.");
+            Log.d(applicationName, "t_a: Loaded " + rosterSize + " entries from /roster/?format=xml.");
         }
     }
 
@@ -818,14 +847,14 @@ public class threaded_application extends Application {
 //            String metaUrl = createUrl("json/metadata");
 //            if (metaUrl == null || metaUrl.equals("") || dl.cancel)
 //                return;
-//            Log.d("Engine_Driver", "t_a: Background loading metadata from " + metaUrl);
+//            Log.d(applicationName, "t_a: Background loading metadata from " + metaUrl);
 //
 //            HttpClient Client = new DefaultHttpClient();
 //            HttpGet httpget = new HttpGet(metaUrl);
 //            ResponseHandler<String> responseHandler = new BasicResponseHandler();
 //            String jsonResponse;
 //            jsonResponse = Client.execute(httpget, responseHandler);
-//            Log.d("Engine_Driver", "t_a: Raw metadata retrieved: " + jsonResponse);
+//            Log.d(applicationName, "t_a: Raw metadata retrieved: " + jsonResponse);
 //
 //            HashMap<String, String> metadataTemp = new HashMap<>();
 //            try {
@@ -837,15 +866,15 @@ public class threaded_application extends Application {
 //                    metadataTemp.put(metadataName, metadataValue);
 //                }
 //            } catch (JSONException e) {
-//                Log.d("Engine_Driver", "t_a: exception trying to retrieve json metadata.");
+//                Log.d(applicationName, "t_a: exception trying to retrieve json metadata.");
 //            } catch (Exception e) {
 //                throw new IOException();
 //            }
 //            if (metadataTemp.size() == 0) {
-//                Log.d("Engine_Driver", "t_a: did not retrieve any json metadata entries.");
+//                Log.d(applicationName, "t_a: did not retrieve any json metadata entries.");
 //            } else {
 //                jmriMetadata = (HashMap<String, String>) metadataTemp.clone();  // save the metadata in global variable
-//                Log.d("Engine_Driver", "t_a: Loaded " + jmriMetadata.size() + " metadata entries from json web server.");
+//                Log.d(applicationName, "t_a: Loaded " + jmriMetadata.size() + " metadata entries from json web server.");
 //            }
 //        }
 //    }
@@ -863,20 +892,20 @@ public class threaded_application extends Application {
                 try {
                     runMethod(this);
                     if (!cancel) {
-                        Log.d("Engine_Driver", "t_a: sendMsg - message - ROSTER_UPDATE");
+                        Log.d(applicationName, "t_a: sendMsg - message - ROSTER_UPDATE");
                         sendMsg(comm_msg_handler, message_type.ROSTER_UPDATE);      //send message to alert other activities
                     }
                 } catch (Throwable t) {
-                    Log.d("Engine_Driver", "t_a: Data fetch failed: " + t.getMessage());
+                    Log.d(applicationName, "t_a: Data fetch failed: " + t.getMessage());
                 }
 
                 // background load of Data completed
                 finally {
                     if (cancel) {
-                        Log.d("Engine_Driver", "t_a: Data fetch cancelled");
+                        Log.d(applicationName, "t_a: Data fetch cancelled");
                     }
                 }
-                Log.d("Engine_Driver", "t_a: Data fetch ended");
+                Log.d(applicationName, "t_a: Data fetch ended");
             }
 
             Download() {
@@ -1144,7 +1173,7 @@ public class threaded_application extends Application {
             consist_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
             roster_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
         } catch (Exception e) {
-            Log.d("Engine_Driver", "t_a: initShared object create exception");
+            Log.d(applicationName, "t_a: initShared object create exception");
         }
         doFinish = false;
         turnouts_list_position = 0;
@@ -1505,7 +1534,7 @@ public class threaded_application extends Application {
             if (consists != null && consists[i] != null && consists[i].isActive()) {
                 sendMsg(comm_msg_handler, message_type.ESTOP, "", i);
                 EStopActivated = true;
-                Log.d("Engine_Driver", "t_a: EStop sent to server for " + i);
+                Log.d(applicationName, "t_a: EStop sent to server for " + i);
             }
         }
     }
@@ -1658,7 +1687,7 @@ public class threaded_application extends Application {
         int port = web_server_port;
         if (getServerType().equals("MRC")) {  //special case ignore any url passed-in if connected to MRC, as it does not forward
             defaultUrl = "";
-            Log.d("Engine_Driver", "t_a: ignoring web url for MRC");
+            Log.d(applicationName, "t_a: ignoring web url for MRC");
         }
         if ( (port > 0) || (defaultUrl.toLowerCase().startsWith("http")) ) {
             if (defaultUrl.toLowerCase().startsWith("http")) { //if url starts with http, use it as is
@@ -1731,7 +1760,7 @@ public class threaded_application extends Application {
     public void applyTheme(Activity activity, boolean isPreferences) {
         int selectedTheme = getSelectedTheme(isPreferences);
         activity.setTheme(selectedTheme);
-        Log.d("Engine_Driver", "t_a: applyTheme: " + selectedTheme);
+        Log.d(applicationName, "t_a: applyTheme: " + selectedTheme);
         theme = activity.getTheme();
 
     }
@@ -1797,7 +1826,7 @@ public class threaded_application extends Application {
             else if (to.equals("Portrait") && (co != ActivityInfo.SCREEN_ORIENTATION_PORTRAIT))
                 activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         } catch (Exception e) {
-            Log.e("Engine_Driver", "t_a: setActivityOrientation: Unable to change Orientation: " + e.getMessage());
+            Log.e(applicationName, "t_a: setActivityOrientation: Unable to change Orientation: " + e.getMessage());
         }
 
         webMenuSelected = false;  // reset after each check
@@ -1805,7 +1834,7 @@ public class threaded_application extends Application {
     }
 
     public void checkExit(final Activity activity) {
-        Log.d("Engine_Driver", "t_a: checkExit(1): ");
+        Log.d(applicationName, "t_a: checkExit(1): ");
         boolean prefDoubleBackButtonToExit = prefs.getBoolean("prefDoubleBackButtonToExit", getResources().getBoolean(R.bool.prefDoubleBackButtonToExitDefaultValue));
         if (!prefDoubleBackButtonToExit) {
             checkAskExit(activity, false);
@@ -1825,7 +1854,7 @@ public class threaded_application extends Application {
     }
 
     public void checkExit(final Activity activity, boolean forceFastDisconnect) {
-        Log.d("Engine_Driver", "t_a: checkExit(2): ");
+        Log.d(applicationName, "t_a: checkExit(2): ");
         boolean  prefDoubleBackButtonToExit = prefs.getBoolean("prefDoubleBackButtonToExit", getResources().getBoolean(R.bool.prefDoubleBackButtonToExitDefaultValue));
         if (!prefDoubleBackButtonToExit) {
             checkAskExit(activity, forceFastDisconnect);
@@ -1858,7 +1887,7 @@ public class threaded_application extends Application {
         b.setCancelable(true);
         b.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
-                Log.d("Engine_Driver", "t_a: checkAskExit(): onClick() ");
+                Log.d(applicationName, "t_a: checkAskExit(): onClick() ");
                 exitConfirmed = true;
                 if (!forceFastDisconnect) {
                     sendMsg(comm_msg_handler, message_type.DISCONNECT, "");  //trigger disconnect / shutdown sequence
@@ -1891,7 +1920,7 @@ public class threaded_application extends Application {
     @Override
     protected void attachBaseContext(Context base) {
         languageCountry = Locale.getDefault().getLanguage();
-        if (!Locale.getDefault().getCountry().equals("")) {
+        if (!Locale.getDefault().getCountry().isEmpty()) {
             languageCountry = languageCountry + "_" + Locale.getDefault().getCountry();
         }
         super.attachBaseContext(LocaleHelper.onAttach(base, languageCountry));
@@ -2087,11 +2116,11 @@ public class threaded_application extends Application {
                 break;
             default:
                 val = 0;
-                Log.d("debug", "t_a: throttleCharToInt: no match for argument " + cWhichThrottle);
+                Log.d(threaded_application.applicationName, "t_a: throttleCharToInt: no match for argument " + cWhichThrottle);
                 break;
         }
         if (val > maxThrottlesCurrentScreen)
-            Log.d("debug", "t_a: throttleCharToInt: argument exceeds max number of throttles for current screen " + cWhichThrottle);
+            Log.d(threaded_application.applicationName, "t_a: throttleCharToInt: argument exceeds max number of throttles for current screen " + cWhichThrottle);
         return val;
     }
 
@@ -2109,7 +2138,7 @@ public class threaded_application extends Application {
 
         String newValue = currentValue;
         //if name is blank or the default name, make it unique
-        if (currentValue.equals("") || currentValue.equals(defaultName)) {
+        if (currentValue.isEmpty() || currentValue.equals(defaultName)) {
             deviceId = mainapp.getFakeDeviceId();
             if (MobileControl2.isMobileControl2()) {
                 // Change default name for ESU MCII
@@ -2204,7 +2233,7 @@ public class threaded_application extends Application {
         safeToast(msg_txt, Toast.LENGTH_SHORT);
     }
     public static void safeToast(final String msg_txt, final int length) {
-        Log.d("Engine_Driver", "t_a: safeToast: " + msg_txt);
+        Log.d(applicationName, "t_a: safeToast: " + msg_txt);
         //need to do Toast() on the main thread so create a handler
         Handler h = new Handler(Looper.getMainLooper());
         h.post(new Runnable() {
@@ -2453,7 +2482,7 @@ public class threaded_application extends Application {
     }
 
     public void writeSharedPreferencesToFileIfAllowed() {
-        Log.d("Engine_Driver", "t_a: writeSharedPreferencesToFileIfAllowed: start");
+        Log.d(applicationName, "t_a: writeSharedPreferencesToFileIfAllowed: start");
         SharedPreferences sharedPreferences = getSharedPreferences("jmri.enginedriver_preferences", 0);
         String prefAutoImportExport = sharedPreferences.getString("prefAutoImportExport", threaded_application.context.getResources().getString(R.string.prefAutoImportExportDefaultValue));
 
@@ -2465,7 +2494,7 @@ public class threaded_application extends Application {
                     ImportExportPreferences importExportPreferences = new ImportExportPreferences();
                     importExportPreferences.writeSharedPreferencesToFile(threaded_application.context, sharedPreferences, exportedPreferencesFileName);
                 }
-                Log.d("Engine_Driver", "t_a: writeSharedPreferencesToFileIfAllowed: done");
+                Log.d(applicationName, "t_a: writeSharedPreferencesToFileIfAllowed: done");
             } else {
                 safeToast(R.string.toastConnectUnableToSavePref, Toast.LENGTH_LONG);
             }
@@ -2537,7 +2566,7 @@ public class threaded_application extends Application {
                 if ( (i==0) && (!keepFunctions.isEmpty()) ) { return; } // if it already at the start of the list, don't do anything
 
                 importExportPreferences.removeRecentLocoFromList(i);
-                Log.d("Engine_Driver", "t_a: addLocoToRecents: Loco '" + locoName + "' removed from Recents");
+                Log.d(applicationName, "t_a: addLocoToRecents: Loco '" + locoName + "' removed from Recents");
                 break;
             }
         }
@@ -2549,7 +2578,7 @@ public class threaded_application extends Application {
         importExportPreferences.addRecentLocoToList(0, locoAddress, locoAddressSize, locoName, source_type.ROSTER, keepFunctions);
 
         importExportPreferences.writeRecentLocosListToFile(prefs);
-        Log.d("Engine_Driver", "t_a: Loco '" + locoName + "' added to Recents");
+        Log.d(applicationName, "t_a: Loco '" + locoName + "' added to Recents");
 
     }
 
@@ -2563,7 +2592,7 @@ public class threaded_application extends Application {
                     && size.equals(importExportPreferences.recentLocoAddressSizeList.get(i))
                     && name.equals(importExportPreferences.recentLocoNameList.get(i))) {
                 position = i;
-                Log.d("Engine_Driver", "t_a: findLocoInRecents: Loco '" + name + "' found in Recents");
+                Log.d(applicationName, "t_a: findLocoInRecents: Loco '" + name + "' found in Recents");
                 break;
             }
         }
@@ -2601,7 +2630,7 @@ public class threaded_application extends Application {
                 Message msg = Message.obtain();
                 msg.what = message_type.RESTART_APP;
                 msg.arg1 = restart_reason_type.AUTO_IMPORT;
-                Log.d("Engine_Driver", "t_a: updateConnectionList: Reload of Server Preferences. Restart Requested: " + connectedHostName);
+                Log.d(applicationName, "t_a: updateConnectionList: Reload of Server Preferences. Restart Requested: " + connectedHostName);
                 comm_msg_handler.sendMessage(msg);
             } else {
 //                Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastConnectUnableToLoadPref), Toast.LENGTH_LONG).show();
@@ -2633,7 +2662,7 @@ public class threaded_application extends Application {
             if ((xSpeed - xLastSpeed >= 1) || (xLastSpeed - xSpeed >= 1)
                     || ((xSpeed == 0) && (xLastSpeed != 0))
                     || ((xSpeed == 126) && (xLastSpeed != 126))) {
-//                    Log.d("Engine_Driver", "t_a: haptic_test: " + "beep");
+//                    Log.d(applicationName, "t_a: haptic_test: " + "beep");
                 vibrate(prefHapticFeedbackDuration);
             }
         }
@@ -2753,10 +2782,19 @@ public class threaded_application extends Application {
     }
 
     public void hideSoftKeyboard(View view) {
+        hideSoftKeyboard(view, "unknown");
+    }
+    public void hideSoftKeyboard(View view, String activityName) {
+        Log.d(applicationName, "t_a: hideSoftKeyboard()");
+        activityInTransition(activityName);
         // Check if no view has focus:
         if (view != null) {
-            InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+            try {
+                InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+            } catch (Exception e) {
+                Log.e(applicationName, "select_loco: hideSoftKeyboard(): unable to hide the soft keyboard");
+            }
         }
     }
 
@@ -2766,7 +2804,7 @@ public class threaded_application extends Application {
     }
 
     public void stopAllSounds() {
-        Log.d("Engine_Driver", "t_a: stopAllSounds (locoSounds)");
+        Log.d(applicationName, "t_a: stopAllSounds (locoSounds)");
         if (soundPool != null) {
             for (int soundType = 0; soundType < 3; soundType++) {
                 for (int throttleIndex = 0; throttleIndex < 2; throttleIndex++) {
@@ -2800,7 +2838,7 @@ public class threaded_application extends Application {
 //                method = s.getMethodName();
 //            }
 //            if (doNext == 2) {
-//                Log.d("Engine_Driver", s.getMethodName() + "->" + method + ": " + label);
+//                Log.d(applicationName, s.getMethodName() + "->" + method + ": " + label);
 //                return;
 //            }
 //            if ((s.getMethodName().equals("getStackTrace")) || (doNext>0)) { doNext++; }
@@ -2921,7 +2959,7 @@ public class threaded_application extends Application {
 
     // listener for the joystick events
     public boolean implDispatchGenericMotionEvent(android.view.MotionEvent event) {
-        //Log.d("Engine_Driver", "dgme " + event.getAction());
+        //Log.d(applicationName, "dgme " + event.getAction());
         if ((!prefGamePadType.equals(threaded_application.WHICH_GAMEPAD_MODE_NONE)) && (!mainapp.prefGamePadIgnoreJoystick)) { // respond to the gamepad and keyboard inputs only if the preference is set
 
             int action;
@@ -3104,7 +3142,7 @@ public class threaded_application extends Application {
     public String getFakeDeviceId(boolean forceNewId) {
 //        return Settings.System.getString(getContentResolver(), Settings.Secure.ANDROID_ID);  // no longer permitted
         mainapp.deviceId = prefs.getString("prefAndroidId", "");
-        if ( (mainapp.deviceId.equals("")) || (forceNewId) ) {
+        if ( (mainapp.deviceId.isEmpty()) || (forceNewId) ) {
             Random rand = new Random();
             mainapp.deviceId = String.valueOf(rand.nextInt(999999)); //use random string
             prefs.edit().putString("prefAndroidId", deviceId).commit();

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -196,6 +196,7 @@ import jmri.enginedriver.type.acceleratorometer_action_type;
 import jmri.enginedriver.type.direction_type;
 
 public class throttle extends AppCompatActivity implements android.gesture.GestureOverlayView.OnGestureListener, PermissionsHelper.PermissionsHelperGrantedCallback {
+    static final String activityName = "throttle";
 
     protected threaded_application mainapp; // hold pointer to mainapp
     protected SharedPreferences prefs;
@@ -467,6 +468,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private float externalGamepadyAxis;
     private float externalGamepadxAxis2;
     private float externalGamepadyAxis2;
+
+    int keyboardStopCount = 0;
 
 //    protected MediaPlayer _mediaPlayer;
 
@@ -777,7 +780,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-//            Log.d("Engine_Driver", "RptUpdater: onProgressChanged - mAutoIncrement: " + mAutoIncrement + " mAutoDecrement: " + mAutoDecrement);
+//            Log.d(threaded_application.applicationName, activityName + ": RptUpdater: onProgressChanged - mAutoIncrement: " + mAutoIncrement + " mAutoDecrement: " + mAutoDecrement);
             if (mAutoIncrement[whichThrottle]) {
                 incrementSpeed(whichThrottle, speed_commands_from_type.BUTTONS);
                 repeatUpdateHandler.postDelayed(new RptUpdater(whichThrottle, REP_DELAY), REP_DELAY);
@@ -901,7 +904,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         public void handleMessage(Message msg) {
             String response_str = msg.obj.toString();
 
-//            Log.d("Engine_Driver", "throttle handleMessage " + response_str );
+//            Log.d(threaded_application.applicationName, activityName + " handleMessage() " + response_str );
 
             switch (msg.what) {
                 case message_type.RESPONSE: { // handle messages from WiThrottle server
@@ -979,7 +982,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                             } catch (
                                                     Exception e) {     // isReverseOfLead returns null if addr is not in con
                                                 // - should not happen unless WiT is reporting on engine user just dropped from ED consist?
-                                                Log.d("Engine_Driver", "throttle " + whichThrottle + " loco " + addr + " direction reported by WiT but engine is not assigned");
+                                                Log.d(threaded_application.applicationName, activityName + ": " + whichThrottle + " loco " + addr + " direction reported by WiT but engine is not assigned");
                                             }
                                         }
                                     } else if (com3 == 'V') { // set speed
@@ -1071,7 +1074,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 case message_type.REQUEST_REFRESH_THROTTLE:
 //                    refreshMenu();
                     set_labels();
-                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: REQUEST_REFRESH_THROTTLE");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleMessageHandler(): REQUEST_REFRESH_THROTTLE");
                     break;
                 case message_type.REFRESH_FUNCTIONS:
                     setAllFunctionLabelsAndListeners();
@@ -1148,7 +1151,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     kidsTimerActions(kids_timer_action_type.ENDED, 0);
                     break;
                 case message_type.IMPORT_SERVER_AUTO_AVAILABLE:
-                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: AUTO_IMPORT_URL_AVAILABLE " + response_str);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleMessageHandler(): AUTO_IMPORT_URL_AVAILABLE " + response_str);
                     autoImportUrlAskToImport();
                     break;
                 case message_type.SOUNDS_FORCE_LOCO_SOUNDS_TO_START:
@@ -1157,7 +1160,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     }
                     break;
                 case message_type.GAMEPAD_ACTION:
-                    Log.d("Engine_Driver", "throttle: ThrottleMessageHandler: GAMEPAD_ACTION " + response_str);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleMessageHandler(): GAMEPAD_ACTION " + response_str);
                     if (!response_str.isEmpty()) {
                         String[] splitString = response_str.split(":");
                         externalGamepadAction = Integer.parseInt(splitString[0]);
@@ -1171,7 +1174,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     }
                     break;
                 case message_type.VOLUME_BUTTON_ACTION: // volumem button n another activity
-                    Log.d("Engine_Driver", "throttle handleMessage VOLUMN_BUTTON_ACTION " + response_str);
+                    Log.d(threaded_application.applicationName, activityName + ": handleMessage(): VOLUME_BUTTON_ACTION " + response_str);
                     if (!response_str.isEmpty()) {
                         String[] splitString = response_str.split(":");
                         doVolumeButtonAction(Integer.parseInt(splitString[0]), Integer.parseInt(splitString[1]), Integer.parseInt(splitString[2]));
@@ -1179,7 +1182,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     break;
 
                 case message_type.GAMEPAD_JOYSTICK_ACTION:
-                    Log.d("Engine_Driver", "throttle handleMessage GAMEPAD_JOYSTICK_ACTION " + response_str);
+                    Log.d(threaded_application.applicationName, activityName + ": handleMessage(): GAMEPAD_JOYSTICK_ACTION " + response_str);
                     if (!response_str.isEmpty()) {
                         String[] splitString = response_str.split(":");
                         externalGamepadAction = Integer.parseInt(splitString[0]);
@@ -1214,6 +1217,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         isRestarting = true;        // tell OnDestroy to skip removing handlers since it will run after the new Intent is created
         removeHandlers();
 
+        threaded_application.activityInTransition(activityName);
         //end current throttle Intent then start the new Intent
         Intent newThrottle = mainapp.getThrottleIntent();
         this.finish();
@@ -1240,9 +1244,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
                 try {
                     Settings.System.putInt(mContext.getContentResolver(), Settings.System.SCREEN_BRIGHTNESS, brightnessValue);
-                    Log.d("Engine_Driver", "screen brightness successfully changed to " + brightnessValue);
+                    Log.d(threaded_application.applicationName, activityName + ": setScreenBrightness(): screen brightness successfully changed to " + brightnessValue);
                 } catch (Exception e) {
-                    Log.e("Engine_Driver", "screen brightness was NOT changed to " + brightnessValue);
+                    Log.e(threaded_application.applicationName, activityName + ": setScreenBrightness(): screen brightness was NOT changed to " + brightnessValue);
                 }
             } else {
                 WindowManager.LayoutParams lp = getWindow().getAttributes();
@@ -1448,7 +1452,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 speedUpdate(0);  // update all throttles
                                 applySpeedRelatedOptions();  // update all throttles
                                 if (IS_ESU_MCII) {
-                                    Log.d("Engine_Driver", "ESU_MCII: Move knob request for EStop");
+                                    Log.d(threaded_application.applicationName, activityName + ": setupSensor(): ESU_MCII: Move knob request for EStop");
                                     setEsuThrottleKnobPosition(whichVolume, 0);
                                 }
                         }
@@ -1815,7 +1819,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             sbs[whichThrottle].setProgress(speedWiT);
             // Now update ESU MCII Knob position
             if (IS_ESU_MCII) {
-                Log.d("Engine_Driver", "ESU_MCII: Move knob request for WiT speed report");
+                Log.d(threaded_application.applicationName, activityName + ": speedUpdateWiT(): ESU_MCII: Move knob request for WiT speed report");
                 setEsuThrottleKnobPosition(whichThrottle, speedWiT);
             }
         }
@@ -1889,7 +1893,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         int lastScaleSpeed = (int) Math.round(lastSpeed * displayUnitScale);
         int scaleSpeed = lastScaleSpeed + change;
         int speed = (int) Math.round(scaleSpeed / displayUnitScale);
-//        Log.d("Engine_Driver","throttle: speedChange -  change: " + change + " lastSpeed: " + lastSpeed+ " lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed:" + scaleSpeed);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange():  change: " + change + " lastSpeed: " + lastSpeed+ " lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed:" + scaleSpeed);
         if (lastScaleSpeed == scaleSpeed) {
             speed += (int) Math.signum(change);
         }
@@ -1902,7 +1906,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             speed = limitSpeedMax[whichThrottle];
         }
 
-//        Log.d("Engine_Driver","throttle: speedChange -  change: " + change + " speed: " + speed+ " scaleSpeed: " + scaleSpeed);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange():  change: " + change + " speed: " + speed+ " scaleSpeed: " + scaleSpeed);
 
         throttle_slider.setProgress(speed);
         doLocoSound(whichThrottle);
@@ -2148,7 +2152,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         sendSpeedMsg(whichThrottle, speed);
         // Now update ESU MCII Knob position
         if (IS_ESU_MCII && moveMc2Knob) {
-            Log.d("Engine_Driver", "ESU_MCII: Move knob request for speed update");
+            Log.d(threaded_application.applicationName, activityName + ": speedUpdateAndNotify(): ESU_MCII: Move knob request for speed update");
             setEsuThrottleKnobPosition(whichThrottle, speed);
         }
         doLocoSound(whichThrottle);
@@ -2163,7 +2167,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         sendSpeedMsg(whichThrottle, speed);
         // Now update ESU MCII Knob position
         if (IS_ESU_MCII) {
-            Log.d("Engine_Driver", "ESU_MCII: Move knob request for speed change");
+            Log.d(threaded_application.applicationName, activityName + ": speedChangeAndNotify(): ESU_MCII: Move knob request for speed change");
             setEsuThrottleKnobPosition(whichThrottle, speed);
         }
         doLocoSound(whichThrottle);
@@ -2186,7 +2190,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             speed_label.setText(Integer.toString(scaleSpeed));
             mainapp.throttleVibration(scaleSpeed, prevScaleSpeed);
         } catch (NumberFormatException | ClassCastException e) {
-            Log.e("Engine_Driver", "problem showing speed: " + e.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": setDisplayedSpeed(): problem showing speed: " + e.getMessage());
         }
     }
 
@@ -2302,7 +2306,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         mainapp.sendMsg(mainapp.comm_msg_handler, message_type.DIRECTION, addr, whichThrottle, locoDir);
                     } catch (
                             Exception e) { // isReverseOfLead returns null if addr is not in con - should never happen since we are walking through consist list
-                        Log.d("Engine_Driver", "throttle " + mainapp.throttleIntToString(whichThrottle) + " direction change for unselected loco " + addr);
+                        Log.d(threaded_application.applicationName, activityName + ": " + mainapp.throttleIntToString(whichThrottle) + " direction change for unselected loco " + addr);
                     }
                 }
             }
@@ -2477,7 +2481,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             startActivityForResult(select_loco, sub_activity_type.SELECT_LOCO);
             connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
         } catch (Exception ex) {
-            Log.d("Engine_Driver", "Throttle: start_select_loco_activity() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
+            Log.d(threaded_application.applicationName, activityName + ": start_select_loco_activity() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
         }
     }
 
@@ -2492,7 +2496,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 startActivityForResult(in, sub_activity_type.GAMEPAD_TEST);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             } catch (Exception ex) {
-                Log.d("Engine_Driver", "Throttle: start_gamepad_test_activity() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
+                Log.d(threaded_application.applicationName, activityName + ": start_gamepad_test_activity() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
             }
         } else { // don't bother doing the test if the preference is set not to
             mainapp.gamePadDeviceIdsTested[gamepadNo] = GAMEPAD_GOOD;
@@ -2508,7 +2512,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 startActivityForResult(consistLightsEdit, sub_activity_type.CONSIST_LIGHTS);
                 connection_activity.overridePendingTransition(this, R.anim.fade_in, R.anim.fade_out);
             } catch (Exception ex) {
-                Log.d("Engine_Driver", "Throttle: start_consist_lights_edit() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
+                Log.d(threaded_application.applicationName, activityName + ": start_consist_lights_edit() failed. " + ((ex.getMessage() != null) ? ex.getMessage() : "") );
             }
         }
     }
@@ -2621,26 +2625,17 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     // helper function to enable/disable all children for a group
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-
         // implemented in derived class, but called from this class
-
     }
 
     // update the appearance of all function buttons
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
-
         // implemented in derived class, but called from this class
-
     }
 
     // update a function button appearance based on its state
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
-
         // implemented in derived class, but called from this class
-
     }
 
     /*
@@ -2648,7 +2643,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
      * todo: need to handle momentary buttons somehow
      */
     void set_function_request(int whichThrottle, int function, int reqState) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request");
         Button b;
         b = functionMaps[whichThrottle].get(function);
         if (b != null) {
@@ -2719,7 +2714,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
         // Ensure ESU MCII tracks selected throttle
         if (IS_ESU_MCII) {
-            Log.d("Engine_Driver", "ESU_MCII: Throttle changed to: " + whichVolume);
+            Log.d(threaded_application.applicationName, activityName + ": setVolumeIndicator(): ESU_MCII: Throttle changed to: " + whichVolume);
             setEsuThrottleKnobPosition(whichVolume, getSpeed(whichVolume));
             if (!isEsuMc2Stopped) {
                 // Set green LED on if controlling a throttle; flash if nothing selected
@@ -2819,7 +2814,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // setup the appropriate keycodes for the type of gamepad that has been selected in the preferences
     private void setGamepadKeys() {
         mainapp.prefGamePadType = prefs.getString("prefGamePadType", getApplicationContext().getResources().getString(R.string.prefGamePadTypeDefaultValue));
-        Log.d("Engine_Driver", "setGamepadKeys() : prefGamePadType" + mainapp.prefGamePadType);
+        Log.d(threaded_application.applicationName, activityName + ": setGamepadKeys() : prefGamePadType" + mainapp.prefGamePadType);
 
         // Gamepad button Preferences
         prefGamePadButtons[0] = prefs.getString("prefGamePadButtonStart", getApplicationContext().getResources().getString(R.string.prefGamePadButtonStartDefaultValue));
@@ -3079,7 +3074,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     // map the button pressed to the user selected action for that button on the gamepad or ESP32 DIY Gamepad (which thinks it is a Keyboard)
     private void performButtonAction(int buttonNo, int action, boolean isActive, int whichThrottle, int whichGamePadIsEventFrom, int repeatCnt) {
-        Log.d("Engine_Driver", "throttle: performButtonAction() buttonNo: " + buttonNo + " action: " + ((action == ACTION_DOWN) ? "ACTION_DOWN" : "ACTION_UP"));
+        Log.d(threaded_application.applicationName, activityName + ": performButtonAction() buttonNo: " + buttonNo + " action: " + ((action == ACTION_DOWN) ? "ACTION_DOWN" : "ACTION_UP"));
 
         if (prefGamePadButtons[buttonNo].equals(pref_gamepad_button_option_type.ALL_STOP)) {  // All Stop
             if (isActive && (action == ACTION_DOWN) && (repeatCnt == 0)) {
@@ -3358,7 +3353,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     // map the button pressed to the user selected action for that button on a keyboard
     private void performKeyboardKeyAction(int keyCode, int action, boolean isShiftPressed, int repeatCnt, int originalWhichThrottle, int whichGamePadIsEventFrom) {
-        Log.d("Engine_Driver", "throttle: performKeyboardKeyAction() action: " + action);
+        Log.d(threaded_application.applicationName, activityName + ": performKeyboardKeyAction() action: " + action);
         int whichThrottle = originalWhichThrottle;
         boolean isActive = getConsist(originalWhichThrottle).isActive();
         if ((keyboardThrottle >= 0) && (keyboardThrottle != originalWhichThrottle)) {
@@ -3366,11 +3361,13 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             isActive = getConsist(whichThrottle).isActive();
         }
 
-        if ((keyCode == KEYCODE_Z) || (keyCode == KEYCODE_MOVE_END)) {  // All Stop
+        if ((keyCode == KEYCODE_Z) || (keyCode == KEYCODE_MOVE_END)) {  // E Stop
+
             if (isActive && (action == ACTION_DOWN) && (repeatCnt == 0)) {
                 GamepadFeedbackSound(false);
                 if (!isSemiRealisticTrottle) {
-                    speedUpdateAndNotify(0);         // update all three throttles
+                    speedUpdateAndNotify(0);         // update all throttles
+                    mainapp.sendEStopMsg();
                 } else {
 // ok
                     // assumes only one Throttle
@@ -3380,9 +3377,16 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             }
         } else if ((keyCode == KEYCODE_X) || (keyCode == KEYCODE_MOVE_HOME)) {  // Stop
             if (isActive && (action == ACTION_DOWN) && (repeatCnt == 0)) {
+                keyboardStopCount++;
                 GamepadFeedbackSound(false);
                 if (!isSemiRealisticTrottle) {
-                    speedUpdateAndNotify(whichThrottle, 0);
+                    if (keyboardStopCount==1) {
+                        speedUpdateAndNotify(whichThrottle, 0);
+                    } else { // Estop all
+                        speedUpdateAndNotify(0);         // update all throttles
+                        mainapp.sendEStopMsg();
+                        keyboardStopCount = 0;
+                    }
                     tts.speakWords(tts_msg_type.GAMEPAD_THROTTLE_SPEED, whichThrottle, false
                             , getMaxSpeed(whichThrottle)
                             , getSpeedFromCurrentSliderPosition(whichThrottle, false)
@@ -3679,20 +3683,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     }
                 }
             } else if ((!keyboardString.isEmpty()) && (keyboardString.charAt(0) == 'G')) {  // Forced Latching Function
-                    if ((action == ACTION_DOWN) && (repeatCnt == 0)) {
-                        keyboardString = keyboardString + num;
-                    }
-                    if (keyboardString.length() == 3) {  // have a two digit function number now
-                        int fKey = Integer.parseInt(keyboardString.substring(1, 3));
-                        if(fKey<MAX_FUNCTIONS) {
-                            if (action == ACTION_DOWN) {
-                                doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt, true);
-                            } else {
-                                doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt, true);
-                                resetKeyboardString();
-                            }
+                if ((action == ACTION_DOWN) && (repeatCnt == 0)) {
+                    keyboardString = keyboardString + num;
+                }
+                if (keyboardString.length() == 3) {  // have a two digit function number now
+                    int fKey = Integer.parseInt(keyboardString.substring(1, 3));
+                    if (fKey < MAX_FUNCTIONS) {
+                        if (action == ACTION_DOWN) {
+                            doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt, true);
+                        } else {
+                            doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt, true);
+                            resetKeyboardString();
                         }
                     }
+                }
             } else if ((!keyboardString.isEmpty()) && (keyboardString.charAt(0) == 'S')) {  // speed
                 if ((action == ACTION_DOWN) && (repeatCnt == 0)) {
                     keyboardString = keyboardString + num;
@@ -3750,10 +3754,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 }
             }
         }
+
+        if ((keyCode != KEYCODE_X) && (keyCode != KEYCODE_MOVE_HOME)) {  // if the key was anything other than a stop, reset the count
+            keyboardStopCount = 0;
+        }
     }
 
     void resetKeyboardString() {
-        Log.d("Engine_Driver", "throttle: resetKeyboardString()");
+        Log.d(threaded_application.applicationName, activityName + ": resetKeyboardString()");
         keyboardString = "";
         keyboardThrottle = -1;  //reset it
     }
@@ -3762,7 +3770,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         doGamepadFunction(fKey, action, isActive, whichThrottle, repeatCnt, false);
     }
     void doGamepadFunction(int fKey, int action, boolean isActive, int whichThrottle, int repeatCnt, boolean forceIsLatching) {
-        Log.d("Engine_Driver", "throttle: doGamepadFunction() : fkey: " + fKey + " action: " + action + " isActive: " + isActive);
+        Log.d(threaded_application.applicationName, activityName + ": doGamepadFunction() : fkey: " + fKey + " action: " + action + " isActive: " + isActive);
         if (isActive && (repeatCnt == 0)) {
             String lab = mainapp.function_labels[whichThrottle].get(fKey);
             if (lab != null) {
@@ -3806,7 +3814,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // listener for the joystick events
     @Override
     public boolean dispatchGenericMotionEvent(android.view.MotionEvent event) {
-        Log.d("Engine_Driver", "dispatchGenericMotionEvent() Joystick Event");
+        Log.d(threaded_application.applicationName, activityName + ": dispatchGenericMotionEvent() Joystick Event");
         if ( (!mainapp.prefGamePadType.equals(threaded_application.WHICH_GAMEPAD_MODE_NONE)) && (!mainapp.prefGamePadIgnoreJoystick) ) {
 
             boolean acceptEvent = true; // default to assuming that we will respond to the event
@@ -3862,7 +3870,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     yAxis2 = externalGamepadyAxis2;
                 }
 
-                Log.d("Engine_Driver", "dispatchGenericMotionEvent() Joystick Event x: " + xAxis + "y: " + yAxis + "x2: " + xAxis2 + "y2: " + yAxis2 );
+                Log.d(threaded_application.applicationName, activityName + ": dispatchGenericMotionEvent() Joystick Event x: " + xAxis + "y: " + yAxis + "x2: " + xAxis2 + "y2: " + yAxis2 );
 
                 if ((mainapp.usingMultiplePads) && (whichGamePadIsEventFrom >= -1)) { // we have multiple gamepads AND the preference is set to make use of them AND the event came for a gamepad
                     if (whichGamePadIsEventFrom >= 0) {
@@ -3882,7 +3890,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     mGamepadAutoIncrement = false;
                     mGamepadAutoDecrement = false;
                     GamepadFeedbackSoundStop();
-                    Log.d("Engine_Driver", "dispatchGenericMotionEvent: ACTION_UP"
+                    Log.d(threaded_application.applicationName, activityName + ": dispatchGenericMotionEvent(): ACTION_UP"
                             + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                             + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
                     );
@@ -4007,7 +4015,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     boolean isActive = getConsist(whichThrottle).isActive();
 
                     if (keyCode != 0) {
-                        Log.d("Engine_Driver", "throttle: dispatchKeyEvent(): keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
+                        Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent(): keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
                     }
 
                     if (!mainapp.prefGamePadType.equals("Keyboard")) {
@@ -4015,12 +4023,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                             mGamepadAutoIncrement = false;
                             mGamepadAutoDecrement = false;
                             GamepadFeedbackSoundStop();
-                            Log.d("Engine_Driver", "throttle: dispatchKeyEvent (not Keyboard): ACTION_UP"
+                            Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent (not Keyboard): ACTION_UP"
                                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
                             );
                         } else {
-                            Log.d("Engine_Driver", "throttle: dispatchKeyEvent (not Keyboard): ACTION_DOWN");
+                            Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent (not Keyboard): ACTION_DOWN");
                         }
 
                         // if the preference name has "-rotate" at the end of it swap the direction keys around
@@ -4068,7 +4076,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                             mGamepadAutoDecrement = false;
                             GamepadFeedbackSoundStop();
                         }
-                        Log.d("Engine_Driver", "throttle: dispatchKeyEvent: ACTION" + ((action == ACTION_UP) ? "UP" : "DOWN")
+                        Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent: ACTION" + ((action == ACTION_UP) ? "UP" : "DOWN")
                                 + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                                 + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
                         );
@@ -4087,7 +4095,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             boolean isActive = getConsist(whichVolume).isActive();
 
             if (keyCode != 0) {
-                Log.d("Engine_Driver", "ESU_MCII: keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
+                Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent(): ESU_MCII: keycode " + keyCode + " action " + action + " repeat " + repeatCnt);
                 if (action == ACTION_UP) {
                     esuButtonAutoIncrement = false;
                     esuButtonAutoDecrement = false;
@@ -4102,7 +4110,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         return true; // stop processing this key
                     default:
                         // Unrecognised key - do nothing
-                        Log.d("Engine_Driver", "ESU_MCII: Unrecognised keyCode: " + keyCode);
+                        Log.d(threaded_application.applicationName, activityName + ": dispatchKeyEvent(): ESU_MCII: Unrecognised keyCode: " + keyCode);
 
                 }
             }
@@ -4115,7 +4123,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     void GamepadIncrementSpeed(int whichThrottle, int stepMultiplier) {
-        Log.d("Engine_Driver", "GamepadIncrementSpeed()");
+        Log.d(threaded_application.applicationName, activityName + ": GamepadIncrementSpeed()");
         incrementSpeed(whichThrottle, speed_commands_from_type.GAMEPAD, stepMultiplier);
         GamepadFeedbackSound(atMaxSpeed(whichThrottle) || atMinSpeed(whichThrottle));
         tts.speakWords(tts_msg_type.GAMEPAD_THROTTLE_SPEED, whichThrottle, false
@@ -4128,7 +4136,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     void GamepadDecrementSpeed(int whichThrottle, int stepMultiplier) {
-        Log.d("Engine_Driver", "GamepadDecrementSpeed()");
+        Log.d(threaded_application.applicationName, activityName + ": GamepadDecrementSpeed()");
         decrementSpeed(whichThrottle, speed_commands_from_type.GAMEPAD, stepMultiplier);
         GamepadFeedbackSound(atMinSpeed(whichThrottle) || atMaxSpeed(whichThrottle));
         tts.speakWords(tts_msg_type.GAMEPAD_THROTTLE_SPEED, whichThrottle, false
@@ -4192,7 +4200,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             whichThrottle = WhichThrottle;
             stepMultiplier = StepMultiplier;
 
-            Log.d("Engine_Driver", "GamepadRptUpdater: WhichThrottle: " + whichThrottle
+            Log.d(threaded_application.applicationName, activityName + ": GamepadRptUpdater(): WhichThrottle: " + whichThrottle
                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
             );
@@ -4206,7 +4214,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-            Log.d("Engine_Driver", "GamepadRptUpdater: run(): WhichThrottle: " + whichThrottle
+            Log.d(threaded_application.applicationName, activityName + ": GamepadRptUpdater(): run(): WhichThrottle: " + whichThrottle
                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
             );
@@ -4229,7 +4237,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         int whichThrottle;
 
         private VolumeKeysRptUpdater(int WhichThrottle) {
-            Log.d("Engine_Driver", "VolumeKeysRptUpdater: WhichThrottle: " + whichThrottle
+            Log.d(threaded_application.applicationName, activityName + ": VolumeKeysRptUpdater(): WhichThrottle: " + whichThrottle
                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
             );
@@ -4244,7 +4252,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-            Log.d("Engine_Driver", "VolumeKeysRptUpdater: run(): WhichThrottle: " + whichThrottle
+            Log.d(threaded_application.applicationName, activityName + ": VolumeKeysRptUpdater(): run(): WhichThrottle: " + whichThrottle
                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
             );
@@ -4294,26 +4302,26 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void onButtonDown() {
-            Log.d("Engine_Driver", "ESU_MCII: Knob button down for throttle " + whichVolume);
+            Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonDown(): ESU_MCII: Knob button down for throttle " + whichVolume);
             if (!isScreenLocked) {
                 if (!isEsuMc2KnobEnabled) {
-                    Log.d("Engine_Driver", "ESU_MCII: Knob disabled - direction change ignored");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonDown(): ESU_MCII: Knob disabled - direction change ignored");
                 } else if (prefEsuMc2EndStopDirectionChange) {
-                    Log.d("Engine_Driver", "ESU_MCII: Attempting to switch direction");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonDown(): ESU_MCII: Attempting to switch direction");
                     changeDirectionIfAllowed(whichVolume, (getDirection(whichVolume) == 1 ? 0 : 1));
                     speedUpdateAndNotify(whichVolume, 0, false);
                 } else {
-                    Log.d("Engine_Driver", "ESU_MCII: Direction change option disabled - do nothing");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonDown(): ESU_MCII: Direction change option disabled - do nothing");
                     speedUpdateAndNotify(whichVolume, 0, false);
                 }
             } else {
-                Log.d("Engine_Driver", "ESU_MCII: Screen locked - do nothing");
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonDown(): ESU_MCII: Screen locked - do nothing");
             }
         }
 
         @Override
         public void onButtonUp() {
-            Log.d("Engine_Driver", "ESU_MCII: Knob button up for throttle " + whichVolume);
+            Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onButtonUp(): ESU_MCII: Knob button up for throttle " + whichVolume);
         }
 
         @Override
@@ -4321,20 +4329,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             int speed;
             if (!isScreenLocked) {
                 if (!isEsuMc2KnobEnabled) {
-                    Log.d("Engine_Driver", "ESU_MCII: Disabled knob position moved for throttle " + whichVolume);
-                    Log.d("Engine_Driver", "ESU_MCII: Nothing updated");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged(): ESU_MCII: Disabled knob position moved for throttle " + whichVolume);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: Nothing updated");
                 } else if (getConsist(whichVolume).isActive() && !isEsuMc2Stopped) {
                     speed = esuThrottleScales[whichVolume].positionToStep(knobPos);
-                    Log.d("Engine_Driver", "ESU_MCII: Knob position changed for throttle " + whichVolume);
-                    Log.d("Engine_Driver", "ESU_MCII: New knob position: " + knobPos + " ; speedstep: " + speed);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: Knob position changed for throttle " + whichVolume);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: New knob position: " + knobPos + " ; speedstep: " + speed);
                     speedUpdateAndNotify(whichVolume, speed, false); // No need to move knob
                 } else {
                     // Ignore knob movements for stopped or inactive throttles
-                    Log.d("Engine_Driver", "ESU_MCII: Knob position moved for " + (isEsuMc2Stopped ? "stopped" : "inactive") + " throttle " + whichVolume);
-                    Log.d("Engine_Driver", "ESU_MCII: Nothing updated");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: Knob position moved for " + (isEsuMc2Stopped ? "stopped" : "inactive") + " throttle " + whichVolume);
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: Nothing updated");
                 }
             } else {
-                Log.d("Engine_Driver", "ESU_MCII: Screen locked - do nothing");
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onPositionChanged():ESU_MCII: Screen locked - do nothing");
             }
         }
     };
@@ -4350,14 +4358,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         @Override
         public void onStopButtonDown() {
             if (!getConsist(whichVolume).isActive()) {
-                Log.d("Engine_Driver", "ESU_MCII: Stop button down for inactive throttle " + whichVolume);
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onStopButton(): ESU_MCII: Stop button down for inactive throttle " + whichVolume);
                 return;
             }
-            Log.d("Engine_Driver", "ESU_MCII: Stop button down for throttle " + whichVolume);
+            Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onStopButton(): ESU_MCII: Stop button down for throttle " + whichVolume);
             if (!isEsuMc2Stopped) {
                 origSpeed = getSpeed(whichVolume);
                 timePressed = System.currentTimeMillis();
-                Log.d("Engine_Driver", "ESU_MCII: Speed value was: " + origSpeed);
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): onStopButton(): ESU_MCII: Speed value was: " + origSpeed);
             }
             // Toggle press status
             isEsuMc2Stopped = !isEsuMc2Stopped;
@@ -4397,19 +4405,19 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 buttonTimer.cancel();
             }
             if (!getConsist(whichVolume).isActive()) {
-                Log.d("Engine_Driver", "ESU_MCII: Stop button up for inactive throttle " + whichVolume);
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button up for inactive throttle " + whichVolume);
                 return;
             }
             if (fromTimer) {
-                Log.d("Engine_Driver", "ESU_MCII: Stop button timer finished for throttle " + whichVolume);
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button timer finished for throttle " + whichVolume);
             } else {
-                Log.d("Engine_Driver", "ESU_MCII: Stop button up for throttle " + whichVolume);
+                Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button up for throttle " + whichVolume);
             }
             if (isEsuMc2Stopped) {
                 if (fromTimer || System.currentTimeMillis() - timePressed > delay) {
                     // It's a long initial press so record this
                     wasLongPress = true;
-                    Log.d("Engine_Driver", "ESU_MCII: Stop button press was long - long flash Red LED");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button press was long - long flash Red LED");
                     esuMc2Led.setState(EsuMc2Led.RED, EsuMc2LedState.LONG_FLASH);
                     esuMc2Led.setState(EsuMc2Led.GREEN, EsuMc2LedState.OFF);
                     // Set all throttles to zero
@@ -4422,12 +4430,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 } else {
                     wasLongPress = false;
                     if (prefEsuMc2StopButtonShortPress) {
-                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short - short flash Red LED");
+                        Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button press was short - short flash Red LED");
                         esuMc2Led.setState(EsuMc2Led.RED, EsuMc2LedState.QUICK_FLASH);
                         esuMc2Led.setState(EsuMc2Led.GREEN, EsuMc2LedState.OFF);
                         setEnabledEsuMc2ThrottleScreenButtons(whichVolume, false);
                     } else {
-                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short but action disabled");
+                        Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button press was short but action disabled");
                         isEsuMc2Stopped = !isEsuMc2Stopped;
                         esuMc2Led.revertLEDStates();
                     }
@@ -4435,15 +4443,15 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             } else {
                 if (!wasLongPress) {
                     if (prefEsuMc2StopButtonShortPress) {
-                        Log.d("Engine_Driver", "ESU_MCII: Revert speed value to: " + origSpeed);
+                        Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): SU_MCII: Revert speed value to: " + origSpeed);
                         set_stop_button(whichVolume, false);
                         speedUpdateAndNotify(whichVolume, origSpeed);
                         setEnabledEsuMc2ThrottleScreenButtons(whichVolume, true);
                     } else {
-                        Log.d("Engine_Driver", "ESU_MCII: Stop button press was short but revert action disabled");
+                        Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Stop button press was short but revert action disabled");
                     }
                 } else {
-                    Log.d("Engine_Driver", "ESU_MCII: Resume control without speed revert");
+                    Log.d(threaded_application.applicationName, activityName + ": ThrottleListner(): doStopButtonUp(): ESU_MCII: Resume control without speed revert");
                     origSpeed = 0;
                     for (int throttleIndex = 0; throttleIndex < mainapp.numThrottles; throttleIndex++) {
                         set_stop_button(throttleIndex, false);
@@ -4459,25 +4467,25 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     // Function to move ESU MCII control knob
     protected void setEsuThrottleKnobPosition(int whichThrottle, int speed) {
-        Log.d("Engine_Driver", "ESU_MCII: Request to update knob position for throttle " + whichThrottle);
+        Log.d(threaded_application.applicationName, activityName + ": setEsuThrottleKnobPosition(): ESU_MCII: Request to update knob position for throttle " + whichThrottle);
         if (whichThrottle == whichVolume) {
             int knobPos;
             knobPos = esuThrottleScales[whichThrottle].stepToPosition(speed);
-            Log.d("Engine_Driver", "ESU_MCII: Update knob position for throttle " + mainapp.throttleIntToString(whichThrottle));
-            Log.d("Engine_Driver", "ESU_MCII: New knob position: " + knobPos + " ; speedstep: " + speed);
+            Log.d(threaded_application.applicationName, activityName + ": setEsuThrottleKnobPosition(): ESU_MCII: Update knob position for throttle " + mainapp.throttleIntToString(whichThrottle));
+            Log.d(threaded_application.applicationName, activityName + ": setEsuThrottleKnobPosition(): ESU_MCII: New knob position: " + knobPos + " ; speedstep: " + speed);
             try {
                 esuThrottleFragment.moveThrottle(knobPos);
             } catch (IllegalArgumentException ex) {
-                Log.e("Engine_Driver", "ESU_MCII: Problem moving throttle " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": setEsuThrottleKnobPosition(): ESU_MCII: Problem moving throttle " + ex.getMessage());
             }
         } else {
-            Log.d("Engine_Driver", "ESU_MCII: This throttle not selected for control by knob");
+            Log.d(threaded_application.applicationName, activityName + ": setEsuThrottleKnobPosition(): ESU_MCII: This throttle not selected for control by knob");
         }
     }
 
     private void updateEsuMc2ZeroTrim() {
         int zeroTrim = threaded_application.getIntPrefValue(prefs, "prefEsuMc2ZeroTrim", getApplicationContext().getResources().getString(R.string.prefEsuMc2ZeroTrimDefaultValue));
-        Log.d("Engine_Driver", "ESU_MCII: Update zero trim for throttle to: " + zeroTrim);
+        Log.d(threaded_application.applicationName, activityName + ": updateEsuMc2ZeroTrim(): ESU_MCII: Update zero trim for throttle to: " + zeroTrim);
 
         // first the knob
         esuThrottleFragment.setZeroPosition(zeroTrim);
@@ -4491,7 +4499,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private void performEsuMc2ButtonAction(int buttonNo, int action, boolean isActive, int whichThrottle, int repeatCnt) {
 
         if (isEsuMc2Stopped) {
-            Log.d("Engine_Driver", "ESU_MCII: Device button presses whilst stopped ignored");
+            Log.d(threaded_application.applicationName, activityName + ": performEsuMc2ButtonAction(): ESU_MCII: Device button presses whilst stopped ignored");
 //            Toast.makeText(getApplicationContext(), getApplicationContext().getResources().getString(R.string.toastEsuMc2NoButtonPresses), Toast.LENGTH_SHORT).show();
             threaded_application.safeToast(R.string.toastEsuMc2NoButtonPresses, Toast.LENGTH_SHORT);
             return;
@@ -4880,7 +4888,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 isDirectionButtonLongPress = true;
                 directionButtonLongPressHandler.postDelayed(run, prefDirectionButtonLongPressDelay);
 
-                // Log.d("Engine_Driver", "onTouch direction " + function + " action " +
+                // Log.d(threaded_application.applicationName, activityName + ": onTouch(): direction " + function + " action " +
 
                 v.playSoundEffect(SoundEffectConstants.CLICK);  // make the click sound once
 
@@ -5090,7 +5098,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-//            Log.d("Engine_Driver", "doLocoSoundDelayed.run: (locoSound) wt" + whichThrottle);
+//            Log.d(threaded_application.applicationName, activityName + ": doLocoSoundDelayed(): run: (locoSound) wt" + whichThrottle);
             doLocoSound(whichThrottle);
         }
     } // end DoLocoSoundDelayed
@@ -5103,18 +5111,18 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     if ((mainapp.consists != null) && (mainapp.consists[whichThrottle].isActive())) {
                         mSound = getLocoSoundStep(whichThrottle);
 
-                        Log.d("Engine_Driver", "doLocoSound               : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
+                        Log.d(threaded_application.applicationName, activityName + ": doLocoSound               : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                         if ((mSound >= 0)) {
                             if (mainapp.soundsLocoCurrentlyPlaying[whichThrottle] == sounds_type.NOTHING_CURRENTLY_PLAYING) { // nothing currently playing
-//                                Log.d("Engine_Driver", "doLocoSound 2              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
+//                                Log.d(threaded_application.applicationName, activityName + ": doLocoSound 2              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                                 //see if there is a startup sound for this profile
                                 if (mainapp.soundsLocoDuration[whichThrottle][sounds_type.STARTUP_INDEX] > 0) {
-//                                    Log.d("Engine_Driver", "doLocoSound 3              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
+//                                    Log.d(threaded_application.applicationName, activityName + ": doLocoSound 3              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                                     soundStart(sounds_type.LOCO, whichThrottle, sounds_type.STARTUP_INDEX, sounds_type.REPEAT_NONE);
                                     soundScheduleNextLocoSound(whichThrottle, mSound, mainapp.soundsLocoDuration[whichThrottle][sounds_type.STARTUP_INDEX]);
                                     soundQueueNextLocoSound(whichThrottle, mSound);
                                 } else {
-//                                    Log.d("Engine_Driver", "doLocoSound 4              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
+//                                    Log.d(threaded_application.applicationName, activityName + ": doLocoSound 4              : (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                                     soundStart(sounds_type.LOCO, whichThrottle, mSound, sounds_type.REPEAT_INFINITE);
                                     mainapp.soundsLocoQueue[whichThrottle].setLastAddedValue(mSound);
                                 }
@@ -5138,7 +5146,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         if ((mainapp.soundsLocoCurrentlyPlaying[whichThrottle] == mSound) && (mainapp.soundsLocoQueue[whichThrottle].queueCount() == 0) && (!wasDirectionChange)) {
             return; // sound is already playing and nothing is queued
         }
-//        Log.d("Engine_Driver", "soundQueueNextLocoSound  : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " " + mainapp.soundsLocoQueue[whichThrottle].displayQueue());
+//        Log.d(threaded_application.applicationName, activityName + ": soundQueueNextLocoSound  : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " " + mainapp.soundsLocoQueue[whichThrottle].displayQueue());
 
         int queueCount = mainapp.soundsLocoQueue[whichThrottle].queueCount();
 
@@ -5150,7 +5158,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     } // end soundQueueNextLocoSound()
 
     void soundScheduleNextLocoSound(int whichThrottle, int mSound, int forcedExpectedEndTime) {
-//        Log.d("Engine_Driver", "soundScheduleNextLocoSound : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " " + mainapp.soundsLocoQueue[whichThrottle].displayQueue());
+//        Log.dthreaded_application.applicationName, activityName + ": soundScheduleNextLocoSound : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " " + mainapp.soundsLocoQueue[whichThrottle].displayQueue());
 
         int expectedEndTime;
         if (forcedExpectedEndTime > 0) {
@@ -5164,7 +5172,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             mainapp.throttle_msg_handler.postDelayed(
                     new SoundScheduleNextSoundToPlay(sounds_type.LOCO, whichThrottle, nextSound),
                     expectedEndTime - 100);
-//            Log.d("Engine_Driver", "soundScheduleNextLocoSound : (locoSound) wt:" + whichThrottle + " snd: " + nextSound + " Start in: " + expectedEndTime + "msec");
+//            Log.d(threaded_application.applicationName, activityName + ": soundScheduleNextLocoSound : (locoSound) wt:" + whichThrottle + " snd: " + nextSound + " Start in: " + expectedEndTime + "msec");
         }
     } //end soundScheduleNextLocoSound()
 
@@ -5176,12 +5184,12 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         speed = (float) ((speed / 126 * steps) + 0.99);
         rslt = (int) speed;
 
-//        Log.d("Engine_Driver", "getLocoSoundStep         : (locoSound) wt: " + whichThrottle + " step:" + rslt);
+//        Log.d(threaded_application.applicationName, activityName + ": getLocoSoundStep         : (locoSound) wt: " + whichThrottle + " step:" + rslt);
         return rslt;
     } // end getLocoSoundStep()
 
     void doDeviceButtonSound(int whichThrottle, int soundType) {
-        Log.d("Engine_Driver", "doDeviceButtonSound (locoSounds): wt: " + whichThrottle + " soundType: " + soundType);
+        Log.d(threaded_application.applicationName, activityName + ": doDeviceButtonSound (locoSounds): wt: " + whichThrottle + " soundType: " + soundType);
         int soundTypeArrayIndex = soundType - 1;
 
         if ((mainapp.consists != null)
@@ -5218,7 +5226,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     } // end soundIsPlaying()
 
     void startBellHornSound(int soundType, int whichThrottle) {
-//        Log.d("Engine_Driver", "startBellHornSound        : soundType:" + soundType + " wt: " + whichThrottle);
+//        Log.d(threaded_application.applicationName, activityName + ": startBellHornSound        : soundType:" + soundType + " wt: " + whichThrottle);
         int soundTypeArrayIndex = soundType - 1;
 
         if (soundIsPlaying(soundType, whichThrottle) < 0) { // check if the loop sound is not currently playing
@@ -5235,7 +5243,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     } // end startBellHornSound()
 
     void stopBellHornSound(int soundType, int whichThrottle) {
-//        Log.d("Engine_Driver", "stopBellHornSound        : soundType:" + soundType + " wt: " + whichThrottle + " playing: " + soundIsPlaying(soundType,whichThrottle));
+//        Log.d(threaded_application.applicationName, activityName + ": stopBellHornSound        : soundType:" + soundType + " wt: " + whichThrottle + " playing: " + soundIsPlaying(soundType,whichThrottle));
         int soundTypeArrayIndex = soundType - 1;
 
         if (soundType != sounds_type.HORN_SHORT) {
@@ -5259,13 +5267,13 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     } // end stopBellHornSound(
 
     void soundStart(int soundType, int whichThrottle, int mSound, int loop) {
-//        Log.d("Engine_Driver", "soundStart: SoundType:" + soundType + " wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop);
+//        Log.d(threaded_application.applicationName, activityName + ": soundStart: SoundType:" + soundType + " wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop);
         int soundTypeArrayIndex = soundType - 1;
 
         switch (soundType) {
             default:
             case sounds_type.LOCO: // loco
-//                Log.d("Engine_Driver", "soundStart               : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop);
+//                Log.d(threaded_application.applicationName, activityName + ": soundStart               : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop);
                 if (mSound >= 0) {
                     if (mainapp.soundsLocoCurrentlyPlaying[whichThrottle] != mSound) {
                         if (mSound < sounds_type.STARTUP_INDEX) {
@@ -5278,7 +5286,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                     = mainapp.soundPool.play(mainapp.soundsLoco[whichThrottle][mSound],
                                     soundsVolume(sounds_type.LOCO, whichThrottle), soundsVolume(sounds_type.LOCO, whichThrottle),
                                     0, sounds_type.REPEAT_NONE, 1);
-//                            Log.d("Engine_Driver", "soundStart SU            : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop + " Sid: " + mainapp.soundsLocoStreamId[whichThrottle][mSound]);
+//                            Log.d(threaded_application.applicationName, activityName + ": soundStart SU            : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " loop:" + loop + " Sid: " + mainapp.soundsLocoStreamId[whichThrottle][mSound]);
 
 //                        } else if (mSound == sounds_type.SHUTDOWN_INDEX) {
                         }
@@ -5304,7 +5312,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }  // end startSound()
 
     int soundStop(int soundType, int whichThrottle, int mSound, boolean forceStop) {
-//        Log.d("Engine_Driver", "soundStop: soundType" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
+//        Log.d(threaded_application.applicationName, activityName + ": soundStop: soundType" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
         int timesPlayed = 0;
         double expectedEndTime = 0;
         int soundTypeArrayIndex = soundType - 1;
@@ -5339,7 +5347,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
             case sounds_type.LOCO: // loco
             default:
-//                Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " mSound: " + snd + " forceStop:" + forceStop);
+//                Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " mSound: " + snd + " forceStop:" + forceStop);
                 if (mSound >= 0) {
                     if (mSound < sounds_type.STARTUP_INDEX) {
                         if (!forceStop) {
@@ -5358,7 +5366,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 repeats = (int) (mainapp.prefDeviceSoundsMomentum / duration) + 1;
                             }
 //                            double x = expectedEndTime + repeats * duration;
-//                        Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " expected to end in: " +(x/1000)+"sec" );
+//                        Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " expected to end in: " +(x/1000)+"sec" );
 
                             mainapp.soundPool.pause(mainapp.soundsLocoStreamId[whichThrottle][mSound]); // unfortunately you seem to have to pause it to change the number of repeats
                             mainapp.soundPool.setLoop(mainapp.soundsLocoStreamId[whichThrottle][mSound], repeats);  // don't really stop it, just let it finish
@@ -5371,19 +5379,19 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 expectedEndTime = mainapp.prefDeviceSoundsMomentum;  // schedule the next sound for the preference amount regardless
                             }
 
-//                        Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " will end in: " +(expectedEndTime/1000)+"sec" );
+//                        Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " will end in: " +(expectedEndTime/1000)+"sec" );
                         } else {
                             mainapp.soundPool.stop(mainapp.soundsLocoStreamId[whichThrottle][mSound]);
-//                        Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " FORCED STOP");
+//                        Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " FORCED STOP");
                         }
                     } else if (mSound == sounds_type.STARTUP_INDEX) {
                         // this will only ever play once
                         if (!forceStop) {
                             expectedEndTime = mainapp.soundsLocoStartTime[whichThrottle][mSound] + mainapp.soundsLocoDuration[whichThrottle][mSound] - System.currentTimeMillis();
-//                            Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " will end in: " +(expectedEndTime/1000)+"sec" );
+//                            Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " will end in: " +(expectedEndTime/1000)+"sec" );
                         } else {
                             mainapp.soundPool.stop(mainapp.soundsLocoStreamId[whichThrottle][mSound]);
-//                            Log.d("Engine_Driver", "soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " FORCED STOP");
+//                            Log.d(threaded_application.applicationName, activityName + ": soundStop                : (locoSound) wt: " + whichThrottle + " snd: " + mSound + " timesPlayed:" + timesPlayed + " FORCED STOP");
                         }
 
                     }
@@ -5408,13 +5416,13 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-//            Log.d("Engine_Driver", "SoundScheduleNextSoundToPlay.run: Type" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
+//            Log.d(threaded_application.applicationName, activityName + ": SoundScheduleNextSoundToPlay.run: Type" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
             switch (soundType) {
                 default:
                     break;
                 case sounds_type.LOCO: // loco
                     // pull the next sound off the queue
-//                    Log.d("Engine_Driver", "SoundScheduleNextSoundToPlay.run: (locoSound) wt: " + whichThrottle + " snd: " + mSound);
+//                    Log.d(threaded_application.applicationName, activityName + ": SoundScheduleNextSoundToPlay.run: (locoSound) wt: " + whichThrottle + " snd: " + mSound);
                     soundStop(soundType, whichThrottle, mainapp.soundsLocoCurrentlyPlaying[whichThrottle], true);
                     soundStart(soundType, whichThrottle, mSound, sounds_type.REPEAT_INFINITE);
                     mainapp.soundsLocoQueue[whichThrottle].dequeue();
@@ -5446,7 +5454,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         @Override
         public void run() {
-//            Log.d("Engine_Driver", "SoundScheduleSoundToStop.run: Type" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
+//            Log.d(threaded_application.applicationName, activityName + ": SoundScheduleSoundToStop.run: Type" + soundType + " wt: " + whichThrottle + " snd: " + mSound);
             switch (soundType) {
                 default:
                     break;
@@ -5498,7 +5506,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         @Override
         public boolean onTouch(View v, MotionEvent event) {
             mainapp.exitDoubleBackButtonInitiated = 0;
-            // Log.d("Engine_Driver", "onTouch func " + function + " action " +
+            // Log.d(threaded_application.applicationName, activityName + ": onTouch(): func " + function + " action " +
 
             // make the click sound once
             if (event.getAction() == MotionEvent.ACTION_DOWN) {
@@ -5521,7 +5529,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         }
 
         private void handleAction(int action) {
-//            Log.d("Engine_Driver", "handleAction - action: " + action );
+//            Log.d(threaded_application.applicationName, activityName + ": handleAction(): action: " + action );
             int isLatching = consist_function_latching_type.NA;  // only used for the special consist function matching
 
             switch (action) {
@@ -5598,7 +5606,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         @Override
         public boolean onTouch(View v, MotionEvent event) {
             mainapp.exitDoubleBackButtonInitiated = 0;
-//             Log.d("Engine_Driver", "throttle: ThrottleSeekBarListener: onTouch: Throttle action " + event.getAction());
+//             Log.d(threaded_application.applicationName, activityName + ": ThrottleSeekBarListener: onTouch: Throttle action " + event.getAction());
             // consume event if gesture is in progress, otherwise pass it to the SeekBar onProgressChanged()
             return (gestureInProgress);
         }
@@ -5611,7 +5619,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             if (vsbSpeeds != null) {
                 touchFromUser = vsbSpeeds[whichThrottle].touchFromUser;
             }
-//                Log.d("Engine_Driver", "onProgressChanged -- lj: " + limitedJump[whichThrottle] + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " s: " + speed + " js: " + jumpSpeed);
+//                Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): lj: " + limitedJump[whichThrottle] + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " s: " + speed + " js: " + jumpSpeed);
 
             // limit speed change if change was initiated by a user slider touch (prevents "bouncing")
             if ((fromUser) || (touchFromUser)) {
@@ -5626,7 +5634,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
                     if (dif > max_throttle_change) { // if jump is too large then limit it
 
-                        // Log.d("Engine_Driver", "onProgressChanged -- throttling change");
+                        // Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): throttling change");
 
                         if (speed < lastSpeed) { // going down
                             setAutoIncrementOrDecrement(whichThrottle, auto_increment_or_decrement_type.DECREMENT);
@@ -5789,7 +5797,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
         mainapp = (threaded_application) this.getApplication();
         prefs = getSharedPreferences("jmri.enginedriver_preferences", 0);
         mainapp.applyTheme(this);
@@ -5805,13 +5813,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         dirs[throttleIndex] = (int) savedInstanceState.getSerializable("dir" + throttleIndex);
                 }
             } catch (Exception ignored) {              // log the error, but otherwise keep going.
-                Log.d("Engine_Driver", "Restore of saved instance state failed " + android.os.Build.VERSION.SDK_INT);
+                Log.d(threaded_application.applicationName, activityName + ": onCreate(): Restore of saved instance state failed " + android.os.Build.VERSION.SDK_INT);
             }
         }
 
 
         if (mainapp.isForcingFinish()) { // expedite
             mainapp.appIsFinishing = true;
+            this.finish();
             return;
         }
 
@@ -5943,7 +5952,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 bLSpds[i].setOnClickListener(arrowSpeedButtonTouchListener);
 
             } catch (Exception ex) {
-                Log.d("debug", "onCreate: " + ex.getMessage());
+                Log.d(threaded_application.applicationName, activityName + ": onCreate(): Exception: " + ex.getMessage());
             }
 
             // set listeners for 3 direction buttons for each throttle
@@ -6339,20 +6348,20 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             tg = new ToneGenerator(AudioManager.STREAM_NOTIFICATION,
                     threaded_application.getIntPrefValue(prefs, "prefGamePadFeedbackVolume", getApplicationContext().getResources().getString(R.string.prefGamePadFeedbackVolumeDefaultValue)));
         } catch (RuntimeException e) {
-            Log.e("Engine_Driver", "new ToneGenerator failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
+            Log.e(threaded_application.applicationName, activityName + ": onCreate(): new ToneGenerator failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
         }
         // set GamePad Support
         setGamepadKeys();
 
         // initialise ESU MCII
         if (IS_ESU_MCII) {
-            Log.d("Engine_Driver", "ESU_MCII: Initialise fragments...");
+            Log.d(threaded_application.applicationName, activityName + ": onCreate(): ESU_MCII: Initialise fragments...");
             int zeroTrim = threaded_application.getIntPrefValue(prefs, "prefEsuMc2ZeroTrim", getApplicationContext().getResources().getString(R.string.prefEsuMc2ZeroTrimDefaultValue));
             esuThrottleFragment = ThrottleFragment.newInstance(zeroTrim);
             esuThrottleFragment.setOnThrottleListener(esuOnThrottleListener);
             esuStopButtonFragment = StopButtonFragment.newInstance();
             esuStopButtonFragment.setOnStopButtonListener(esuOnStopButtonListener);
-            Log.d("Engine_Driver", "ESU_MCII: ...fragments initialised");
+            Log.d(threaded_application.applicationName, activityName + ": onCreate(): ESU_MCII: ...fragments initialised");
 
             getSupportFragmentManager().beginTransaction()
                     .add(esuThrottleFragment, "mc2:throttle")
@@ -6363,7 +6372,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
             // Now apply knob zero trim
             updateEsuMc2ZeroTrim();
-            Log.d("Engine_Driver", "ESU_MCII: Initialisation complete");
+            Log.d(threaded_application.applicationName, activityName + ": onCreate(): ESU_MCII: Initialisation complete");
         }
 
         setupSensor(); // setup the support for shake actions.
@@ -6398,8 +6407,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     @SuppressLint("ApplySharedPref")
     @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
+
         threaded_application.currentActivity = activity_id_type.THROTTLE;
         if (mainapp.isForcingFinish()) { // expedite
             mainapp.appIsFinishing = true;
@@ -6503,7 +6514,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             prefs.edit().putBoolean("prefForcedRestart", false).commit();
 
             int prefForcedRestartReason = prefs.getInt("prefForcedRestartReason", restart_reason_type.NONE);
-            Log.d("Engine_Driver", "connection: Forced Restart Reason: " + prefForcedRestartReason);
+            Log.d(threaded_application.applicationName, activityName + ": onResume(): connection: Forced Restart Reason: " + prefForcedRestartReason);
             if (mainapp.prefsForcedRestart(prefForcedRestartReason)) {
                 Intent in = new Intent().setClass(this, SettingsActivity.class);
                 startActivityForResult(in, 0);
@@ -6566,7 +6577,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     private void showHideConsistMenus() {
         if ((mainapp.consists == null) && (!mainapp.isDCCEX)) {
-            Log.d("Engine_Driver", "showHideConsistMenu consists[] is null and not DCC-EX");
+            Log.d(threaded_application.applicationName, activityName + ": showHideConsistMenu(): consists[] is null and not DCC-EX");
             return;
         }
 
@@ -6575,7 +6586,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             for (int throttleIndex = 0; throttleIndex < mainapp.maxThrottlesCurrentScreen; throttleIndex++) {
                 Consist con = mainapp.consists[throttleIndex];
                 if (con == null) {
-                    Log.d("Engine_Driver", "showHideConsistMenu consists[" + throttleIndex + "] is null");
+                    Log.d(threaded_application.applicationName, activityName + ": showHideConsistMenu(): consists[" + throttleIndex + "] is null");
                     break;
                 }
                 boolean isMulti = con.isMulti();
@@ -6634,6 +6645,8 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     @Override
     public void onPause() {
         super.onPause();
+        threaded_application.activityPaused(activityName);
+
         if (webViewIsOn) {
             pauseWebView();
         }
@@ -6680,7 +6693,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     @Override
     public void onStart() {
-        Log.d("Engine_Driver", "throttle: onStart(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onStart(): called");
         super.onStart();
         // put pointer to this activity's handler in main app's shared variable
         if (mainapp.throttle_msg_handler == null)
@@ -6701,9 +6714,9 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     @Override
     public void onDestroy() {
-        Log.d("Engine_Driver", "throttle: onDestroy(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy(): called");
         super.onDestroy();
-        Log.d("Engine_Driver", "throttle.onDestroy() called");
+        Log.d(threaded_application.applicationName, activityName + ": onDestroy() called");
         if (!isRestarting) {
             removeHandlers();
         } else {
@@ -6728,7 +6741,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             mainapp.throttle_msg_handler.removeCallbacksAndMessages(null);
             mainapp.throttle_msg_handler = null;
         } else {
-            Log.d("Engine_Driver", "onDestroy: mainapp.throttle_msg_handler is null. Unable to removeCallbacksAndMessages");
+            Log.d(threaded_application.applicationName, activityName + ": onDestroy(): mainapp.throttle_msg_handler is null. Unable to removeCallbacksAndMessages");
         }
 
         if (volumeKeysRepeatUpdateHandler != null) {
@@ -6805,7 +6818,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // set label and dcc functions (based on settings) or hide if no label
     @SuppressLint("ClickableViewAccessibility")
     void set_function_labels_and_listeners_for_view(int whichThrottle) {
-        Log.d("Engine_Driver", "throttle: set_function_labels_and_listeners_for_view() called");
+        Log.d(threaded_application.applicationName, activityName + ": set_function_labels_and_listeners_for_view() called");
 
 //        // implemented in derived class, but called from this class
 
@@ -6923,7 +6936,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // screen elements
 
     protected void set_labels() {
-//         Log.d("Engine_Driver","throttle: set_labels() starting");
+//         Log.d(threaded_application.applicationName, activityName + ": set_labels()");
 
         if (mainapp.appIsFinishing) {
             return;
@@ -6964,7 +6977,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         refreshMenu();
 
         vThrotScrWrap.invalidate();
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels(): end");
     }
 
     private void refreshMenu() {
@@ -7247,7 +7260,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             speedUpdate(0);  // update all throttles
             applySpeedRelatedOptions();  // update all throttles
             if (IS_ESU_MCII) {
-                Log.d("Engine_Driver", "ESU_MCII: Move knob request for EStop");
+                Log.d(threaded_application.applicationName, activityName + ": onOptionsItemSelected(): ESU_MCII: Move knob request for EStop");
                 setEsuThrottleKnobPosition(whichVolume, 0);
             }
             mainapp.buttonVibration();
@@ -7370,7 +7383,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 try {
                     overrideThrottleNames[mainapp.throttleCharToInt(data.getCharExtra("whichThrottle", ' '))] = data.getStringExtra("overrideThrottleName");
                 } catch (RuntimeException e) {
-                    Log.e("Engine_Driver", "Throttle: Call to OverrideThrottleName failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
+                    Log.e(threaded_application.applicationName, activityName + ": Call to OverrideThrottleName failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
                 }
                 if ((getConsist(whichVolume) != null) && (!getConsist(whichVolume).isActive())) {
                     setNextActiveThrottle(); // if consist on Volume throttle was released, move to next throttle
@@ -7403,7 +7416,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                             tg = new ToneGenerator(AudioManager.STREAM_NOTIFICATION,
                                     threaded_application.getIntPrefValue(prefs, "prefGamePadFeedbackVolume", getApplicationContext().getResources().getString(R.string.prefGamePadFeedbackVolumeDefaultValue)));
                         } catch (RuntimeException e) {
-                            Log.e("Engine_Driver", "new ToneGenerator failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
+                            Log.e(threaded_application.applicationName, activityName + ": onActivityResult(): new ToneGenerator failed. Runtime Exception, OS " + android.os.Build.VERSION.SDK_INT + " Message: " + e);
                         }
                     }
                     // update GamePad Support
@@ -7457,11 +7470,11 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                                 tts.speakWords(tts_msg_type.GAMEPAD_GAMEPAD_TEST_RESET);
                                 break;
                             default:
-                                Log.e("Engine_Driver", "OnActivityResult(ACTIVITY_GAMEPAD_TEST) invalid result!");
+                                Log.e(threaded_application.applicationName, activityName + ": OnActivityResult(ACTIVITY_GAMEPAD_TEST) invalid result!");
                         }
                     }
                 } else {
-                    Log.e("Engine_Driver", "OnActivityResult(ACTIVITY_GAMEPAD_TEST) called with null data!");
+                    Log.e(threaded_application.applicationName, activityName + ": OnActivityResult(ACTIVITY_GAMEPAD_TEST) called with null data!");
                 }
                 break;
             }
@@ -7495,7 +7508,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // touch events outside the GestureOverlayView get caught here
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-//        Log.d("Engine_Driver", "onTouchEvent action: " + event.getAction());
+//        Log.d(threaded_application.applicationName, activityName + ": onTouchEvent(): action: " + event.getAction());
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 gestureStart(event);
@@ -7514,16 +7527,16 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
-//        Log.d("Engine_Driver", "dispatchTouchEvent:");
+//        Log.d(threaded_application.applicationName, activityName + ": dispatchTouchEvent():");
         // if screen is locked
         if (isScreenLocked) {
             // check if we have a swipe up
             if (ev.getAction() == ACTION_DOWN) {
-//                Log.d("Engine_Driver", "dispatchTouchEvent: ACTION_DOWN" );
+//                Log.d(threaded_application.applicationName, activityName + ": dispatchTouchEvent(): ACTION_DOWN" );
                 gestureStart(ev);
             }
             if (ev.getAction() == ACTION_UP) {
-//                Log.d("Engine_Driver", "dispatchTouchEvent: ACTION_UP" );
+//                Log.d(threaded_application.applicationName, activityName + ": dispatchTouchEvent(): ACTION_UP" );
                 gestureEnd(ev);
             }
             // otherwise ignore the event
@@ -7557,7 +7570,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private void gestureStart(MotionEvent event) {
         gestureStartX = event.getX();
         gestureStartY = event.getY();
-//        Log.d("Engine_Driver", "gestureStart x=" + gestureStartX + " y=" + gestureStartY);
+//        Log.d(threaded_application.applicationName, activityName + ": gestureStart(): x=" + gestureStartX + " y=" + gestureStartY);
 
         toolbarHeight = mainapp.getToolbarHeight(toolbar, statusLine, screenNameLine);
 
@@ -7584,7 +7597,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                         )
                 )
                 ) {
-//                    Log.d("Engine_Driver","exiting gestureStart on slider: " + gestureStartX + ", " + gestureStartY);
+//                    Log.d(threaded_application.applicationName, activityName + ": gestureStart() exit on slider: " + gestureStartX + ", " + gestureStartY);
                     return;
                 }
             }
@@ -7596,15 +7609,15 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
         // start the gesture timeout timer
         if (mainapp.throttle_msg_handler != null) {
-//            Log.d("Engine_Driver","gestureStart start gesture timer");
+//            Log.d(threaded_application.applicationName, activityName + ": gestureStart(): start gesture timer");
             mainapp.throttle_msg_handler.postDelayed(gestureStopped, gestureCheckRate);
         } else {
-            Log.d("Engine_Driver", "gestureStart Can't start gesture timer");
+            Log.d(threaded_application.applicationName, activityName + ": gestureStart(): Can't start gesture timer");
         }
     }
 
     public void gestureMove(MotionEvent event) {
-//        Log.d("Engine_Driver", "gestureMove action " + event.getAction() + " eventTime: " + event.getEventTime() );
+//        Log.d(threaded_application.applicationName, activityName + ": gestureMove(): action " + event.getAction() + " eventTime: " + event.getEventTime() );
         if (gestureInProgress) {
             // stop the gesture timeout timer
             if (mainapp.throttle_msg_handler != null)
@@ -7618,18 +7631,18 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 velocityTracker.computeCurrentVelocity(1000);
                 int velocityX = (int) velocityTracker.getXVelocity();
                 int velocityY = (int) velocityTracker.getYVelocity();
-//                Log.d("Engine_Driver", "gestureMove gestureVelocity vel " + velocityX);
+//                Log.d(threaded_application.applicationName, activityName + ": gestureMove(): gestureVelocity vel " + velocityX);
                 if ((Math.abs(velocityX) < threaded_application.min_fling_velocity) && (Math.abs(velocityY) < threaded_application.min_fling_velocity)) {
                     gestureFailed(event);
                 }
             }
 //            else {
-//                Log.d("Engine_Driver", "gestureMove event.getEventTime(): " +event.getEventTime()   + " gestureLastCheckTime: " + gestureLastCheckTime + " gestureCheckRate: " + gestureCheckRate);
-//                Log.d("Engine_Driver", "gestureMove event.getEventTime() - gestureLastCheckTime: " + (event.getEventTime() - gestureLastCheckTime) + " gestureCheckRate: " + gestureCheckRate);
+//                Log.d(threaded_application.applicationName, activityName + ": gestureMove(): event.getEventTime(): " +event.getEventTime()   + " gestureLastCheckTime: " + gestureLastCheckTime + " gestureCheckRate: " + gestureCheckRate);
+//                Log.d(threaded_application.applicationName, activityName + ": gestureMove(): event.getEventTime() - gestureLastCheckTime: " + (event.getEventTime() - gestureLastCheckTime) + " gestureCheckRate: " + gestureCheckRate);
 //            }
             if (gestureInProgress) {
                 // restart the gesture timeout timer
-//                Log.d("Engine_Driver","gestureSMove restart gesture timer");
+//                Log.d(threaded_application.applicationName, activityName + ": gestureMove(): restart gesture timer");
                 if (mainapp.throttle_msg_handler != null)
                     mainapp.throttle_msg_handler.postDelayed(gestureStopped, gestureCheckRate);
             }
@@ -7637,7 +7650,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     private void gestureEnd(MotionEvent event) {
-//        Log.d("Engine_Driver", "gestureEnd action " + event.getAction() + " inProgress? " + gestureInProgress);
+//        Log.d(threaded_application.applicationName, activityName + ": gestureEnd(): action " + event.getAction() + " inProgress? " + gestureInProgress);
         if ((mainapp != null) && (mainapp.throttle_msg_handler != null) && (gestureInProgress)) {
             mainapp.throttle_msg_handler.removeCallbacks(gestureStopped);
 
@@ -7723,7 +7736,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     private void gestureCancel(MotionEvent event) {
-//        Log.d("Engine_Driver", "gestureEnd gestureCancel");
+//        Log.d(threaded_application.applicationName, activityName + ": gestureEnd(): gestureCancel");
         if (mainapp.throttle_msg_handler != null)
             mainapp.throttle_msg_handler.removeCallbacks(gestureStopped);
         gestureInProgress = false;
@@ -7731,7 +7744,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     void gestureFailed(MotionEvent event) {
-//        Log.d("Engine_Driver", "gestureEnd gestureFailed");
+//        Log.d(threaded_application.applicationName, activityName + ": gestureEnd gestureFailed");
         // end the gesture
         gestureInProgress = false;
         gestureFailed = true;
@@ -7745,14 +7758,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     private final Runnable gestureStopped = new Runnable() {
         @Override
         public void run() {
-//            Log.d("Engine_Driver", "gestureStopped");
+//            Log.d(threaded_application.applicationName, activityName + ": gestureStopped()");
             if (gestureInProgress) {
                 // end the gesture
                 gestureInProgress = false;
                 gestureFailed = true;
                 // create a MOVE event to trigger the underlying control
                 if (vThrotScr != null) {
-//                    Log.d("Engine_Driver", "gestureStopped vThrotScr != null");
+//                    Log.d(threaded_application.applicationName, activityName + ": gestureStopped vThrotScr != null");
                     // use uptimeMillis() rather than 0 for time in
                     // MotionEvent.obtain() call in throttle gestureStopped:
                     MotionEvent event = MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(), MotionEvent.ACTION_MOVE, gestureStartX,
@@ -7760,7 +7773,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     try {
                         vThrotScr.dispatchTouchEvent(event);
                     } catch (IllegalArgumentException e) {
-                        Log.d("Engine_Driver", "gestureStopped trigger IllegalArgumentException, OS " + android.os.Build.VERSION.SDK_INT);
+                        Log.d(threaded_application.applicationName, activityName + ": gestureStopped trigger IllegalArgumentException, OS " + android.os.Build.VERSION.SDK_INT);
                     }
                 }
             }
@@ -7834,7 +7847,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             public void onClick(DialogInterface dialog, int whichButton) {
                 mainapp.exitDoubleBackButtonInitiated = 0;
                 passwordText = input.getText().toString();
-                Log.d("", "Password Value : " + passwordText);
+                Log.d(threaded_application.applicationName, activityName + ": showTimerPasswordDialog(): onClick(): Password Value : " + passwordText);
 
                 if (passwordText.equals(prefKidsTimerResetPassword)) { //reset
                     kidsTimerActions(kids_timer_action_type.ENDED, 0);
@@ -7867,7 +7880,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     @SuppressLint("SwitchIntDef")
     public void navigateToHandler(@RequestCodes int requestCode) {
-        Log.d("Engine_Driver", "throttle: navigateToHandler:" + requestCode);
+        Log.d(threaded_application.applicationName, activityName + ": navigateToHandler:" + requestCode);
         if (!PermissionsHelper.getInstance().isPermissionGranted(throttle.this, requestCode)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 PermissionsHelper.getInstance().requestNecessaryPermissions(throttle.this, requestCode);
@@ -7878,16 +7891,16 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             //noinspection SwitchStatementWithTooFewBranches
             switch (requestCode) {
 //                case PermissionsHelper.READ_SERVER_AUTO_PREFERENCES:
-//                    Log.d("Engine_Driver", "Got permission for READ_SERVER_AUTO_PREFERENCES");
+//                    Log.d(threaded_application.applicationName, activityName + ": navigateToHandler(): Got permission for READ_SERVER_AUTO_PREFERENCES");
 //                    autoImportUrlAskToImportImpl();
 //                    break;
 //                case PermissionsHelper.STORE_SERVER_AUTO_PREFERENCES:
-//                    Log.d("Engine_Driver", "Got permission for STORE_SERVER_AUTO_PREFERENCES");
+//                    Log.d(threaded_application.applicationName, activityName + ": navigateToHandler(): Got permission for STORE_SERVER_AUTO_PREFERENCES");
 //                    autoImportFromURLImpl();
 //                    break;
                 default:
                     // do nothing
-                    Log.d("Engine_Driver", "Unrecognised permissions request code: " + requestCode);
+                    Log.d(threaded_application.applicationName, activityName + ": navigateToHandler(): Unrecognised permissions request code: " + requestCode);
             }
         }
     }
@@ -7895,7 +7908,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     @Override
     public void onRequestPermissionsResult(@RequestCodes int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (!PermissionsHelper.getInstance().processRequestPermissionsResult(throttle.this, requestCode, permissions, grantResults)) {
-            Log.d("Engine_Driver", "Unrecognised request - send up to super class");
+            Log.d(threaded_application.applicationName, activityName + ": onRequestPermissionsResult(): Unrecognised request - send up to super class");
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
@@ -7914,7 +7927,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
         // Importing file in background thread
         @SuppressLint("ApplySharedPref")
         public void run() {
-            Log.d("Engine_Driver", "throttle: Import preferences from Server: start");
+            Log.d(threaded_application.applicationName, activityName + ": Import preferences from Server: start");
             int count;
             String n_url;
 
@@ -7933,14 +7946,14 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             try {
                 urlPreferencesFileName = "auto_" + mainapp.connectedHostName.replaceAll("[^A-Za-z0-9_]", "_") + ".ed";
                 urlPreferencesFilePath = context.getExternalFilesDir(null) + "/" + urlPreferencesFileName;
-                Log.d("Engine_Driver", "throttle: Import preferences from Server: linkg for: " + urlPreferencesFilePath);
+                Log.d(threaded_application.applicationName, activityName + ": Import preferences from Server: linkg for: " + urlPreferencesFilePath);
                 url = new URL(n_url);
 
                 connection = url.openConnection();
                 connection.connect();
 
             } catch (Exception e) {
-                Log.d("Engine_Driver", "throttle: Auto import preferences from Server Failed: " + e.getMessage());
+                Log.d(threaded_application.applicationName, activityName + ": Auto import preferences from Server Failed: " + e.getMessage());
                 return;
             }
 
@@ -7955,10 +7968,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                     localDate = new Date(timestamp);
 
                     if (localDate.compareTo(urlDate) >= 0) {
-                        Log.d("Engine_Driver", "throttle: Auto Import preferences from Server: Local file is up-to-date: " + localFile);
+                        Log.d(threaded_application.applicationName, activityName + ": Auto Import preferences from Server: Local file is up-to-date: " + localFile);
                         return;
 //                    } else {
-//                        Log.d("Engine_Driver", "throttle: Import preferences from Server: Local file is newer. Date " + localDate.toString());
+//                        Log.d(threaded_application.applicationName, activityName + ": Import preferences from Server: Local file is newer. Date " + localDate.toString());
                     }
                 }
 
@@ -7983,10 +7996,10 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
                 mainapp.sendMsg(mainapp.comm_msg_handler, message_type.IMPORT_SERVER_AUTO_AVAILABLE, "", 0);
 
             } catch (Exception e) {
-                Log.e("Engine_Driver", "throttle: Auto import preferences from Server Failed: " + e.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Auto import preferences from Server Failed: " + e.getMessage());
             }
 
-            Log.d("Engine_Driver", "throttle: Auto Import preferences from Server: End");
+            Log.d(threaded_application.applicationName, activityName + ": Auto Import preferences from Server: End");
             return;
         }
 
@@ -8038,7 +8051,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // restart the app so that the new preferences can be applied
     // note: should verify that permissions have been granted before calling this method since it will try to read the preference file
     private void loadSharedPreferencesFromFileImpl(SharedPreferences sharedPreferences, String exportedPreferencesFileName, String deviceId, int forceRestartReason) {
-        Log.d("Engine_Driver", "Preferences: Loading saved preferences from file: " + exportedPreferencesFileName);
+        Log.d(threaded_application.applicationName, activityName + ": loadSharedPreferencesFromFileImpl(): Loading saved preferences from file: " + exportedPreferencesFileName);
         boolean result = importExportPreferences.loadSharedPreferencesFromFile(getApplicationContext(), sharedPreferences, exportedPreferencesFileName, deviceId, false);
 
         if (!result) {
@@ -8052,7 +8065,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
 
     @SuppressLint("ApplySharedPref")
     public void forceRestartApp(int forcedRestartReason) {
-        Log.d("Engine_Driver", "throttle.forceRestartApp() ");
+        Log.d(threaded_application.applicationName, activityName + ": forceRestartApp() ");
         Message msg = Message.obtain();
         msg.what = message_type.RESTART_APP;
         msg.arg1 = forcedRestartReason;
@@ -8207,7 +8220,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     } // end getSpeedFromCurrentSliderPosition()
 
     void soundsStopAllSoundsForLoco(int whichThrottle) {
-//        Log.d("Engine_Driver", "soundsStopAllSoundsForLoco : (locoSound) wt: " + whichThrottle);
+//        Log.d(threaded_application.applicationName, activityName + ": soundsStopAllSoundsForLoco(): (locoSound) wt: " + whichThrottle);
         if (mainapp.soundPool != null) {
             for (int i = 0; i < 17; i++) {
                 mainapp.soundPool.stop(mainapp.soundsLocoStreamId[whichThrottle][i]);
@@ -8304,7 +8317,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     }
 
     private void handleDeviceButtonAction(int whichThrottle, int buttonType, int soundType, int action) {
-        Log.d("Engine_Driver", "handleDeviceButtonAction: handleAction - action: " + action);
+        Log.d(threaded_application.applicationName, activityName + ": handleDeviceButtonAction(): handleAction - action: " + action);
 
         if ((buttonType == sounds_type.BUTTON_BELL) && (!mainapp.prefDeviceSoundsBellIsMomentary)) {
             boolean rslt = !mainapp.soundsDeviceButtonStates[whichThrottle][buttonType];
@@ -8456,6 +8469,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
     // used for swipes for the main activities only - Throttle, Turnouts, Routes, Web
     protected void startACoreActivity(Activity activity, Intent in, boolean swipe, float deltaX) {
         if (activity != null && in != null) {
+            threaded_application.activityInTransition(activityName);
             in.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             ActivityOptions options;
             if (deltaX > 0) {
@@ -8498,7 +8512,7 @@ public class throttle extends AppCompatActivity implements android.gesture.Gestu
             whichThrottle = WhichThrottle;
             stepMultiplier = StepMultiplier;
 
-            Log.d("Engine_Driver", "GamepadRptUpdater: WhichThrottle: " + whichThrottle
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticGamepadRptUpdater(): WhichThrottle: " + whichThrottle
                     + " mGamepadAutoIncrement: " + (mGamepadAutoIncrement ? "True" : "False")
                     + " mGamepadAutoDecrement: " + (mGamepadAutoDecrement ? "True" : "False")
             );

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_big_buttons.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_big_buttons.java
@@ -40,6 +40,7 @@ import jmri.enginedriver.type.slider_type;
 import jmri.enginedriver.type.web_view_location_type;
 
 public class throttle_big_buttons extends throttle {
+    static final String activityName = "throttle_big_buttons";
 
     protected static final int MAX_SCREEN_THROTTLES = 1;
 
@@ -56,7 +57,7 @@ public class throttle_big_buttons extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_big_buttons: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
         mainapp.maxThrottlesCurrentScreen = MAX_SCREEN_THROTTLES;
@@ -107,9 +108,16 @@ public class throttle_big_buttons extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle_big_buttons: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -135,7 +143,7 @@ public class throttle_big_buttons extends throttle {
 
 
     protected void set_labels() {
-//        Log.d("Engine_Driver","throttle_big_buttons: set_labels() starting");
+//        Log.d(threaded_application.applicationName, activityName + ": set_labels() starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) { return;}
@@ -152,7 +160,7 @@ public class throttle_big_buttons extends throttle {
             if ( (mainapp.consists != null) && (mainapp.consists[throttleIndex] != null)
                     && (mainapp.consists[throttleIndex].isActive()) ) {
                 if (!prefShowAddressInsteadOfName) {
-                    if (!overrideThrottleNames[throttleIndex].equals("")) {
+                    if (!overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = overrideThrottleNames[throttleIndex];
                         bLabelPlainText = overrideThrottleNames[throttleIndex];
                     } else {
@@ -164,7 +172,7 @@ public class throttle_big_buttons extends throttle {
 //                    bLabelPlainText = mainapp.consists[throttleIndex].toString();
 //                    bLabel = mainapp.consists[throttleIndex].toHtml();
                 } else {
-                    if (overrideThrottleNames[throttleIndex].equals("")) {
+                    if (overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = mainapp.consists[throttleIndex].formatConsistAddr();
                     } else {
                         bLabel = overrideThrottleNames[throttleIndex];
@@ -248,7 +256,7 @@ public class throttle_big_buttons extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = dm.heightPixels - (int) (titleBar * (dm.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         ImageView myImage = findViewById(R.id.backgroundImgView);
@@ -278,7 +286,7 @@ public class throttle_big_buttons extends throttle {
             setAllFunctionStates(throttleIndex);
         }
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": ending set_labels");
 
     }
 
@@ -301,8 +309,7 @@ public class throttle_big_buttons extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView() " + newEnabledState);
 
         if (vg == null) { return;}
         if (mainapp.appIsFinishing) { return;}
@@ -321,7 +328,7 @@ public class throttle_big_buttons extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -336,7 +343,7 @@ public class throttle_big_buttons extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         Button b;
         boolean[] fs;   // copy of this throttle's function state array

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_original.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_original.java
@@ -38,6 +38,7 @@ import jmri.enginedriver.type.slider_type;
 import jmri.enginedriver.type.web_view_location_type;
 
 public class throttle_original extends throttle {
+    static final String activityName = "throttle_original";
 
     protected static final int MAX_SCREEN_THROTTLES = 3;
 
@@ -50,8 +51,7 @@ public class throttle_original extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView() " + newEnabledState);
 
         if (vg == null) {
             return;
@@ -74,7 +74,7 @@ public class throttle_original extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) {
             return;
@@ -91,7 +91,7 @@ public class throttle_original extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         if (function > threaded_application.MAX_FUNCTION_NUMBER)
             return; //bail if this function number not supported
@@ -117,7 +117,7 @@ public class throttle_original extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_original: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
         mainapp.maxThrottlesCurrentScreen = MAX_SCREEN_THROTTLES;
@@ -181,7 +181,7 @@ public class throttle_original extends throttle {
 //    @SuppressWarnings("deprecation")
 //    @Override
     protected void set_labels() {
-//        Log.d("Engine_Driver", "throttle_original: set_labels() starting");
+//        Log.d(threaded_application.applicationName, activityName + ": set_labels() starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) {
@@ -224,7 +224,7 @@ public class throttle_original extends throttle {
         String bLabelPlainText;
 
         if (mainapp.consists == null) {
-            Log.d("Engine_Driver", "throttle_original.setLabels consists is null");
+            Log.d(threaded_application.applicationName, activityName + ": set_Labels() consists is null");
             return;
         }
 
@@ -235,11 +235,11 @@ public class throttle_original extends throttle {
 
             Consist con = mainapp.consists[throttleIndex];
             if (con == null) {
-                Log.d("Engine_Driver", "throttle_original setLabels consists[" + throttleIndex + "] is null");
+                Log.d(threaded_application.applicationName, activityName + ": set_Labels() consists[" + throttleIndex + "] is null");
             } else {
                 if (con.isActive()) {
                     if (!prefShowAddressInsteadOfName) {
-                        if (!overrideThrottleNames[throttleIndex].equals("")) {
+                        if (!overrideThrottleNames[throttleIndex].isEmpty()) {
                             bLabel = overrideThrottleNames[throttleIndex];
                             bLabelPlainText = overrideThrottleNames[throttleIndex];
                         } else {
@@ -251,7 +251,7 @@ public class throttle_original extends throttle {
 //                        bLabelPlainText = mainapp.consists[throttleIndex].toString();
 //                        bLabel = mainapp.consists[throttleIndex].toHtml();
                     } else {
-                        if (overrideThrottleNames[throttleIndex].equals("")) {
+                        if (overrideThrottleNames[throttleIndex].isEmpty()) {
                             bLabel = con.formatConsistAddr();
                         } else {
                             bLabel = overrideThrottleNames[throttleIndex];
@@ -345,7 +345,7 @@ public class throttle_original extends throttle {
 
 
         if ((screenHeight > throttleMargin) && (mainapp.consists != null)) { // don't do this if height is invalid
-            //Log.d("Engine_Driver","starting screen height adjustments, screenHeight=" + screenHeight);
+            // Log.d(threaded_application.applicationName, activityName + ": starting screen height adjustments, screenHeight=" + screenHeight);
             // determine how to split the screen (evenly if all three, 45/45/10 for two, 80/10/10 if only one)
 
             adjustThrottleHeights();
@@ -371,11 +371,11 @@ public class throttle_original extends throttle {
                 sliderBottomRightX[throttleIndex] = x + sbSpeeds[throttleIndex].getWidth() - ovx;
                 sliderBottomRightY[throttleIndex] = y + sbSpeeds[throttleIndex].getHeight() - ovy;
 
-//            Log.d("Engine_Driver","slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
+//            Log.d(threaded_application.applicationName, activityName + ": set_labels(): slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
 //                    + " Bottom: " + sliderBottomRightX[throttleIndex] + ", " + sliderBottomRightY[throttleIndex]);
             }
         } else {
-            Log.d("Engine_Driver", "screen height adjustments skipped, screenHeight=" + screenHeight);
+            Log.d(threaded_application.applicationName, activityName + ": screen height adjustments skipped, screenHeight=" + screenHeight);
         }
 
         // update the direction indicators
@@ -386,7 +386,7 @@ public class throttle_original extends throttle {
             setAllFunctionStates(throttleIndex);
         }
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels() end");
 
     }
 
@@ -503,7 +503,7 @@ public class throttle_original extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = displayMetrics.heightPixels - (int) (titleBar * (displayMetrics.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            // Log.d(threaded_application.applicationName, activityName + ": vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         double height = screenHeight;

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_semi_realistic.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_semi_realistic.java
@@ -60,6 +60,7 @@ import jmri.enginedriver.type.speed_commands_from_type;
 import jmri.enginedriver.type.stop_button_type;
 
 public class throttle_semi_realistic extends throttle {
+    static final String activityName = "throttle_semi_realistic";
 
     protected static final int MAX_SCREEN_THROTTLES = 1;
 
@@ -190,7 +191,7 @@ public class throttle_semi_realistic extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "srmt: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
 
@@ -365,9 +366,16 @@ public class throttle_semi_realistic extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "srmt: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return; }
 
@@ -391,7 +399,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     protected void set_labels() {
-        Log.d("Engine_Driver", "srmt: set_labels(): starting");
+        Log.d(threaded_application.applicationName, activityName + ": set_labels(): starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) { return; }
@@ -681,7 +689,7 @@ public class throttle_semi_realistic extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","srmt: set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states");
 
         if (mainapp.appIsFinishing) {
             return;
@@ -737,7 +745,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void onProgressChanged(SeekBar sbSemiRealisticThrottle, int newSliderPosition, boolean fromUser) {
-             Log.d("Engine_Driver","srmt: SemiRealisticThrottleSliderListener: onProgressChanged()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticThrottleSliderListener: onProgressChanged()");
             // limit speed change if change was initiated by a user slider touch (prevents "bouncing")
             if ((fromUser) || (vsbSemiRealisticThrottles[whichThrottle].touchFromUser)) {
                 if (semiRealisticThrottleGestureState == GESTURE_STARTED) {
@@ -754,21 +762,21 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void onStartTrackingTouch(SeekBar sbThrottle) {
-            Log.d("Engine_Driver","srmt: SemiRealisticThrottleSliderListener: onStartTrackingTouch()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticThrottleSliderListener: onStartTrackingTouch()");
             semiRealisticThrottleGestureState = GESTURE_STARTED;
             gestureInProgress = false;
         }
 
         @Override
         public void onStopTrackingTouch(SeekBar sbThrottle) {
-            Log.d("Engine_Driver","srmt: SemiRealisticThrottleSliderListener: onStopTrackingTouch()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticThrottleSliderListener: onStopTrackingTouch()");
             finalSliderPosition = getSemiRealisticThrottleSlider(whichThrottle).getProgress();
             semiRealisticThrottleGestureState = GESTURE_FINISHED;
             autoIncrementDecrement();
         }
 
         public void autoIncrementDecrement() {
-            Log.d("Engine_Driver","srmt: SemiRealisticThrottleSliderListener: autoIncrementDecrement()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticThrottleSliderListener: autoIncrementDecrement()");
             if (lastSliderPosition == finalSliderPosition) {
                 int targetSpeed = getSpeedFromSemiRealisticThrottleCurrentSliderPosition(whichThrottle);
                 if (getSpeed(whichThrottle) < targetSpeed) {
@@ -947,7 +955,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void onClick(View v) {
-            Log.d("Engine_Driver","srmt: AirButtonTouchListener: onClick()");
+            Log.d(threaded_application.applicationName, activityName + ": AirButtonTouchListener: onClick()");
             airEnabled = !airEnabled;
             showAirButtonState(whichThrottle);
             mainapp.buttonVibration();
@@ -981,7 +989,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public boolean onLongClick(View v) {
-            Log.d("Engine_Driver","srmt: TargetArrowSpeedButtonTouchListener: onLongClick()");
+            Log.d(threaded_application.applicationName, activityName + ": TargetArrowSpeedButtonTouchListener: onLongClick()");
             boolean repeatRequired = true;
             mainapp.exitDoubleBackButtonInitiated = 0;
             if (arrowDirection.equals(speed_button_type.RIGHT)) {
@@ -1007,7 +1015,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void onClick(View v) {
-            Log.d("Engine_Driver","srmt: TargetArrowSpeedButtonTouchListener: onClick()");
+            Log.d(threaded_application.applicationName, activityName + ": TargetArrowSpeedButtonTouchListener: onClick()");
             mainapp.exitDoubleBackButtonInitiated = 0;
             if (arrowDirection.equals(speed_button_type.RIGHT)) {
                 stopSemiRealsticThrottleSpeedButtonRepeater(whichThrottle);
@@ -1054,7 +1062,7 @@ public class throttle_semi_realistic extends throttle {
         @SuppressLint("ClickableViewAccessibility")
         @Override
         public boolean onTouch(View v, MotionEvent event) {
-            Log.d("Engine_Driver","srmt: TargetArrowSpeedButtonTouchListener: onTouch(): event: " + event.getAction());
+            Log.d(threaded_application.applicationName, activityName + ": TargetArrowSpeedButtonTouchListener: onTouch(): event: " + event.getAction());
             mainapp.exitDoubleBackButtonInitiated = 0;
             if ((event.getAction() == MotionEvent.ACTION_UP || event.getAction() == MotionEvent.ACTION_CANCEL)
                     && mSemiRealisticSpeedButtonsAutoIncrementOrDecrement[whichThrottle] == auto_increment_or_decrement_type.INCREMENT) {
@@ -1087,7 +1095,7 @@ public class throttle_semi_realistic extends throttle {
 
     @Override
     void doVolumeButtonAction(int action, int key, int repeatCnt) {
-        Log.d("Engine_Driver", "srmt: doVolumeButtonAction(): action: " + action);
+        Log.d(threaded_application.applicationName, activityName + ": doVolumeButtonAction(): action: " + action);
         if (action==ACTION_UP) {
             mVolumeKeysAutoIncrement = false;
             mVolumeKeysAutoDecrement = false;
@@ -1148,7 +1156,7 @@ public class throttle_semi_realistic extends throttle {
 
     @Override
     void semiRealisticThrottleSliderPositionUpdate(int whichThrottle, int newSpeed) {
-        Log.d("Engine_Driver","srmt: semiRealisticThrottleSliderPositionUpdate(): newSpeed " + newSpeed);
+        Log.d(threaded_application.applicationName, activityName + ": semiRealisticThrottleSliderPositionUpdate(): newSpeed " + newSpeed);
         if (newSpeed < 0)
             newSpeed = 0;
         int sliderPosition = getNewSemiRealisticThrottleSliderPositionFromSpeed(newSpeed, whichThrottle);
@@ -1163,7 +1171,7 @@ public class throttle_semi_realistic extends throttle {
         setSemiRealisticAutoIncrementDecrement(whichThrottle, auto_increment_or_decrement_type.DECREMENT);
     }
     protected void setSemiRealisticAutoIncrementDecrement(int whichThrottle, int direction) {
-        Log.d("Engine_Driver","srmt: setSemiRealisticAutoIncrementDecrement(): direction " + direction);
+        Log.d(threaded_application.applicationName, activityName + ": setSemiRealisticAutoIncrementDecrement(): direction " + direction);
         switch (direction) {
             case auto_increment_or_decrement_type.OFF:
             case auto_increment_or_decrement_type.INCREMENT:
@@ -1182,7 +1190,7 @@ public class throttle_semi_realistic extends throttle {
 
     @Override
     public void decrementSemiRealisticThrottlePosition(int whichThrottle, int from) {
-        Log.d("Engine_Driver","srmt: decrementSemiRealisticThrottlePosition(): from: " + from);
+        Log.d(threaded_application.applicationName, activityName + ": decrementSemiRealisticThrottlePosition(): from: " + from);
         decrementSemiRealisticThrottlePosition(whichThrottle, from, 1);
     }
     @Override
@@ -1217,7 +1225,7 @@ public class throttle_semi_realistic extends throttle {
     }
     @Override
     public void incrementSemiRealisticThrottlePosition(int whichThrottle, int from, int stepMultiplier) {
-        Log.d("Engine_Driver","srmt: incrementSemiRealisticThrottlePosition(): from: " + from);
+        Log.d(threaded_application.applicationName, activityName + ": incrementSemiRealisticThrottlePosition(): from: " + from);
         switch (from) {
             case speed_commands_from_type.BUTTONS:
                 updateSemiRealisticThrottleSliderAndTargetSpeed(whichThrottle, prefSpeedButtonsSpeedStep);
@@ -1270,7 +1278,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void updateBrakeSliderAndTargetSpeed(int whichThrottle, int delta) {
-        Log.d("Engine_Driver","srmt: updateBrakeSliderAndTargetSpeed(): delta: " + delta);
+        Log.d(threaded_application.applicationName, activityName + ": updateBrakeSliderAndTargetSpeed(): delta: " + delta);
         int brakeSliderPosition = getBrakeSliderPosition(whichThrottle);
         int newPosition = brakeSliderPosition+delta;
         getBrakeSlider(whichThrottle).setProgress(newPosition);
@@ -1288,7 +1296,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void updateLoadSliderAndTargetSpeed(int whichThrottle, int delta) {
-        Log.d("Engine_Driver","srmt: updateBrakeSliderAndTargetSpeed(): delta: " + delta);
+        Log.d(threaded_application.applicationName, activityName + ": updateBrakeSliderAndTargetSpeed(): delta: " + delta);
         int loadSliderPosition = getLoadSliderPosition(whichThrottle);
         int newPosition = loadSliderPosition+delta;
         getLoadSlider(whichThrottle).setProgress(newPosition);
@@ -1334,7 +1342,7 @@ public class throttle_semi_realistic extends throttle {
     @SuppressLint("DefaultLocale")
     @Override
     void setTargetSpeed(int whichThrottle, boolean fromSlider) {
-        Log.d("Engine_Driver","srmt: setTargetSpeed(): fromSlider: " + fromSlider);
+        Log.d(threaded_application.applicationName, activityName + ": setTargetSpeed(): fromSlider: " + fromSlider);
         int targetSpeed;
         int sliderSpeed;
         if (fromSlider) {
@@ -1344,7 +1352,7 @@ public class throttle_semi_realistic extends throttle {
         }
 
         sliderSpeed = getSpeedFromSemiRealisticThrottleCurrentSliderPosition(whichThrottle);
-//        Log.d("Engine_Driver",String.format("srmt: X targetSpeed: %d sliderSpeed: %d", targetSpeed, sliderSpeed));
+//        Log.d(threaded_application.applicationName, activityName + ": X targetSpeed: %d sliderSpeed: %d", targetSpeed, sliderSpeed));
         int targetDirection = getTargetDirection(whichThrottle);
         double targetAccelleration = 1; //default
         double brakeSliderPosition = getBrakeSliderPosition(whichThrottle);
@@ -1372,7 +1380,7 @@ public class throttle_semi_realistic extends throttle {
             }
         }
 
-//        Log.d("Engine_Driver",String.format("srmt: X airLine: %.2f airLineAsBrakeStep: %.2f airLineAsBrakePcnt: %.2f brakePcnt: %.2f targetSpeed: %d effectiveBrake: %.2f",
+//        Log.d(threaded_application.applicationName, activityName + ": X airLine: %.2f airLineAsBrakeStep: %.2f airLineAsBrakePcnt: %.2f brakePcnt: %.2f targetSpeed: %d effectiveBrake: %.2f",
 //        airLine, airLineAsBrakeStep, airLineAsBrakePcnt, brakePcnt, targetSpeed, effectiveBrake));
 
         double intermediateBrake;
@@ -1384,7 +1392,7 @@ public class throttle_semi_realistic extends throttle {
             if (targetSpeed == 0) { // throttle is at zero
                 intermediateBrake = -1 * effectiveBrake;
                 targetAccelleration = intermediateBrake;
-//                Log.d("Engine_Driver",String.format("srmt: X (Target Speed zero) intermediateBrake: %.2f", intermediateBrake));
+//                Log.d(threaded_application.applicationName, activityName + ": X (Target Speed zero) intermediateBrake: %.2f", intermediateBrake));
 
             } else { // throttle is still active
                 targetSpeed = (int) (Math.round((double) sliderSpeed) - (Math.round((double) sliderSpeed) * (1 - effectiveBrake)) );
@@ -1393,17 +1401,17 @@ public class throttle_semi_realistic extends throttle {
 //                    intermediateBrake = -1 * (1 - (effectiveBrake * effectiveBrake * maxBrakeUnderPower));
                     intermediateBrake = -1 * ( 1 - effectiveBrake * maxBrakeUnderPower);
                     targetAccelleration = intermediateBrake;
-//                    Log.d("Engine_Driver",String.format("srmt: X (Lower Speed) intermediateBrake: %.2f targetSpeed: %d",intermediateBrake, targetSpeed));
+//                    Log.d(threaded_application.applicationName, activityName + ": X (Lower Speed) intermediateBrake: %.2f targetSpeed: %d",intermediateBrake, targetSpeed));
 
                 } else {
 //                    intermediateBrake = 1 - (effectiveBrake * effectiveBrake * maxBrake);
                     intermediateBrake = 1 + (1 - effectiveBrake * maxBrake);
                     targetAccelleration = intermediateBrake;
-//                    Log.d("Engine_Driver",String.format("srmt: X (Higher Speed) intermediateBrake: %.2f targetSpeed: %d",intermediateBrake, targetSpeed));
+//                    Log.d(threaded_application.applicationName, activityName + ": X (Higher Speed) intermediateBrake: %.2f targetSpeed: %d",intermediateBrake, targetSpeed));
                 }
             }
         }
-//        Log.d("Engine_Driver",String.format("srmt: X intermediateBrake: %.2f targetAccelleration: %.2f",intermediateBrake, targetAccelleration));
+//        Log.d(threaded_application.applicationName, activityName + ": X intermediateBrake: %.2f targetAccelleration: %.2f",intermediateBrake, targetAccelleration));
 
         // load
 //        double intermediateLoad = 1;
@@ -1412,13 +1420,13 @@ public class throttle_semi_realistic extends throttle {
                     * getLoadPcnt(loadSliderPosition, prefSemiRealisticThrottleNumberOfLoadSteps, maxLoad);
         }
 
-//        Log.d("Engine_Driver",String.format("srmt: X 1 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
+//        Log.d(threaded_application.applicationName, activityName + ": X 1 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
 
         // check max and min
         if (targetSpeed < 0) targetSpeed = 0;
         if (targetSpeed > maxThrottle) targetSpeed = maxThrottle;
 
-//        Log.d("Engine_Driver",String.format("srmt: X 2 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
+//        Log.d(threaded_application.applicationName, activityName + ": X 2 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
 
         // check up or down
         if ( ((targetSpeed < speed) && (targetAccelleration > 0))
@@ -1426,7 +1434,7 @@ public class throttle_semi_realistic extends throttle {
             targetAccelleration = targetAccelleration * -1;
         }
 
-        Log.d("Engine_Driver",String.format("srmt: X 3 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
+        Log.d(threaded_application.applicationName, activityName + ":" + String.format(" X 3 targetSpeed: %d targetAccelleration: %.2f",targetSpeed, targetAccelleration));
 
         targetAccelerations[whichThrottle] = targetAccelleration;
 //        targetAccelerationsForDisplay[whichThrottle] = String.format("a:%.2f b:%.2f l:%.2f A:%.2f", air, intermediateBrake, intermediateLoad, getTargetAccelleration(whichThrottle));
@@ -1493,7 +1501,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void updateSemiRealisticThrottleSliderAndTargetSpeed(int whichThrottle, int delta) {
-        Log.d("Engine_Driver","srmt: updateSemiRealisticThrottleSliderAndTargetSpeed(): delta: " + delta);
+        Log.d(threaded_application.applicationName, activityName + ": updateSemiRealisticThrottleSliderAndTargetSpeed(): delta: " + delta);
         int currentPosition = getSemiRealisticThrottleSlider(whichThrottle).getProgress();
         int newPosition = currentPosition+delta;
         getSemiRealisticThrottleSlider(whichThrottle).setProgress(newPosition);
@@ -1501,7 +1509,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     protected void displayTargetScaleSpeed(int whichThrottle) {
-        Log.d("Engine_Driver","srmt: displayTargetScaleSpeed():");
+        Log.d(threaded_application.applicationName, activityName + ": displayTargetScaleSpeed():");
         int targetSpeed = targetSpeeds[whichThrottle];
         int targetDirection = targetDirections[whichThrottle];
 
@@ -1530,7 +1538,7 @@ public class throttle_semi_realistic extends throttle {
             target_speed_label.setText(result);
             mainapp.throttleVibration(scaleSpeed, prevScaleSpeed);
         } catch (NumberFormatException | ClassCastException e) {
-            Log.e("Engine_Driver", "srmt: problem showing Target speed: " + e.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": problem showing Target speed: " + e.getMessage());
         }
     }
 
@@ -1557,34 +1565,34 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
     protected int getSpeedFromSemiRealisticThrottleCurrentSliderPosition(int whichThrottle) {
-        Log.d("Engine_Driver", "srmt: getSpeedFromSemiRealisticThrottleCurrentSliderPosition()");
+        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSemiRealisticThrottleCurrentSliderPosition()");
         int semiRealisticThrottleSpeed = 0;
         if (vsbSemiRealisticThrottles[whichThrottle].isEnabled()) {
             semiRealisticThrottleSpeed = getSpeedFromSemiRealisticThrottleNewSliderPosition(vsbSemiRealisticThrottles[whichThrottle].getProgress(), whichThrottle);
         }
-//        Log.d("Engine_Driver", "srmt: getSpeedFromSemiRealisticThrottleCurrentSliderPosition(): " + semiRealisticThrottleSpeed);
+//        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSemiRealisticThrottleCurrentSliderPosition(): " + semiRealisticThrottleSpeed);
         return semiRealisticThrottleSpeed;
     }
 
     int getSpeedFromSemiRealisticThrottleNewSliderPosition(int sliderPosition, int whichThrottle) {
-        Log.d("Engine_Driver", "srmt: getSpeedFromSemiRealisticThrottleNewSliderPosition()");
+        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSemiRealisticThrottleNewSliderPosition()");
         double scale = 1;
         if (useNotches)  scale = 100 / ((double) prefDisplaySemiRealisticThrottleNotches);
         double max = ((double) maxThrottle) / 100;
 
         int semiRealisticThrottleSpeed = (int) Math.round( ((double) sliderPosition) * scale * max);
-        Log.d("Engine_Driver", "srmt: getSpeedFromSemiRealisticThrottleNewSliderPosition(): pref: " + prefDisplaySemiRealisticThrottleNotches + " position: " + sliderPosition + " scale: " + scale + " speed: " + semiRealisticThrottleSpeed);
+        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSemiRealisticThrottleNewSliderPosition(): pref: " + prefDisplaySemiRealisticThrottleNotches + " position: " + sliderPosition + " scale: " + scale + " speed: " + semiRealisticThrottleSpeed);
         return semiRealisticThrottleSpeed;
     }
 
     int getNewSemiRealisticThrottleSliderPositionFromSpeed(int newSpeed, int whichThrottle) {
-        Log.d("Engine_Driver", "srmt: getNewSemiRealisticThrottleSliderPositionFromSpeed()");
+        Log.d(threaded_application.applicationName, activityName + ": getNewSemiRealisticThrottleSliderPositionFromSpeed()");
         double scale = 1;
         if (useNotches)  scale = 100 / ((double) prefDisplaySemiRealisticThrottleNotches);
         double max = ((double) maxThrottle) / 126;
 
         int newSliderPosition = (int) Math.round(newSpeed / scale * max);
-        Log.d("Engine_Driver", "srmt: getNewSemiRealisticThrottleSliderPositionFromSpeed(): pref: " + prefDisplaySemiRealisticThrottleNotches + " new speed: " + newSpeed + " scale: " + scale  + " new pos: " + newSliderPosition);
+        Log.d(threaded_application.applicationName, activityName + ": getNewSemiRealisticThrottleSliderPositionFromSpeed(): pref: " + prefDisplaySemiRealisticThrottleNotches + " new speed: " + newSpeed + " scale: " + scale  + " new pos: " + newSliderPosition);
         return newSliderPosition;
     }
 
@@ -1852,7 +1860,7 @@ public class throttle_semi_realistic extends throttle {
         }
 
         private void doButtonPress() {
-            Log.d("Engine_Driver", "srmt: SemiRealisticDirectionButtonTouchListener: doButtonPress()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticDirectionButtonTouchListener: doButtonPress()");
             boolean result = false;
             mainapp.exitDoubleBackButtonInitiated = 0;
 
@@ -1900,7 +1908,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void run() {
-            Log.d("Engine_Driver","srmt: SemiRealisticSpeedButtonRptUpdater: run()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticSpeedButtonRptUpdater: run()");
 
             if (mainapp.appIsFinishing) { return;}
 
@@ -1929,7 +1937,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void run() {
-            Log.d("Engine_Driver","srmt: SemiRealisticTargetSpeedRptUpdater: run()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticTargetSpeedRptUpdater: run()");
             if (mainapp.appIsFinishing) { return;}
 
             if (getSpeed(whichThrottle) == targetSpeeds[whichThrottle]) return;
@@ -1960,7 +1968,7 @@ public class throttle_semi_realistic extends throttle {
         return getSemiRealisticTargetSpeedRptDelay(whichThrottle, getRepeatDelay(whichThrottle));
     }
     int getSemiRealisticTargetSpeedRptDelay(int whichThrottle, int repeatDelay) {
-        Log.d("Engine_Driver","srmt: getSemiRealisticTargetSpeedRptDelay():" + ((int) Math.round( ((double) repeatDelay) * getTargetAccelleration(whichThrottle))) );
+        Log.d(threaded_application.applicationName, activityName + ": getSemiRealisticTargetSpeedRptDelay():" + ((int) Math.round( ((double) repeatDelay) * getTargetAccelleration(whichThrottle))) );
         return (int) Math.round( ((double) repeatDelay) * getTargetAccelleration(whichThrottle) );
     }
 
@@ -1968,7 +1976,7 @@ public class throttle_semi_realistic extends throttle {
         return getRepeatDelay(whichThrottle, 0);
     }
     int getRepeatDelay(int whichThrottle, int myRepeatDelay) {
-        Log.d("Engine_Driver","srmt: getRepeatDelay():");
+        Log.d(threaded_application.applicationName, activityName + ": getRepeatDelay():");
         int repeatDelay = myRepeatDelay;
 
         if (repeatDelay==0) {
@@ -1982,7 +1990,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void restartSemiRealisticThrottleTargetSpeedRepeater(int whichThrottle, int delayMillis) {
-        Log.d("Engine_Driver","srmt: restartSemiRealisticThrottleTargetSpeedRepeater(): delayMillis: " + delayMillis);
+        Log.d(threaded_application.applicationName, activityName + ": restartSemiRealisticThrottleTargetSpeedRepeater(): delayMillis: " + delayMillis);
         if (delayMillis == 0) {
             semiRealisticTargetSpeedUpdateHandlers[whichThrottle]
                     .post(new SemiRealisticTargetSpeedRptUpdater(whichThrottle, getRepeatDelay(whichThrottle)));
@@ -1993,7 +2001,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void restartSemiRealisticThrottleSpeedButtonRepeater(int whichThrottle, int direction, int delayMillis) {
-        Log.d("Engine_Driver","srmt: restartSemiRealisticThrottleSpeedButtonRepeater(): delayMillis: " + delayMillis);
+        Log.d(threaded_application.applicationName, activityName + ": restartSemiRealisticThrottleSpeedButtonRepeater(): delayMillis: " + delayMillis);
         semiRealisticSpeedButtonLongPressActive = true;
         mSemiRealisticSpeedButtonsAutoIncrementOrDecrement[whichThrottle] = direction;
         if (delayMillis == 0) {
@@ -2004,7 +2012,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void stopSemiRealsticThrottleSpeedButtonRepeater(int whichThrottle) {
-        Log.d("Engine_Driver","srmt: stopSemiRealsticThrottleSpeedButtonRepeater()");
+        Log.d(threaded_application.applicationName, activityName + ": stopSemiRealsticThrottleSpeedButtonRepeater()");
         semiRealisticSpeedButtonLongPressActive = false;
         prevTargetSpeeds[whichThrottle] = 999;
         prevLoads[whichThrottle] = 999;
@@ -2024,7 +2032,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void run() {
-            Log.d("Engine_Driver","srmt: SemiRealisticAirRptUpdater: run()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticAirRptUpdater: run()");
             if (mainapp.appIsFinishing) { return;}
 
             if (getAirValue(whichThrottle) >= 100) {
@@ -2045,7 +2053,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void startSemiRealisticThrottleAirRepeater(int whichThrottle) {
-        Log.d("Engine_Driver","srmt: restartSemiRealisticThrottleAirRepeater():");
+        Log.d(threaded_application.applicationName, activityName + ": restartSemiRealisticThrottleAirRepeater():");
         isAirRechaging = true;
         semiRealisticAirUpdateHandlers[whichThrottle].removeCallbacks(null);
         semiRealisticAirUpdateHandlers[whichThrottle]
@@ -2064,7 +2072,7 @@ public class throttle_semi_realistic extends throttle {
 
         @Override
         public void run() {
-            Log.d("Engine_Driver","srmt: SemiRealisticAirLineRptUpdater: run()");
+            Log.d(threaded_application.applicationName, activityName + ": SemiRealisticAirLineRptUpdater: run()");
             if (mainapp.appIsFinishing) { return;}
 
             if ( (getAirLineValue(whichThrottle) >= 100) || (getBrakeSliderPosition(whichThrottle) > 0)) {  // can't recharge the line if the brake is active
@@ -2094,7 +2102,7 @@ public class throttle_semi_realistic extends throttle {
     }
 
     void startSemiRealisticThrottleAirLineRepeater(int whichThrottle) {
-        Log.d("Engine_Driver","srmt: restartSemiRealisticThrottleAirLineRepeater():");
+        Log.d(threaded_application.applicationName, activityName + ": restartSemiRealisticThrottleAirLineRepeater():");
         isAirLineRechaging = true;
         semiRealisticAirLineUpdateHandlers[whichThrottle].removeCallbacks(null);
         semiRealisticAirLineUpdateHandlers[whichThrottle]

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_simple.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_simple.java
@@ -39,6 +39,7 @@ import jmri.enginedriver.util.VerticalSeekBar;
 import jmri.enginedriver.type.slider_type;
 
 public class throttle_simple extends throttle {
+    static final String activityName = "throttle_simple";
 
     protected static final int MAX_SCREEN_THROTTLES = 6;
 
@@ -60,7 +61,7 @@ public class throttle_simple extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_simple: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
         mainapp.maxThrottlesCurrentScreen = MAX_SCREEN_THROTTLES;
@@ -146,9 +147,16 @@ public class throttle_simple extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle_simple: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -167,7 +175,7 @@ public class throttle_simple extends throttle {
 
 
     protected void set_labels() {
-//        Log.d("Engine_Driver","throttle_simple: set_labels() starting");
+//        Log.d(threaded_application.applicationName, activityName + ": set_labels() starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) { return;}
@@ -272,7 +280,7 @@ public class throttle_simple extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = dm.heightPixels - (int) (titleBar * (dm.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         // always hide the webview for this layout
@@ -352,7 +360,7 @@ public class throttle_simple extends throttle {
             sliderBottomRightX[throttleIndex] = x + vsbSpeeds[throttleIndex].getWidth() - ovx;
             sliderBottomRightY[throttleIndex] = y + vsbSpeeds[throttleIndex].getHeight() -ovy;
 
-//            Log.d("Engine_Driver","slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
+//            Log.d(threaded_application.applicationName, activityName + ": slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
 //                    + " Bottom: " + sliderBottomRightX[throttleIndex] + ", " + sliderBottomRightY[throttleIndex]);
         }
 
@@ -364,7 +372,7 @@ public class throttle_simple extends throttle {
         }
 
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels() end");
 
     }
 
@@ -388,8 +396,7 @@ public class throttle_simple extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView() " + newEnabledState);
 
         if (vg == null) { return;}
         if (mainapp.appIsFinishing) { return;}
@@ -408,7 +415,7 @@ public class throttle_simple extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -424,7 +431,7 @@ public class throttle_simple extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         Button b;
         boolean[] fs;   // copy of this throttle's function state array

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_horizontal.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_horizontal.java
@@ -46,6 +46,7 @@ import jmri.enginedriver.type.slider_type;
 import jmri.enginedriver.type.web_view_location_type;
 
 public class throttle_switching_horizontal extends throttle {
+    static final String activityName = "throttle_switching_horizontal";
 
     protected static final int MAX_SCREEN_THROTTLES = 3;
 
@@ -87,7 +88,7 @@ public class throttle_switching_horizontal extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_switching_horizontal: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
 
@@ -207,9 +208,16 @@ public class throttle_switching_horizontal extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle_switching_horizontal: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -237,7 +245,7 @@ public class throttle_switching_horizontal extends throttle {
 //    @SuppressWarnings("deprecation")
 //    @Override
     protected void set_labels() {
-//        Log.d("Engine_Driver","throttle_switching_horizontal: set_labels() starting");
+//        Log.d(threaded_application.applicationName, activityName + ": set_labels() starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) { return;}
@@ -278,7 +286,7 @@ public class throttle_switching_horizontal extends throttle {
         String bLabelPlainText;
 
         if(mainapp.consists==null) {
-            Log.d("Engine_Driver", "throttle_original.setLabels consists is null");
+            Log.d(threaded_application.applicationName, activityName + ": set_labels() consists is null");
             return;
         }
 
@@ -289,7 +297,7 @@ public class throttle_switching_horizontal extends throttle {
 
             Consist con = mainapp.consists[throttleIndex];
             if(con==null) {
-                Log.d("Engine_Driver", "throttle_original setLabels consists[" + throttleIndex + "] is null");
+                Log.d(threaded_application.applicationName, activityName + ": set_labels(): consists[" + throttleIndex + "] is null");
             }
             else {
                 if (con.isActive()) {
@@ -401,7 +409,7 @@ public class throttle_switching_horizontal extends throttle {
 
 
         if ( (screenHeight > throttleMargin) && (mainapp.consists!=null)) { // don't do this if height is invalid
-            //Log.d("Engine_Driver","starting screen height adjustments, screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": set_labels(): starting screen height adjustments, screenHeight=" + screenHeight);
             // determine how to split the screen (evenly if all three, 45/45/10 for two, 80/10/10 if only one)
 
 
@@ -418,15 +426,15 @@ public class throttle_switching_horizontal extends throttle {
 //                boolean con1Active = false;
 //                boolean con2Active = false;
 //                if (mainapp.consists[0] == null)
-//                    Log.d("Engine_Driver", "throttle_original.set_labels() consists[0] is null");
+//                    Log.d(threaded_application.applicationName, activityName + ": set_labels() consists[0] is null");
 //                else
 //                    con0Active = mainapp.consists[0].isActive();
 //                if( mainapp.consists[1] == null)
-//                    Log.d("Engine_Driver", "throttle_original.set_labels() consists[1] is null");
+//                    Log.d(threaded_application.applicationName, activityName + ": set_labels() consists[1] is null");
 //                else
 //                    con1Active = mainapp.consists[1].isActive();
 //                if (mainapp.consists[2] == null) {
-//                    Log.d("Engine_Driver", "throttle_original.set_labels() consists[2] is null");
+//                    Log.d(threaded_application.applicationName, activityName + ": set_labels() consists[2] is null");
 //                }
 //                else
 //                    con2Active = mainapp.consists[2].isActive();
@@ -501,11 +509,11 @@ public class throttle_switching_horizontal extends throttle {
                 sliderBottomRightX[throttleIndex] = x + hsbSwitchingSpeeds[throttleIndex].getWidth() - ovx;
                 sliderBottomRightY[throttleIndex] = y + hsbSwitchingSpeeds[throttleIndex].getHeight() -ovy;
 
-//            Log.d("Engine_Driver","slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
+//            Log.d(threaded_application.applicationName, activityName + ": set_labels(): slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
 //                    + " Bottom: " + sliderBottomRightX[throttleIndex] + ", " + sliderBottomRightY[throttleIndex]);
             }
         } else {
-            Log.d("Engine_Driver", "screen height adjustments skipped, screenHeight=" + screenHeight);
+            Log.d(threaded_application.applicationName, activityName + ": set_labels(): screen height adjustments skipped, screenHeight=" + screenHeight);
         }
 
         // update the direction indicators
@@ -523,7 +531,7 @@ public class throttle_switching_horizontal extends throttle {
         }
 
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels(): end");
 
     } // end set_labels
 
@@ -552,8 +560,7 @@ public class throttle_switching_horizontal extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView() " + newEnabledState);
 
         if (vg == null) { return;}
         if (mainapp.appIsFinishing) { return;}
@@ -572,7 +579,7 @@ public class throttle_switching_horizontal extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -588,7 +595,7 @@ public class throttle_switching_horizontal extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         Button b;
         boolean[] fs;   // copy of this throttle's function state array
@@ -625,7 +632,7 @@ public class throttle_switching_horizontal extends throttle {
         @SuppressLint("ClickableViewAccessibility")
         @Override
         public boolean onTouch(View v, MotionEvent event) {
-            // Log.d("Engine_Driver", "onTouchThrottle action " + event.getAction());
+            // Log.d(threaded_application.applicationName, activityName + ": onTouchThrottle action " + event.getAction());
             // consume event if gesture is in progress, otherwise pass it to the SeekBar onProgressChanged()
             return (gestureInProgress);
         }
@@ -639,8 +646,8 @@ public class throttle_switching_horizontal extends throttle {
             dir = getDirectionFromSliderPosition(newSliderPosition,whichThrottle);
             lastDir = getDirectionFromSliderPosition(lastSliderPosition,whichThrottle);
 
-//            Log.d("Engine_Driver", "onProgressChanged: fromUser: " + fromUser + " touchFromUser: " + hsbSwitchingSpeeds[whichThrottle].touchFromUser + " limitedJump: " + limitedJump);
-//            Log.d("Engine_Driver", "onProgressChanged: isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
+//            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): fromUser: " + fromUser + " touchFromUser: " + hsbSwitchingSpeeds[whichThrottle].touchFromUser + " limitedJump: " + limitedJump);
+//            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
 
             // limit speed change if change was initiated by a user slider touch (prevents "bouncing")
             if ((fromUser) || (hsbSwitchingSpeeds[whichThrottle].touchFromUser) ) {
@@ -671,7 +678,7 @@ public class throttle_switching_horizontal extends throttle {
                         return;
                     }
 
-//                    Log.d("Engine_Driver", "onProgressChanged -- no throttling");
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- no throttling");
 
                     reverseDirectionIfNeeded(dir, whichThrottle);
 
@@ -681,12 +688,12 @@ public class throttle_switching_horizontal extends throttle {
                     setDisplayedSpeed(whichThrottle, speed);
 
                 } else { // got a touch while processing limitJump
-//                    Log.d("Engine_Driver", "onProgressChanged -- touch while processing limited jump");
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- touch while processing limited jump");
                     newSliderPosition = lastSliderPosition;    //   so suppress multiple touches
                     throttle.setProgress(lastSliderPosition);
                     doLocoSound(whichThrottle);
 
-//                    Log.d("Engine_Driver", "onProgressChange: fromUser: " + fromUser + " hsbSwitchingSpeeds[wt].touchFromUser: " +hsbSwitchingSpeeds[whichThrottle].touchFromUser + " isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChange(): fromUser: " + fromUser + " hsbSwitchingSpeeds[wt].touchFromUser: " +hsbSwitchingSpeeds[whichThrottle].touchFromUser + " isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
                 }
 
                 // Now update ESU MCII Knob position
@@ -697,13 +704,13 @@ public class throttle_switching_horizontal extends throttle {
                 setActiveThrottle(whichThrottle, true);
 
             } else {
-//                Log.d("Engine_Driver", "onProgressChanged -- lj: " + limitedJump + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed);
+//                Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- lj: " + limitedJump + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed);
                 if (limitedJump[whichThrottle]) {
 
                     int tempJumpSpeed = jumpSpeed;
                     if (mChangeDirectionAtZero) { tempJumpSpeed = 0; }  // we will need to change directions.  for now just get to zero
 
-//                    Log.d("Engine_Driver", "onProgressChanged -- lj: " + limitedJump[whichThrottle] + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement[whichThrottle] + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed + " tjs: " + tempJumpSpeed);
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- lj: " + limitedJump[whichThrottle] + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement[whichThrottle] + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed + " tjs: " + tempJumpSpeed);
 
                     // check if we have hit the jumpSpeed or tempJumpSpeed (zero)
                     boolean hitJumpSpeed = false;
@@ -724,11 +731,11 @@ public class throttle_switching_horizontal extends throttle {
 
                     if ( hitJumpSpeed) {   // stop when we reach the target
                         if (mChangeDirectionAtZero) { // if change of direction is needed, then we must be at zero now.  need to continue to the final speed.
-                            Log.d("Engine_Driver", "onProgressChanged !!-- Direction change now needed");
+                            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): !!-- Direction change now needed");
                             mChangeDirectionAtZero = false;
                             reverseDirectionIfNeeded(jumpDir, whichThrottle);
                         } else {
-                            Log.d("Engine_Driver", "onProgressChanged !!-- LimitedJump hit jump speed.");
+                            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): !!-- LimitedJump hit jump speed.");
                             limitedJump[whichThrottle] = false;
                             setAutoIncrementOrDecrement(whichThrottle, auto_increment_or_decrement_type.OFF);
                             throttle.setProgress(getNewSliderPositionFromSpeed(jumpSpeed, whichThrottle, false));
@@ -743,13 +750,13 @@ public class throttle_switching_horizontal extends throttle {
 
         @Override
         public void onStartTrackingTouch(SeekBar sb) {
-//            Log.d("Engine_Driver", "onStartTrackingTouch() onProgressChanged");
+//            Log.d(threaded_application.applicationName, activityName + ": onStartTrackingTouch() onProgressChanged");
             gestureInProgress = false;
         }
 
         @Override
         public void onStopTrackingTouch(SeekBar sb) {
-//            Log.d("Engine_Driver", "onStopTrackingTouch() onProgressChanged");
+//            Log.d(threaded_application.applicationName, activityName + ": onStopTrackingTouch() onProgressChanged");
             limitedJump[whichThrottle] = false;
             setAutoIncrementOrDecrement(whichThrottle, auto_increment_or_decrement_type.OFF);
             kidsTimerActions(kids_timer_action_type.STARTED,0);
@@ -776,7 +783,7 @@ public class throttle_switching_horizontal extends throttle {
         if (getDirection(whichThrottle)==direction_type.REVERSE) {  // treat negative as positive
             change = change * -1;
         }
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - change: " + change + " lastSliderPosition: " + lastSliderPosition);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): change: " + change + " lastSliderPosition: " + lastSliderPosition);
 
         lastScaleSpeed = getSpeedFromSliderPosition(lastSliderPosition, whichThrottle, true);
         scaleSpeed = lastScaleSpeed + change;
@@ -786,21 +793,21 @@ public class throttle_switching_horizontal extends throttle {
              scaleSpeed = 0;
          }
 
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
         if (scaleSpeed<0) {
             int dir = getDirection(whichThrottle) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD;
-//            Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - auto Reverse - dir:" + dir);
+//            Log.d(threaded_application.applicationName, activityName + ": speedChange(): - auto Reverse - dir:" + dir);
             dirs[whichThrottle] = dir;
             setEngineDirection(whichThrottle, dir, false);
             showDirectionIndication(whichThrottle, dir);
         }
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange - change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): change: " + change);
 
         scaleSpeed = Math.abs(scaleSpeed);
 
         int newSliderPosition = getNewSliderPositionFromSpeed(scaleSpeed, whichThrottle, true);
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - newSliderPosition: " + newSliderPosition );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): newSliderPosition: " + newSliderPosition );
 
         if (lastScaleSpeed == scaleSpeed) {
             newSliderPosition += Math.round(Math.signum(change));
@@ -812,15 +819,15 @@ public class throttle_switching_horizontal extends throttle {
         if (newSliderPosition > throttleSwitchingMax[whichThrottle])
             newSliderPosition = throttleSwitchingMax[whichThrottle];
 
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) + " newSliderPosition: " + newSliderPosition);
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange - change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange() - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) + " newSliderPosition: " + newSliderPosition);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange() - change: " + change);
 
         switchingThrottleSlider.setProgress(newSliderPosition);
         speed = Math.abs(getSpeedFromSliderPosition(newSliderPosition, whichThrottle, false));
         setDisplayedSpeed(whichThrottle, speed);
         doLocoSound(whichThrottle);
 
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange -  speed: " + speed + " change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange():  speed: " + speed + " change: " + change);
 
 //        speedUpdateAndNotify(whichThrottle, speed);
 
@@ -847,7 +854,7 @@ public class throttle_switching_horizontal extends throttle {
         setDisplayedSpeed(whichThrottle, speed);
         doLocoSound(whichThrottle);
 
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedUpdate -  sliderPosition: " + sliderPosition + " dir: " + getDirection(whichThrottle) + " Speed: " + speed);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): speedUpdate -  sliderPosition: " + sliderPosition + " dir: " + getDirection(whichThrottle) + " Speed: " + speed);
     }
 
     // process WiT speed report
@@ -912,7 +919,7 @@ public class throttle_switching_horizontal extends throttle {
         } else { // zero - deadzone
             speed = 0;
         }
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - getSpeedFromSliderPosition -  scale: " + scale + " sliderPosition: " + sliderPosition + " speed: " + speed );
+//        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSliderPosition():  scale: " + scale + " sliderPosition: " + sliderPosition + " speed: " + speed );
         return speed;
     }
 
@@ -951,7 +958,7 @@ public class throttle_switching_horizontal extends throttle {
                 newSliderPosition = throttleMidPointDeadZoneLower[whichThrottle] - (int) Math.round( speed / scale );
             }
         }
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - getNewSliderPositionFromSpeed -  scale: " + scale + " speed: " + speed + " newSliderPosition: " + newSliderPosition );
+//        Log.d(threaded_application.applicationName, activityName + ": getNewSliderPositionFromSpeed():  scale: " + scale + " speed: " + speed + " newSliderPosition: " + newSliderPosition );
 
         return newSliderPosition;
     }
@@ -965,7 +972,7 @@ public class throttle_switching_horizontal extends throttle {
     protected void limitSpeed(int whichThrottle) {
         int dir = getDirection(whichThrottle);
         int speed = getSpeedFromSliderPosition(hsbSwitchingSpeeds[whichThrottle].getProgress(),whichThrottle, false);
-//                Log.d("Engine_Driver","limit_speed_button_switching_touch_listener -  speed: " + speed );
+//                Log.d(threaded_application.applicationName, activityName + ": limitSpeed():  speed: " + speed );
 
         isLimitSpeeds[whichThrottle] = !isLimitSpeeds[whichThrottle];
         if (isLimitSpeeds[whichThrottle]) {
@@ -991,7 +998,7 @@ public class throttle_switching_horizontal extends throttle {
         speedUpdate(whichThrottle,  speed);
         setEngineDirection(whichThrottle, dir, false);
 
-        Log.d("Engine_Driver","limitSpeed -  speed: " + speed );
+        Log.d(threaded_application.applicationName, activityName + ": limitSpeed():  speed: " + speed );
         speedChangeAndNotify(whichThrottle,0);
         setActiveThrottle(whichThrottle); // set the throttle the volume keys control depending on the preference
     }
@@ -1107,7 +1114,7 @@ public class throttle_switching_horizontal extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = displayMetrics.heightPixels - (int) (titleBar * (displayMetrics.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": getAvailableSreenHeight(): vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         double height = screenHeight;

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_switching_left_or_right.java
@@ -88,7 +88,7 @@ public class throttle_switching_left_or_right extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_switching_left_or_right: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
 
@@ -299,9 +299,16 @@ public class throttle_switching_left_or_right extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle_switching_left_or_right: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -326,7 +333,7 @@ public class throttle_switching_left_or_right extends throttle {
 
 
     protected void set_labels() {
-//        Log.d("Engine_Driver","throttle_switching_left_or_right: set_labels() starting");
+//        Log.d(threaded_application.applicationName, activityName + ": set_labels() starting");
         super.set_labels();
 
         if (mainapp.appIsFinishing) { return;}
@@ -343,7 +350,7 @@ public class throttle_switching_left_or_right extends throttle {
             if ( (mainapp.consists != null) && (mainapp.consists[throttleIndex] != null)
                     && (mainapp.consists[throttleIndex].isActive()) ) {
                 if (!prefShowAddressInsteadOfName) {
-                    if (!overrideThrottleNames[throttleIndex].equals("")) {
+                    if (!overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = overrideThrottleNames[throttleIndex];
                         bLabelPlainText = overrideThrottleNames[throttleIndex];
                     } else {
@@ -355,7 +362,7 @@ public class throttle_switching_left_or_right extends throttle {
 //                    bLabelPlainText = mainapp.consists[throttleIndex].toString();
 //                    bLabel = mainapp.consists[throttleIndex].toHtml();
                 } else {
-                    if (overrideThrottleNames[throttleIndex].equals("")) {
+                    if (overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = mainapp.consists[throttleIndex].formatConsistAddr();
                     } else {
                         bLabel = overrideThrottleNames[throttleIndex];
@@ -451,7 +458,7 @@ public class throttle_switching_left_or_right extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = dm.heightPixels - (int) (titleBar * (dm.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": set_labels(): vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         if (webView!=null) {
@@ -543,7 +550,7 @@ public class throttle_switching_left_or_right extends throttle {
             sliderBottomRightX[throttleIndex] = x + vsbSwitchingSpeeds[throttleIndex].getWidth() - ovx;
             sliderBottomRightY[throttleIndex] = y + vsbSwitchingSpeeds[throttleIndex].getHeight() -ovy;
 
-//            Log.d("Engine_Driver","slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
+//            Log.d(threaded_application.applicationName, activityName + ": set_labels(): slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
 //                    + " Bottom: " + sliderBottomRightX[throttleIndex] + ", " + sliderBottomRightY[throttleIndex]);
         }
 
@@ -552,7 +559,7 @@ public class throttle_switching_left_or_right extends throttle {
             setAllFunctionStates(throttleIndex);
         }
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels() end");
 
     }
 
@@ -582,8 +589,7 @@ public class throttle_switching_left_or_right extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView " + newEnabledState);
 
         if (vg == null) { return;}
         if (mainapp.appIsFinishing) { return;}
@@ -602,7 +608,7 @@ public class throttle_switching_left_or_right extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -618,7 +624,7 @@ public class throttle_switching_left_or_right extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         Button b;
         boolean[] fs;   // copy of this throttle's function state array
@@ -655,7 +661,7 @@ public class throttle_switching_left_or_right extends throttle {
         @SuppressLint("ClickableViewAccessibility")
         @Override
         public boolean onTouch(View v, MotionEvent event) {
-            // Log.d("Engine_Driver", "onTouchThrottle action " + event.getAction());
+            // Log.d(threaded_application.applicationName, activityName + ": onTouch(): action " + event.getAction());
             // consume event if gesture is in progress, otherwise pass it to the SeekBar onProgressChanged()
             return (gestureInProgress);
         }
@@ -669,8 +675,8 @@ public class throttle_switching_left_or_right extends throttle {
             dir = getDirectionFromSliderPosition(newSliderPosition,whichThrottle);
             lastDir = getDirectionFromSliderPosition(lastSliderPosition,whichThrottle);
 
-//            Log.d("Engine_Driver", "onProgressChanged: fromUser: " + fromUser + " touchFromUser: " + vsbSwitchingSpeeds[whichThrottle].touchFromUser + " limitedJump: " + limitedJump);
-//            Log.d("Engine_Driver", "onProgressChanged: isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
+//            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): fromUser: " + fromUser + " touchFromUser: " + vsbSwitchingSpeeds[whichThrottle].touchFromUser + " limitedJump: " + limitedJump);
+//            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged(): isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
 
             // limit speed change if change was initiated by a user slider touch (prevents "bouncing")
             if ((fromUser) || (vsbSwitchingSpeeds[whichThrottle].touchFromUser) ) {
@@ -699,7 +705,7 @@ public class throttle_switching_left_or_right extends throttle {
                         return;
                     }
 
-//                    Log.d("Engine_Driver", "onProgressChanged -- no throttling");
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- no throttling");
 
                     reverseDirectionIfNeeded(dir, whichThrottle);
 
@@ -709,12 +715,12 @@ public class throttle_switching_left_or_right extends throttle {
                     setDisplayedSpeed(whichThrottle, speed);
 
                 } else { // got a touch while processing limitJump
-//                    Log.d("Engine_Driver", "onProgressChanged -- touch while processing limited jump");
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- touch while processing limited jump");
                     newSliderPosition = lastSliderPosition;    //   so suppress multiple touches
                     throttle.setProgress(lastSliderPosition);
                     doLocoSound(whichThrottle);
 
-//                    Log.d("Engine_Driver", "onProgressChange: fromUser: " + fromUser + " vsbSwitchingSpeeds[wt].touchFromUser: " +vsbSwitchingSpeeds[whichThrottle].touchFromUser + " isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChange(): fromUser: " + fromUser + " vsbSwitchingSpeeds[wt].touchFromUser: " +vsbSwitchingSpeeds[whichThrottle].touchFromUser + " isPauseSpeeds[whichThrottle]: " + isPauseSpeeds[whichThrottle]);
                 }
 
                 // Now update ESU MCII Knob position
@@ -725,13 +731,13 @@ public class throttle_switching_left_or_right extends throttle {
                 setActiveThrottle(whichThrottle); // set the throttle the volume keys control depending on the preference
 
             } else {
-//                Log.d("Engine_Driver", "onProgressChanged -- lj: " + limitedJump + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed);
+//                Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- lj: " + limitedJump + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed);
                 if (limitedJump[whichThrottle]) {
 
                     int tempJumpSpeed = jumpSpeed;
                     if (mChangeDirectionAtZero) { tempJumpSpeed = 0; }  // we will need to change directions.  for now just get to zero
 
-//                    Log.d("Engine_Driver", "onProgressChanged -- lj: " + limitedJump[whichThrottle] + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement[whichThrottle] + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed + " tjs: " + tempJumpSpeed);
+//                    Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() -- lj: " + limitedJump[whichThrottle] + " d: " + dir + " ld: " + lastDir + " ai: " + mAutoIncrement[whichThrottle] + " ad: " + mAutoDecrement[whichThrottle] + " cdaZ: " + mChangeDirectionAtZero + " s: " + speed + " js: " + jumpSpeed + " tjs: " + tempJumpSpeed);
 
                     // check if we have hit the jumpSpeed or tempJumpSpeed (zero)
                     boolean hitJumpSpeed = false;
@@ -752,11 +758,11 @@ public class throttle_switching_left_or_right extends throttle {
 
                     if ( hitJumpSpeed) {   // stop when we reach the target
                         if (mChangeDirectionAtZero) { // if change of direction is needed, then we must be at zero now.  need to continue to the final speed.
-                            Log.d("Engine_Driver", "onProgressChanged !!-- Direction change now needed");
+                            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() !!-- Direction change now needed");
                             mChangeDirectionAtZero = false;
                             reverseDirectionIfNeeded(jumpDir, whichThrottle);
                         } else {
-                            Log.d("Engine_Driver", "onProgressChanged !!-- LimitedJump hit jump speed.");
+                            Log.d(threaded_application.applicationName, activityName + ": onProgressChanged() !!-- LimitedJump hit jump speed.");
                             limitedJump[whichThrottle] = false;
                             setAutoIncrementOrDecrement(whichThrottle, auto_increment_or_decrement_type.OFF);
                             throttle.setProgress(getNewSliderPositionFromSpeed(jumpSpeed, whichThrottle, false));
@@ -770,13 +776,13 @@ public class throttle_switching_left_or_right extends throttle {
 
         @Override
         public void onStartTrackingTouch(SeekBar sb) {
-//            Log.d("Engine_Driver", "onStartTrackingTouch() onProgressChanged");
+//            Log.d(threaded_application.applicationName, activityName + ": onStartTrackingTouch() onProgressChanged");
             gestureInProgress = false;
         }
 
         @Override
         public void onStopTrackingTouch(SeekBar sb) {
-//            Log.d("Engine_Driver", "onStopTrackingTouch() onProgressChanged");
+//            Log.d(threaded_application.applicationName, activityName + ": onStopTrackingTouch() onProgressChanged");
             limitedJump[whichThrottle] = false;
             setAutoIncrementOrDecrement(whichThrottle, auto_increment_or_decrement_type.OFF);
             kidsTimerActions(kids_timer_action_type.STARTED,0);
@@ -803,7 +809,7 @@ public class throttle_switching_left_or_right extends throttle {
         if (getDirection(whichThrottle)==direction_type.REVERSE) {  // treat negative as positive
             change = change * -1;
         }
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - change: " + change + " lastSliderPosition: " + lastSliderPosition);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): change: " + change + " lastSliderPosition: " + lastSliderPosition);
 
         lastScaleSpeed = getSpeedFromSliderPosition(lastSliderPosition, whichThrottle, true);
         scaleSpeed = lastScaleSpeed + change;
@@ -813,21 +819,21 @@ public class throttle_switching_left_or_right extends throttle {
              scaleSpeed = 0;
          }
 
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
         if (scaleSpeed<0) {
             int dir = getDirection(whichThrottle) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD;
-//            Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - auto Reverse - dir:" + dir);
+//            Log.d(threaded_application.applicationName, activityName + ": speedChange(): auto Reverse - dir:" + dir);
             dirs[whichThrottle] = dir;
             setEngineDirection(whichThrottle, dir, false);
             showDirectionIndication(whichThrottle, dir);
         }
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange - change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): change: " + change);
 
         scaleSpeed = Math.abs(scaleSpeed);
 
         int newSliderPosition = getNewSliderPositionFromSpeed(scaleSpeed, whichThrottle, true);
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - newSliderPosition: " + newSliderPosition );
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): newSliderPosition: " + newSliderPosition );
 
         if (lastScaleSpeed == scaleSpeed) {
             newSliderPosition += Math.signum(change);
@@ -839,15 +845,15 @@ public class throttle_switching_left_or_right extends throttle {
         if (newSliderPosition > throttleSwitchingMax[whichThrottle])
             newSliderPosition = throttleSwitchingMax[whichThrottle];
 
-//        Log.d("Engine_Driver", "throttle_switching_left_or_right - speedChange - lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) + " newSliderPosition: " + newSliderPosition);
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange - change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): lastScaleSpeed: " + lastScaleSpeed + " scaleSpeed: " + scaleSpeed + " dir: " + getDirection(whichThrottle) + " newSliderPosition: " + newSliderPosition);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange(): change: " + change);
 
         switchingThrottleSlider.setProgress(newSliderPosition);
         speed = Math.abs(getSpeedFromSliderPosition(newSliderPosition, whichThrottle, false));
         setDisplayedSpeed(whichThrottle, speed);
         doLocoSound(whichThrottle);
 
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedChange -  speed: " + speed + " change: " + change);
+//        Log.d(threaded_application.applicationName, activityName + ": speedChange():  speed: " + speed + " change: " + change);
 
 //        speedUpdateAndNotify(whichThrottle, speed);
         return speed;
@@ -871,7 +877,7 @@ public class throttle_switching_left_or_right extends throttle {
         setDisplayedSpeed(whichThrottle, speed);
         doLocoSound(whichThrottle);
 
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - speedUpdate -  sliderPosition: " + sliderPosition + " dir: " + getDirection(whichThrottle) + " Speed: " + speed);
+//        Log.d(threaded_application.applicationName, activityName + ": speedUpdate():  sliderPosition: " + sliderPosition + " dir: " + getDirection(whichThrottle) + " Speed: " + speed);
     }
 
     // process WiT speed report
@@ -936,7 +942,7 @@ public class throttle_switching_left_or_right extends throttle {
         } else { // zero - deadzone
             speed = 0;
         }
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - getSpeedFromSliderPosition -  scale: " + scale + " sliderPosition: " + sliderPosition + " speed: " + speed );
+//        Log.d(threaded_application.applicationName, activityName + ": getSpeedFromSliderPosition():  scale: " + scale + " sliderPosition: " + sliderPosition + " speed: " + speed );
         return speed;
     }
 
@@ -975,7 +981,7 @@ public class throttle_switching_left_or_right extends throttle {
                 newSliderPosition = throttleMidPointDeadZoneLower[whichThrottle] - (int) Math.round( speed / scale );
             }
         }
-//        Log.d("Engine_Driver","throttle_switching_left_or_right - getNewSliderPositionFromSpeed -  scale: " + scale + " speed: " + speed + " newSliderPosition: " + newSliderPosition );
+//        Log.d(threaded_application.applicationName, activityName + ": getNewSliderPositionFromSpeed():  scale: " + scale + " speed: " + speed + " newSliderPosition: " + newSliderPosition );
 
         return newSliderPosition;
     }
@@ -1010,7 +1016,7 @@ public class throttle_switching_left_or_right extends throttle {
     protected void limitSpeed(int whichThrottle) {
         int dir = getDirection(whichThrottle);
         int speed = getSpeedFromSliderPosition(vsbSwitchingSpeeds[whichThrottle].getProgress(),whichThrottle, false);
-//                Log.d("Engine_Driver","limit_speed_button_switching_touch_listener -  speed: " + speed );
+//                Log.d(threaded_application.applicationName, activityName + ": limitSpeed():  speed: " + speed );
 
         isLimitSpeeds[whichThrottle] = !isLimitSpeeds[whichThrottle];
         if (isLimitSpeeds[whichThrottle]) {
@@ -1038,7 +1044,7 @@ public class throttle_switching_left_or_right extends throttle {
         speedUpdate(whichThrottle,  speed);
         setEngineDirection(whichThrottle, dir, false);
 
-        Log.d("Engine_Driver","limitSpeed -  speed: " + speed );
+        Log.d(threaded_application.applicationName, activityName + ": limitSpeed():  speed: " + speed );
         speedChangeAndNotify(whichThrottle,0);
         setActiveThrottle(whichThrottle); // set the throttle the volume keys control depending on the preference
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle_vertical_left_or_right.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle_vertical_left_or_right.java
@@ -42,6 +42,7 @@ import jmri.enginedriver.type.slider_type;
 import jmri.enginedriver.type.web_view_location_type;
 
 public class throttle_vertical_left_or_right extends throttle {
+    static final String activityName = "throttle_vertical_left_or_right";
 
     protected static final int MAX_SCREEN_THROTTLES = 2;
     protected static final int MAX_SCREEN_THROTTLES_LEFT_OR_RIGHT = 1;
@@ -60,7 +61,7 @@ public class throttle_vertical_left_or_right extends throttle {
     @SuppressLint({"Recycle", "SetJavaScriptEnabled", "ClickableViewAccessibility"})
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d("Engine_Driver", "throttle_vertical_left_or_right: onCreate(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onCreate(): called");
 
         mainapp = (threaded_application) this.getApplication();
         mainapp.maxThrottlesCurrentScreen = MAX_SCREEN_THROTTLES;
@@ -191,9 +192,16 @@ public class throttle_vertical_left_or_right extends throttle {
     } // end of onCreate()
 
     @Override
+    public void onPause() {
+        super.onPause();
+        threaded_application.activityPaused(activityName);
+    }
+
+    @Override
     public void onResume() {
-        Log.d("Engine_Driver", "throttle_vertical_left_or_right: onResume(): called");
+        Log.d(threaded_application.applicationName, activityName + ": onResume(): called");
         super.onResume();
+        threaded_application.activityResumed(activityName);
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -220,7 +228,7 @@ public class throttle_vertical_left_or_right extends throttle {
 
     protected void set_labels() {
         super.set_labels();
-         Log.d("Engine_Driver","throttle_vertical_left_or_right set_labels(): starting");
+         Log.d(threaded_application.applicationName, activityName + ": set_labels(): starting");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -236,7 +244,7 @@ public class throttle_vertical_left_or_right extends throttle {
             if ( (mainapp.consists != null) && (mainapp.consists[throttleIndex] != null)
                     && (mainapp.consists[throttleIndex].isActive()) ) {
                 if (!prefShowAddressInsteadOfName) {
-                    if (!overrideThrottleNames[throttleIndex].equals("")) {
+                    if (!overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = overrideThrottleNames[throttleIndex];
                         bLabelPlainText = overrideThrottleNames[throttleIndex];
                     } else {
@@ -248,7 +256,7 @@ public class throttle_vertical_left_or_right extends throttle {
 //                    bLabelPlainText = mainapp.consists[throttleIndex].toString();
 //                    bLabel = mainapp.consists[throttleIndex].toHtml();
                 } else {
-                    if (overrideThrottleNames[throttleIndex].equals("")) {
+                    if (overrideThrottleNames[throttleIndex].isEmpty()) {
                         bLabel = mainapp.consists[throttleIndex].formatConsistAddr();
                     } else {
                         bLabel = overrideThrottleNames[throttleIndex];
@@ -333,7 +341,7 @@ public class throttle_vertical_left_or_right extends throttle {
         if (screenHeight == 0) {
             // throttle screen hasn't been drawn yet, so use display metrics for now
             screenHeight = dm.heightPixels - (int) (titleBar * (dm.densityDpi / 160.)); // allow for title bar, etc
-            //Log.d("Engine_Driver","vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
+            //Log.d(threaded_application.applicationName, activityName + ": set_labels(): vThrotScrWrap.getHeight()=0, new screenHeight=" + screenHeight);
         }
 
         if (webView != null) {
@@ -420,7 +428,7 @@ public class throttle_vertical_left_or_right extends throttle {
             sliderBottomRightX[throttleIndex] = x + vsbSpeeds[throttleIndex].getWidth() - ovx;
             sliderBottomRightY[throttleIndex] = y + vsbSpeeds[throttleIndex].getHeight() - ovy;
 
-//            Log.d("Engine_Driver","slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
+//            Log.d(threaded_application.applicationName, activityName + ": set_labels(): slider: " + throttleIndex + " Top: " + sliderTopLeftX[throttleIndex] + ", " + sliderTopLeftY[throttleIndex]
 //                    + " Bottom: " + sliderBottomRightX[throttleIndex] + ", " + sliderBottomRightY[throttleIndex]);
 
         }
@@ -432,7 +440,7 @@ public class throttle_vertical_left_or_right extends throttle {
             setAllFunctionStates(throttleIndex);
         }
 
-        // Log.d("Engine_Driver","ending set_labels");
+        // Log.d(threaded_application.applicationName, activityName + ": set_labels() end");
 
     }
 
@@ -455,8 +463,7 @@ public class throttle_vertical_left_or_right extends throttle {
     // helper function to enable/disable all children for a group
     @Override
     void enableDisableButtonsForView(ViewGroup vg, boolean newEnabledState) {
-        // Log.d("Engine_Driver","starting enableDisableButtonsForView " +
-        // newEnabledState);
+        // Log.d(threaded_application.applicationName, activityName + ": enableDisableButtonsForView " + newEnabledState);
 
         if (vg == null) { return;}
         if (mainapp.appIsFinishing) { return;}
@@ -475,7 +482,7 @@ public class throttle_vertical_left_or_right extends throttle {
     // update the appearance of all function buttons
     @Override
     void setAllFunctionStates(int whichThrottle) {
-        // Log.d("Engine_Driver","set_function_states");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_states()");
 
         if (mainapp.appIsFinishing) { return;}
 
@@ -491,7 +498,7 @@ public class throttle_vertical_left_or_right extends throttle {
     // update a function button appearance based on its state
     @Override
     void set_function_state(int whichThrottle, int function) {
-        // Log.d("Engine_Driver","starting set_function_request");
+        // Log.d(threaded_application.applicationName, activityName + ": set_function_request()");
 
         Button b;
         boolean[] fs;   // copy of this throttle's function state array

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/ArrayQueue.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/ArrayQueue.java
@@ -5,7 +5,11 @@ package jmri.enginedriver.util;
 
 import android.util.Log;
 
+import jmri.enginedriver.threaded_application;
+
 public final class ArrayQueue {
+    static final String activityName = "ArrayQueue";
+
     private int front;
     private int rear;
     private final int capacity;
@@ -24,7 +28,7 @@ public final class ArrayQueue {
         boolean rslt = false;
         // check queue is full or not
         if (capacity == rear) {
-            Log.d("Engine_Driver", "ArrayQueue: enqueue: Queue is full");
+            Log.d(threaded_application.applicationName, activityName + ": enqueue(): Queue is full");
         } else {  // insert element at the rear
             if (data!=lastValueAdded) { // don't add the same value again
                 queue[rear] = data;
@@ -32,7 +36,7 @@ public final class ArrayQueue {
                 lastValueAdded = data;
                 rslt = true;
             } else {
-                Log.d("Engine_Driver", "ArrayQueue: enqueue: Queue already contains value: "+data);
+                Log.d(threaded_application.applicationName, activityName + ": enqueue(): Queue already contains value: "+data);
             }
         }
         return rslt;
@@ -42,7 +46,7 @@ public final class ArrayQueue {
         boolean rslt = false;
         // check queue is full or not
         if (capacity == rear) {
-            Log.d("Engine_Driver", "ArrayQueue: enqueueWithIntermediateSteps: Queue is full");
+            Log.d(threaded_application.applicationName, activityName + ": enqueueWithIntermediateSteps(): Queue is full");
         } else {  // insert element at the rear
             if (data!=lastValueAdded) { // don't add the same value again
                 if (Math.abs(Math.abs(data) - Math.abs(lastValueAdded)) > 1) {
@@ -71,7 +75,7 @@ public final class ArrayQueue {
                     }
                     rslt = true;
 //                } else {
-//                Log.d("Engine_Driver", "ArrayQueue: enqueueWithIntermediateSteps: Queue already contains value: "+data);
+//                Log.d(threaded_application.applicationName, activityName + ": enqueueWithIntermediateSteps(): Queue already contains value: "+data);
                 }
             }
         }
@@ -83,7 +87,7 @@ public final class ArrayQueue {
     public void dequeue() {
         // if queue is empty
         if (front == rear) {
-            Log.d("Engine_Driver", "ArrayQueue: dequeue: Queue is Empty");
+            Log.d(threaded_application.applicationName, activityName + ": dequeue(): Queue is Empty");
         } else { // shift all the elements from index 2 till rear // to the right by one
             if (rear - 1 >= 0) {
                 System.arraycopy(queue, 1, queue, 0, rear - 1);
@@ -127,7 +131,7 @@ public final class ArrayQueue {
     public int frontOfQueue() {
         int rslt = -1;
         if (front == rear) {
-//            Log.d("Engine_Driver", "ArrayQueue: frontOfQueue: Queue is Empty");
+//            Log.d(threaded_application.applicationName, activityName + ": frontOfQueue(): Queue is Empty");
             return rslt;
         }
         rslt = queue[front];
@@ -138,7 +142,7 @@ public final class ArrayQueue {
     public int endOfQueue() {
         int rslt = -1;
         if (front == rear) {
-//            Log.d("Engine_Driver", "ArrayQueue: endOfQueue: Queue is Empty");
+//            Log.d(threaded_application.applicationName, activityName + ": endOfQueue(): Queue is Empty");
             return rslt;
         }
         rslt = queue[rear];

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
@@ -12,6 +12,8 @@ import jmri.enginedriver.R;
 import jmri.enginedriver.threaded_application;
 
 public class BackgroundImageLoader {
+    static final String activityName = "BackgroundImageLoader";
+
     private final String prefBackgroundImageFileName;
     private final String prefBackgroundImagePosition;
     private final boolean prefBackgroundImage;
@@ -71,7 +73,7 @@ public class BackgroundImageLoader {
                     break;
             }
         } catch (Exception e) {
-            Log.d("Engine_Driver", "backgroundImageLoader: failed loading background image");
+            Log.d(threaded_application.applicationName, activityName + ": loadBackgroundImageImpl(): failed loading background image");
         }
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/Flashlight.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/Flashlight.java
@@ -23,6 +23,8 @@ import jmri.enginedriver.threaded_application;
  */
 
 public abstract class Flashlight {
+    static final String activityName = "Flashlight";
+
     private static Context flashlightContext;
 
     public static Flashlight newInstance(Context context) {
@@ -35,7 +37,7 @@ public abstract class Flashlight {
             flashlight = new MarshmallowFlashlight();
         }
         flashlight.init();
-        Log.d("Engine_Driver", "Created new " + flashlight.getClass());
+        Log.d(threaded_application.applicationName, activityName + ": newInstance(): Created new " + flashlight.getClass());
         return flashlight;
     }
 
@@ -101,10 +103,10 @@ public abstract class Flashlight {
                 camera.setParameters(parameters);
                 camera.setDisplayOrientation(getDisplayOrientation(activity));
                 camera.startPreview();
-                Log.d("Engine_Driver", "Flashlight switched on");
+                Log.d(threaded_application.applicationName, activityName + ": Flashlight switched on");
                 return true;
             } catch (Exception ex) {
-                Log.e("Engine_Driver", "Error switching on flashlight: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Error switching on flashlight: " + ex.getMessage());
 //                Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOnFailed), Toast.LENGTH_LONG).show();
                 threaded_application.safeToast(R.string.toastFlashlightOnFailed, Toast.LENGTH_LONG);
                 return false;
@@ -120,9 +122,9 @@ public abstract class Flashlight {
                     camera.release();
                     camera = null;
                 }
-                Log.d("Engine_Driver", "Flashlight switched off");
+                Log.d(threaded_application.applicationName, activityName + ": Flashlight switched off");
             } catch (Exception ex) {
-                Log.e("Engine_Driver", "Error switching off flashlight: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Error switching off flashlight: " + ex.getMessage());
 //                Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOffFailed), Toast.LENGTH_LONG).show();
                 threaded_application.safeToast(R.string.toastFlashlightOffFailed, Toast.LENGTH_LONG);
             }
@@ -163,9 +165,9 @@ public abstract class Flashlight {
             try {
                 cameraId = cameraManager.getCameraIdList()[0];
             } catch (CameraAccessException|SecurityException ex) {
-                Log.e("Engine_Driver", "Error initiating camera manager: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Error initiating camera manager: " + ex.getMessage());
             } catch (ArrayIndexOutOfBoundsException ex) {
-                Log.e("Engine_Driver", "Error initiating camera manager: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Error initiating camera manager: " + ex.getMessage());
             }
 
         }
@@ -179,15 +181,15 @@ public abstract class Flashlight {
         public boolean setFlashlightOn(Activity activity) {
             try {
                 cameraManager.setTorchMode(cameraId, true);
-                Log.d("Engine_Driver", "Flashlight switched on");
+                Log.d(threaded_application.applicationName, activityName + ": setFlashlightOn(): Flashlight switched on");
                 return true;
             } catch (CameraAccessException ex) {
-                Log.e("Engine_Driver", "Error switching on flashlight: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": setFlashlightOn(): Error switching on flashlight: " + ex.getMessage());
 //                Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOnFailed), Toast.LENGTH_LONG).show();
                 threaded_application.safeToast(R.string.toastFlashlightOnFailed, Toast.LENGTH_LONG);
                 return false;
             } catch (IllegalArgumentException ex) {
-                Log.e("Engine_Driver", "Problem switching on flashlight:" + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": Problem switching on flashlight:" + ex.getMessage());
                 return false;
             }
         }
@@ -196,13 +198,13 @@ public abstract class Flashlight {
         public void setFlashlightOff() {
             try {
                 cameraManager.setTorchMode(cameraId, false);
-                Log.d("Engine_Driver", "Flashlight switched off");
+                Log.d(threaded_application.applicationName, activityName + ": setFlashlightOff(): Flashlight switched off");
             } catch (CameraAccessException ex) {
-                Log.e("Engine_Driver", "Error switching off flashlight: " + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": setFlashlightOff(): Error switching off flashlight: " + ex.getMessage());
 //                Toast.makeText(flashlightContext, flashlightContext.getResources().getString(R.string.toastFlashlightOffFailed), Toast.LENGTH_LONG).show();
                 threaded_application.safeToast(R.string.toastFlashlightOffFailed, Toast.LENGTH_LONG);
             } catch (IllegalArgumentException ex) {
-                Log.e("Engine_Driver", "Problem switching off flashlight:" + ex.getMessage());
+                Log.e(threaded_application.applicationName, activityName + ": setFlashlightOff(): Problem switching off flashlight:" + ex.getMessage());
             }
         }
     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/GetJsonFromUrl.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/GetJsonFromUrl.java
@@ -45,16 +45,16 @@ public class GetJsonFromUrl extends AsyncTask<String, String, Void> {
 //            // Read content & Log
 //            inputStream = httpEntity.getContent();
 //        } catch (UnsupportedEncodingException e1) {
-//            Log.e("Engine_Driver", "UnsupportedEncodingException: " + e1.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": UnsupportedEncodingException: " + e1.toString());
 //            e1.printStackTrace();
 //        } catch (ClientProtocolException e2) {
-//            Log.e("ClientProtocolException", e2.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": ClientProtocolException", e2.toString());
 //            e2.printStackTrace();
 //        } catch (IllegalStateException e3) {
-//            Log.e("IllegalStateException", e3.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": IllegalStateException", e3.toString());
 //            e3.printStackTrace();
 //        } catch (IOException e4) {
-//            Log.e("IOException", e4.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": IOException", e4.toString());
 //            e4.printStackTrace();
 //        }
 //        // Convert response to string using String Builder
@@ -73,7 +73,7 @@ public class GetJsonFromUrl extends AsyncTask<String, String, Void> {
 //            mainapp.sendMsg(mainapp.comm_msg_handler, message_type.HTTP_SERVER_NAME_RECEIVED, serverName);  // 2=toggle
 //
 //        } catch (Exception e) {
-//            Log.e("Engine_Driver","StringBuilding & BufferedReader: " + "Error converting result " + e.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": StringBuilding & BufferedReader: " + "Error converting result " + e.toString());
 //        }
         return null;
     } // protected Void doInBackground(String... params)
@@ -87,7 +87,7 @@ public class GetJsonFromUrl extends AsyncTask<String, String, Void> {
 ////            JSONArray jArray = new JSONArray(oData.getString("name"));
 //            parseResult = oData.getString(which);
 //        } catch (JSONException e) {
-//            Log.e("Engine_Driver", "JSONException: Error: " + e.toString());
+//            Log.e(threaded_application.applicationName, activityName + ": JSONException: Error: " + e.toString());
 //        } // catch (JSONException e)
 //
 //        return parseResult;

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/ImageDownloader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/ImageDownloader.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * A local cache of downloaded images is maintained internally to improve performance.
  */
 public class ImageDownloader {
+    static final String applicationName = "Engine_Driver";
+    static final String activityName = "ImageDownloader";
 
     public ImageDownloader() {
         resetPurgeTimer();
@@ -66,7 +68,7 @@ public class ImageDownloader {
         @Override
         public void run() {
             downloadBitmap(sourceUrl, imageView);
-            Log.d("Engine_Driver", "ImagDownloader: downloadBitmapInBackground.run:");
+            Log.d(applicationName, activityName + ": downloadBitmapInBackground.run:");
         }
     } // end downloadBitmapInBackground()
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/InPhoneLocoSoundsLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/InPhoneLocoSoundsLoader.java
@@ -26,6 +26,7 @@ import jmri.enginedriver.threaded_application;
 import jmri.enginedriver.type.sounds_type;
 
 public class InPhoneLocoSoundsLoader {
+   static final String activityName = "InPhoneLocoSoundsLoader";
    protected threaded_application mainapp;  // hold pointer to mainapp
    protected SharedPreferences prefs;
    protected Context context;
@@ -61,11 +62,11 @@ public class InPhoneLocoSoundsLoader {
 
       @Override
       public void run() {
-         Log.d("Engine_Driver", "IPLS loader: LoadSoundCompleteDelayed.run: (locoSound)");
+         Log.d(threaded_application.applicationName, activityName + ": LoadSoundCompleteDelayed.run: (locoSound)");
          mainapp.soundsSoundsAreBeingReloaded = false;
          mainapp.sendMsg(mainapp.throttle_msg_handler, message_type.SOUNDS_FORCE_LOCO_SOUNDS_TO_START, "", 0);
 //            Toast.makeText(getApplicationContext(), "Sounds loaded. Delay: " + loadDelay, Toast.LENGTH_SHORT).show();
-         Log.d("Engine_Driver", "IPLS loader: LoadSoundCompleteDelayed.run. Delay: " + loadDelay);
+         Log.d(threaded_application.applicationName, activityName + ": LoadSoundCompleteDelayed.run. Delay: " + loadDelay);
 
       }
    } // end DoLocoSoundDelayed
@@ -73,7 +74,7 @@ public class InPhoneLocoSoundsLoader {
 
    @SuppressLint({"ApplySharedPref", "DiscouragedApi"})
    public boolean loadSounds() {
-      Log.d("Engine_Driver", "IPLS loader: loadSounds: (locoSound)");
+      Log.d(threaded_application.applicationName, activityName + ": loadSounds(): (locoSound)");
       mainapp.prefDeviceSounds[0] = prefs.getString("prefDeviceSounds0", context.getResources().getString(R.string.prefDeviceSoundsDefaultValue));
       mainapp.prefDeviceSounds[1] = prefs.getString("prefDeviceSounds1", context.getResources().getString(R.string.prefDeviceSoundsDefaultValue));
 
@@ -90,7 +91,7 @@ public class InPhoneLocoSoundsLoader {
       }
 
       mainapp.soundsSoundsAreBeingReloaded = true;
-//        Log.d("Engine_Driver", "IPLS loader: loadSounds: (locoSound): sounds really do need to be reloaded");
+//        Log.d(threaded_application.applicationName, activityName + ": loadSounds(): (locoSound): sounds really do need to be reloaded");
 
       if (mainapp.soundPool!=null) {
          mainapp.stopAllSounds();
@@ -122,7 +123,7 @@ public class InPhoneLocoSoundsLoader {
          @Override
          public void onLoadComplete(SoundPool soundPool, int i, int i2) {
             if (i==soundsCountOfSoundBeingLoaded) {
-               Log.d("Engine_Driver", "IPLS loader: loadSounds: Sounds confirmed loaded.");
+               Log.d(threaded_application.applicationName, activityName + ": loadSounds(): Sounds confirmed loaded.");
                if (mainapp.throttle_msg_handler!=null) {
                   mainapp.throttle_msg_handler.postDelayed(
                           new LoadSoundCompleteDelayed(1000), 1000);
@@ -244,20 +245,20 @@ public class InPhoneLocoSoundsLoader {
    } // end loadSound()
 
    void loadSoundFromFile(int soundType, int whichThrottle, int soundNo, Context context, String fileName) {
-//        Log.d("Engine_Driver", "IPLS loader: loadSoundFromFile (locoSound): file: '" + fileName + "' wt: " + whichThrottle + " sNo: " + soundNo);
+//        Log.d(threaded_application.applicationName, activityName + ": loadSoundFromFile(): (locoSound): file: '" + fileName + "' wt: " + whichThrottle + " sNo: " + soundNo);
       int duration;
 
       if (!fileName.isEmpty()) {
          File file = new File(context.getExternalFilesDir(null), fileName);
 
          if(!file.exists()) {
-            Log.d("Engine_Driver", "IPLS loader: loadSoundFromFile (locoSound): file:'" + file.getPath() + "/" + fileName + "' - File can't be found");
+            Log.d(threaded_application.applicationName, activityName + ": loadSoundFromFile(): (locoSound): file:'" + file.getPath() + "/" + fileName + "' - File can't be found");
             loadSoundFromFileFailed(soundType, whichThrottle, soundNo, fileName);
          } else {
 
             MediaPlayer player = MediaPlayer.create(context, Uri.fromFile(file));
             if (player == null) {
-               Log.d("Engine_Driver", "IPLS loader: loadSoundFromFile (locoSound): file:'" + file.getPath() + "/" + fileName + "' - Can't determine duration");
+               Log.d(threaded_application.applicationName, activityName + ": loadSoundFromFile(): (locoSound): file:'" + file.getPath() + "/" + fileName + "' - Can't determine duration");
                loadSoundFromFileFailed(soundType, whichThrottle, soundNo, fileName);
             } else {
                duration = player.getDuration();
@@ -279,7 +280,7 @@ public class InPhoneLocoSoundsLoader {
                      mainapp.soundsLocoDuration[whichThrottle][soundNo] = duration;
                      break;
                }
-               Log.d("Engine_Driver", "IPLS loader: loadSoundFromFile (locoSound) : file loaded: '" + file.getPath() + "/" + fileName + "' wt: " + whichThrottle + " sNo: " + soundNo + " Duration: " + duration);
+               Log.d(threaded_application.applicationName, activityName + ": loadSoundFromFile(): (locoSound) : file loaded: '" + file.getPath() + "/" + fileName + "' wt: " + whichThrottle + " sNo: " + soundNo + " Duration: " + duration);
             }
          }
       } else {
@@ -301,7 +302,7 @@ public class InPhoneLocoSoundsLoader {
             mainapp.soundsLocoDuration[whichThrottle][soundNo] = 0;
             break;
       }
-      Log.d("Engine_Driver", "IPLS loader: loadSoundFromFileFailed: " + fileName);
+      Log.d(threaded_application.applicationName, activityName + ": loadSoundFromFileFailed(): " + fileName);
    }
 
    public void getIplsList() { // In Phone Loco Sounds
@@ -321,13 +322,13 @@ public class InPhoneLocoSoundsLoader {
                             mainapp.iplsFileNames.add(fileName);
                             mainapp.iplsNames.add("♫  " + iplsName);
 
-                           Log.d("Engine_Driver", "IPLS loader: getIplsList: Found: " + fileName);
+                           Log.d(threaded_application.applicationName, activityName + ": getIplsList(): Found: " + fileName);
                         }
                     }
                 }
             }
         } catch (Exception e) {
-           Log.d("Engine_Driver", "IPLS loader: getIplsList: Error trying to find ipls files");
+           Log.d(threaded_application.applicationName, activityName + ": getIplsList(): Error trying to find ipls files");
         }
     }
 
@@ -430,16 +431,16 @@ public class InPhoneLocoSoundsLoader {
             iplsName = name;
 
          } catch (IOException except) {
-            Log.e("Engine_Driver", "IPLS loader: addToIplsList: Error reading .ipls file. "
+            Log.e(threaded_application.applicationName, activityName + ": addToIplsList(): Error reading .ipls file. "
                     + except.getMessage());
          }
 
       }
-      Log.d("Engine_Driver", "IPLS loader: loadRecentLocosListFromFile: ImportExportPreferences: Read recent locos list from file complete successfully");
+      Log.d(threaded_application.applicationName, activityName + ": loadRecentLocosListFromFile(): ImportExportPreferences: Read recent locos list from file complete successfully");
    }
 
    public void clearAllSounds() {
-      Log.d("Engine_Driver", "IPLS loader: clearAllSounds (locoSounds)");
+      Log.d(threaded_application.applicationName, activityName + ": clearAllSounds(): (locoSounds)");
       for (int soundType = 0; soundType < 3; soundType++) {
          for (int throttleIndex = 0; throttleIndex < threaded_application.SOUND_MAX_SUPPORTED_THROTTLES; throttleIndex++) {
             for (int mSound = 0; mSound < mainapp.soundsExtrasStreamId[soundType][throttleIndex].length; mSound++) {

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
@@ -22,8 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import jmri.enginedriver.R;
+import jmri.enginedriver.threaded_application;
 
 public class PermissionsHelper {
+    static final String activityName = "PermissionsHelper";
 
     /**
      * A compile time annotation to range-check the list of possible permission request codes.
@@ -105,12 +107,12 @@ public class PermissionsHelper {
 
             if (!showPermissionRationale(activity, requestCode) && grantResult != PackageManager.PERMISSION_GRANTED) {
                 isRecognised = true;
-                Log.d("Engine_Driver", "Permission denied - showAppSettingsDialog");
+                Log.d(threaded_application.applicationName, activityName + ": Permission denied - showAppSettingsDialog");
                 showAppSettingsDialog(activity, requestCode);
                 break;
             } else if (grantResult != PackageManager.PERMISSION_GRANTED) {
                 isRecognised = true;
-                Log.d("Engine_Driver", "Permission denied - showRetryDialog");
+                Log.d(threaded_application.applicationName, activityName + ": Permission denied - showRetryDialog");
                 if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                     showRetryDialog(activity, requestCode);
                 } else {
@@ -119,7 +121,7 @@ public class PermissionsHelper {
                 break;
             } else {
                 isRecognised = true;
-                Log.d("Engine_Driver", "Permission granted - navigateToHandler");
+                Log.d(threaded_application.applicationName, activityName + ": Permission granted - navigateToHandler");
                 ((PermissionsHelperGrantedCallback) activity).navigateToHandler(requestCode);
             }
         }
@@ -184,9 +186,9 @@ public class PermissionsHelper {
     public void requestNecessaryPermissions(final Activity activity, @RequestCodes final int requestCode) {
         // Request the necessary permissions based on request code
         // All possible request codes should be considered
-        Log.d("Engine_Driver", "isDialogOpen at requestNecessaryPermissions? " + isDialogOpen);
+        Log.d(threaded_application.applicationName, activityName + ": requestNecessaryPermissions(): isDialogOpen at requestNecessaryPermissions()? " + isDialogOpen);
         if (!isDialogOpen) {
-            Log.d("Engine_Driver", "Requesting " + getManifestPermissionId(requestCode)+ " permissions");
+            Log.d(threaded_application.applicationName, activityName + ": requestNecessaryPermissions(): Requesting " + getManifestPermissionId(requestCode)+ " permissions");
             switch (requestCode) {
                 case READ_IMAGES:
                     activity.requestPermissions(new String[]{
@@ -243,7 +245,7 @@ public class PermissionsHelper {
 //                    activity.requestPermissions(new String[]{
 //                                    Manifest.permission.NEARBY_WIFI_DEVICES},
 //                            requestCode);
-//                    Log.d("Engine_Driver", "Requesting NEARBY_WIFI_DEVICES permissions");
+//                    Log.d(threaded_application.applicationName, activityName + ": Requesting NEARBY_WIFI_DEVICES permissions");
 //                    break;
                 case POST_NOTIFICATIONS:
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -272,7 +274,7 @@ public class PermissionsHelper {
             }
 
         } else {
-            Log.d("Engine_Driver", "Permissions dialog is opened - don't ask yet...");
+            Log.d(threaded_application.applicationName, activityName + ": requestNecessaryPermissions(): Permissions dialog is opened - don't ask yet...");
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/SwipeDetector.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/SwipeDetector.java
@@ -8,7 +8,10 @@ import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 
+import jmri.enginedriver.threaded_application;
+
 public class SwipeDetector implements View.OnTouchListener {
+    static final String activityName = "SwipeDetector";
 
     public enum Action {
         LR, // Left to Right
@@ -55,13 +58,13 @@ public class SwipeDetector implements View.OnTouchListener {
                 if (Math.abs(deltaX) > MIN_DISTANCE) {
                     // left or right
                     if (deltaX < 0) {
-                        Log.d("Engine_Driver","SwipeDetector: Swipe Left to Right");
+                        Log.d(threaded_application.applicationName, activityName + ": onTouch(): Swipe Left to Right");
 //                        Logger.show(Log.INFO,logTag, "Swipe Left to Right");
                         mSwipeDetected = Action.LR;
                         return true;
                     }
                     if (deltaX > 0) {
-                        Log.d("Engine_Driver","SwipeDetector: Swipe Right to Left");
+                        Log.d(threaded_application.applicationName, activityName + ": onTouch(): Swipe Right to Left");
 //                        Logger.show(Log.INFO,logTag, "Swipe Right to Left");
                         mSwipeDetected = Action.RL;
                         return true;
@@ -72,13 +75,13 @@ public class SwipeDetector implements View.OnTouchListener {
                     if (Math.abs(deltaY) > MIN_DISTANCE) {
                         // top or down
                         if (deltaY < 0) {
-                            Log.d("Engine_Driver","SwipeDetector: Swipe Top to Bottom");
+                            Log.d(threaded_application.applicationName, activityName + ": onTouch(): Swipe Top to Bottom");
 //                            Logger.show(Log.INFO,logTag, "Swipe Top to Bottom");
                             mSwipeDetected = Action.TB;
                             return false;
                         }
                         if (deltaY > 0) {
-                            Log.d("Engine_Driver","SwipeDetector: Swipe Bottom to Top");
+                            Log.d(threaded_application.applicationName, activityName + ": onTouch(): Swipe Bottom to Top");
 //                            Logger.show(Log.INFO,logTag, "Swipe Bottom to Top");
                             mSwipeDetected = Action.BT;
                             return false;

--- a/EngineDriver/src/main/java/jmri/jmrit/roster/RosterEntry.java
+++ b/EngineDriver/src/main/java/jmri/jmrit/roster/RosterEntry.java
@@ -15,6 +15,8 @@ import jmri.enginedriver.threaded_application;
 
 @SuppressWarnings("UnnecessaryContinue")
 public class RosterEntry {
+    static final String activityName = "RosterEntry";
+
     // members to remember all the info
     protected String _fileName = null;
 
@@ -157,7 +159,7 @@ public class RosterEntry {
         for (int k = 0; k < nm.getLength(); k++) {
             if ("id".compareTo(nm.item(k).getNodeName()) == 0) {
                 _id = nm.item(k).getNodeValue();
-                Log.d("Engine_Driver", "RosterEntry: adding id " + _id);
+                Log.d(threaded_application.applicationName, activityName + ": adding id " + _id);
                 continue;
             }
             if ("fileName".compareTo(nm.item(k).getNodeName()) == 0) {
@@ -215,13 +217,13 @@ public class RosterEntry {
 
             if ("dateUpdated".compareTo(node.getNodeName()) == 0) {
                 _dateUpdated = node.getNodeValue();
-//Log.d("RosterEntry ", "Adding date updated "+_dateUpdated+" / text content : "+node.getNodeValue());
+//Log.d(threaded_application.applicationName, activityName + ": Adding date updated "+_dateUpdated+" / text content : "+node.getNodeValue());
                 continue;
             }
 /*    		if ( "locoaddress".compareTo(node.getNodeName()) == 0) {
                 _dccAddress = node.getNodeValue();
     			//TODO _isLongAddress=
-    			//Log.d("RosterEntry ", "Adding 2nd dcc address "+_dccAddress+" / text content : "+node.getNodeValue());
+    			//Log.d(threaded_application.applicationName, activityName + ": Adding 2nd dcc address "+_dccAddress+" / text content : "+node.getNodeValue());
 
     			continue;
     		}
@@ -231,12 +233,12 @@ public class RosterEntry {
                 for (int j = 0; j < nnm.getLength(); j++) {
                     if ("model".compareTo(nnm.item(j).getNodeName()) == 0) {
                         _decoderModel = nnm.item(j).getNodeValue();
-//    					Log.d("RosterEntry ", "adding decoder "+_decoderModel);
+//    					Log.d(threaded_application.applicationName, activityName + ": adding decoder "+_decoderModel);
                         continue;
                     }
                     if ("family".compareTo(nnm.item(j).getNodeName()) == 0) {
                         _decoderFamily = nnm.item(j).getNodeValue();
-//    					Log.d("RosterEntry ", "adding decoder family "+_decoderFamily);
+//    					Log.d(threaded_application.applicationName, activityName + ": adding decoder family "+_decoderFamily);
                         continue;
                     }
                     if ("comment".compareTo(nnm.item(j).getNodeName()) == 0) {
@@ -318,7 +320,7 @@ public class RosterEntry {
                         setFunctionImage(num, imOff);
                     if (imOn != null)
                         setFunctionSelectedImage(num, imOn);
-                    Log.d("RosterEntry ", "Setting function " + num + "(" + val + ") " + lockable + " " + imOff + "/" + imOn);
+                    Log.d(threaded_application.applicationName, activityName + ": loadFunctions(): Setting function " + num + "(" + val + ") " + lockable + " " + imOff + "/" + imOn);
                 }
             }
         }

--- a/EngineDriver/src/main/java/jmri/jmrit/roster/RosterLoader.java
+++ b/EngineDriver/src/main/java/jmri/jmrit/roster/RosterLoader.java
@@ -15,7 +15,10 @@ import java.util.HashMap;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import jmri.enginedriver.threaded_application;
+
 public class RosterLoader {
+    static final String activityName = "comm_handler";
     final URL rosterUrl;
 
     public RosterLoader(String Url) {
@@ -30,7 +33,7 @@ public class RosterLoader {
         try {
             return rosterUrl.openConnection().getInputStream();
         } catch (IOException e) {
-            Log.e("Engine_Driver", "Error retrieving roster xml: " + e.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": InputStream(): Error retrieving roster xml: " + e.getMessage());
             throw new RuntimeException(e);
         }
     }
@@ -51,7 +54,7 @@ public class RosterLoader {
             }
             rosterStream.close();
         } catch (Exception e) {
-            Log.e("Engine_Driver", "Error building hashmap of Roster Entries: " + e.getMessage());
+            Log.e(threaded_application.applicationName, activityName + ": parse(): Error building hashmap of Roster Entries: " + e.getMessage());
             return null;
         }
         return roster;

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -309,7 +309,7 @@
     <string name="FilterRosterListHint">Contém…</string>
     <string name="LocoSelectMethodHelp">Digite o endereço DCC da sua locomotiva acima e clique em \'Acquire\'.\n\nAlternadamente, selecione uma locomotiva da \'Lista\' JMRI ou selecione uma locmotivas usadas \'Recentemente\', clicando em um dos botões acima.</string>
 
-<!--    <string name="LocoSelectMethodQuestion">Método: </string>-->
+<!--    <string name="LocoSelectMethodQuestion">-->
     <string name="prefSelectLocoByRadioButtonsTitle">Selecione a aparência do método loco</string>
     <string name="prefSelectLocoByRadioButtonsSummary">Mostrar uma lista de texto de métodos em vez de botões de imagem</string>
     <string name="LocoSelectMethodAddress">DCC Endereço</string>

--- a/EngineDriver/src/main/res/values/integers.xml
+++ b/EngineDriver/src/main/res/values/integers.xml
@@ -15,8 +15,6 @@
       Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 -->
 
-<!-- TODO: workout how to use the KEYCODES from android.view.KeyEvent rather having the declare them as integers -->
-
 <resources>
     <integer name="KeyCode_0"> 7</integer>
     <integer name="KeyCode_1"> 8</integer>

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,4 +1,8 @@
 **Version 2.40.200
+* added a new seperate check for when the app is in background
+* reduce the amount of static text related to log messages
+* wholesale cleanup if the code to 'finish' an activity
+*additional log messages in select_loco
 **Version 2.40.198
  * Tidy up of the AppIntro permissions
  * Change the location permission warnings to a toast message


### PR DESCRIPTION
* added a new separate check for when the app is in background
* reduce the amount of static text related to log messages (applicationName and activityName)
* wholesale cleanup of the code to 'finish' an activity
* additional log messages in select_loco

A particular tablet was going into background when the soft keyboard was being closed, and the system decided it needed the memory and immediately killed ED. The new 'check' is based around the activities telling t_a when they are in-view, or transitioning to another view.

Every call to log.d or log.e now uses a static applicationName from t_a, and a static activityName from each class. 
a) it will remove a lot of inconsistencies with the log messages 
b) it should reduce the app size and memory usage a little bit