### PR TITLE
- Bug Fix - If you try to close the Web screen

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/web_activity.java
@@ -614,7 +614,7 @@ public class web_activity extends AppCompatActivity implements android.gesture.G
                 return true;
             }
 //            navigateAway(true, null); // don't really finish the activity here
-            Intent in = new Intent().setClass(this, throttle.class);
+            Intent in = mainapp.getThrottleIntent();
             startACoreActivity(this, in, false, 0);
             return true;
         }

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -1,4 +1,5 @@
 **Version 2.41.210
+ * Bug Fix - If you try to close the Web screen if using anything other than the default throttle layout, ED will crash.
 **Version 2.41.208
  * Additional French translations by Alain Carasso
  * Additional Google translations


### PR DESCRIPTION
Bug Fix - If you try to close the Web screen if using anything other than the default throttle layout, ED will crash.