### PR TITLE
Don't query the DCC-EX EStop Pause/Resume state

### DIFF
--- a/EngineDriver/src/main/java/jmri/enginedriver/PreferencesActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/PreferencesActivity.java
@@ -1445,7 +1445,7 @@ public class PreferencesActivity extends AppCompatActivity implements Preference
         enableDisablePreference(prefScreen, "prefDccexThrownLabel", enable);
         enableDisablePreference(prefScreen, "prefDccexClosedLabel", enable);
 
-        enable = ( ((mainapp.isDccexProtocol()) && (mainapp.getDccexVersionNumeric() >= 5.005058))
+        enable = ( ((mainapp.isDccexProtocol()) && (mainapp.getDccexVersionNumeric() >= 5.005059))
                 || (mainapp.connectedHostName.isEmpty()));
         enableDisablePreference(prefScreen, "prefDccexEmergencyStopPauseResume", enable);
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/SendProcessorDccex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/SendProcessorDccex.java
@@ -101,7 +101,7 @@ public class SendProcessorDccex {
     /* ******************************************************************************************** */
 
     public static void sendDccexRequestEmergencyStopState() {
-        if (mainapp.getDccexVersionNumeric() >= 5.005058)
+        if (mainapp.getDccexVersionNumeric() >= 5.005059)
             comm_thread.wifiSend("<!Q>");
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/comms/SendProcessorDccex.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/comms/SendProcessorDccex.java
@@ -46,7 +46,8 @@ public class SendProcessorDccex {
                 sendDccexRequestRoutes();
                 sendDccexRequestTracks();
             }
-            sendDccexRequestEmergencyStopState();
+            if (prefs.getBoolean("prefDccexEmergencyStopPauseResume", false))
+                sendDccexRequestEmergencyStopState();
             mainapp.DCCEXlistsRequested = 0;  // don't ask again
         } else {
             comm_thread.wifiSend("<#>");
@@ -100,7 +101,8 @@ public class SendProcessorDccex {
     /* ******************************************************************************************** */
 
     public static void sendDccexRequestEmergencyStopState() {
-        comm_thread.wifiSend("<!Q>");
+        if (mainapp.getDccexVersionNumeric() >= 5.005058)
+            comm_thread.wifiSend("<!Q>");
     }
 
     /* ******************************************************************************************** */

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -3847,7 +3847,7 @@ public class threaded_application extends Application {
 
         // inflate your xml layout
         LayoutInflater inflater = activity.getLayoutInflater();
-        final View layout = inflater.inflate(R.layout.toast_custom, null);
+        @SuppressLint("InflateParams") final View layout = inflater.inflate(R.layout.toast_custom, null);
 
         Display display = activity.getWindowManager().getDefaultDisplay();
         Point size = new Point();

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -178,7 +178,7 @@ import jmri.enginedriver.type.speed_commands_from_type;
 import jmri.enginedriver.type.gamepad_test_type;
 import jmri.enginedriver.type.swipe_up_down_option_type;
 import jmri.enginedriver.type.speed_step_type;
-import jmri.enginedriver.type.acceleratorometer_action_type;
+import jmri.enginedriver.type.accelerometer_action_type;
 import jmri.enginedriver.type.direction_type;
 import jmri.enginedriver.type.gamepad_status_type;
 
@@ -546,7 +546,7 @@ public class throttle extends AppCompatActivity implements
     private SensorManager sensorManager;
     private Sensor accelerometer;
     private jmri.enginedriver.util.ShakeDetector shakeDetector;
-    private String prefAccelerometerShake = acceleratorometer_action_type.NONE;
+    private String prefAccelerometerShake = accelerometer_action_type.NONE;
     private boolean accelerometerCurrent = false;
 
     //    protected static final String THEME_DEFAULT = "Default";
@@ -1531,7 +1531,7 @@ public class throttle extends AppCompatActivity implements
     }
 
     private void setupSensor() {
-        if (!prefAccelerometerShake.equals(acceleratorometer_action_type.NONE)) {
+        if (!prefAccelerometerShake.equals(accelerometer_action_type.NONE)) {
             // ShakeDetector initialization
             sensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
             accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
@@ -1543,7 +1543,7 @@ public class throttle extends AppCompatActivity implements
                     public void onShake(int count) {
 
                         switch (prefAccelerometerShake) {
-                            case acceleratorometer_action_type.WEB_VIEW:
+                            case accelerometer_action_type.WEB_VIEW:
                                 if ((prefWebViewLocation.equals(web_view_location_type.NONE)) && (keepWebViewLocation.equals(web_view_location_type.NONE))) {
                                     GamepadFeedbackSound(true);
                                     mainapp.safeToast(R.string.toastShakeWebViewUnavailable, Toast.LENGTH_SHORT);
@@ -1552,7 +1552,7 @@ public class throttle extends AppCompatActivity implements
                                     showHideWebView(getApplicationContext().getResources().getString(R.string.toastShakeWebViewHidden));
                                 }
                                 break;
-                            case acceleratorometer_action_type.NEXT_V:
+                            case accelerometer_action_type.NEXT_V:
                                 GamepadFeedbackSound(false);
                                 setNextActiveThrottle();
                                 tts.speakWords(tts_msg_type.VOLUME_THROTTLE, whichVolume, false
@@ -1561,18 +1561,18 @@ public class throttle extends AppCompatActivity implements
                                         , 0
                                         , getConsistAddressString(whichVolume));
                                 break;
-                            case acceleratorometer_action_type.LOCK_DIM_SCREEN:
+                            case accelerometer_action_type.LOCK_DIM_SCREEN:
                                 GamepadFeedbackSound(false);
                                 setRestoreScreenLockDim(getApplicationContext().getResources().getString(R.string.toastShakeScreenLocked));
                                 break;
-                            case acceleratorometer_action_type.DIM_SCREEN:
+                            case accelerometer_action_type.DIM_SCREEN:
                                 GamepadFeedbackSound(false);
                                 setRestoreScreenDim(getApplicationContext().getResources().getString(R.string.toastShakeScreenDimmed));
                                 break;
-                            case acceleratorometer_action_type.ALL_STOP:
+                            case accelerometer_action_type.ALL_STOP:
                                 GamepadFeedbackSound(false);
                                 speedUpdateAndNotify(0);         // update all throttles
-                            case acceleratorometer_action_type.E_STOP:
+                            case accelerometer_action_type.E_STOP:
                                 GamepadFeedbackSound(false);
                                 mainapp.sendEStopMsg();
                                 if ( (mainapp.isWiThrottleProtocol()) || (!mainapp.prefDccexEmergencyStopPauseResume) ) {
@@ -5880,7 +5880,7 @@ public class throttle extends AppCompatActivity implements
         CookieManager cookieManager = CookieManager.getInstance();
         cookieManager.setAcceptCookie(true);
 
-        if (!prefAccelerometerShake.equals(acceleratorometer_action_type.NONE)) {
+        if (!prefAccelerometerShake.equals(accelerometer_action_type.NONE)) {
             if (!accelerometerCurrent) { // preference has only just been changed to turn it on
                 setupSensor();
             } else {

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/accelerometer_action_type.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/accelerometer_action_type.java
@@ -17,7 +17,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 package jmri.enginedriver.type;
 
-public interface acceleratorometer_action_type {
+public interface accelerometer_action_type {
     String NONE = "None";
     String NEXT_V = "NextV";
     String DIM_SCREEN = "Dim";

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.1.1'
+        classpath 'com.android.tools.build:gradle:9.2.0'
     }
 }
 

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -7,6 +7,8 @@
  * Bug Fixes
      * Clock not displaying initially, and not updating consistently.
      * Layout swap button was not refreshing the screen.
+     * EStop Action Bar button not always sending EStop.
+     * Don't query the DCC-EX EStop Pause/Resume state unless the preference is set and the CS version is correct.
   * Other
      * Reworking of the custom toast popup.
      * Reworking of most of the images in the intro/wizard
@@ -1109,7 +1111,7 @@
  *   TODO: move some actions from onCreate() or onResume() to onStart() in activities to simplify and remove some repeated calls.
  *   TODO: Improve the way it deals with multiple DCC-EX commands on single line. Really needs to be read char by char.
  *   TODO: Continue converting the three old style themes/styles to the reusable format.
- *   TODO: Move most, if not all, toasts to the new custom toast.
+ *   TODO: Move most, if not all, toasts to the new custom toast. Especially the longer ones.
  * intro
  *   TODO: if saved preferences found, prompt for import and shortcircuit intro. This is unlikely as the folder is not created till the app runs the first time, so you can't pre load the saved preferences in the folder.
  * web
@@ -1149,7 +1151,7 @@
  *   TODO: option/button to support DPU "unfenced" mode, relatively adjusting 2nd throttle from first
  *   TODO: retrieve and show icons for function buttons (if set)
  *   TODO: if nS is lead of ED consist, MT-nS loses track of "other" loco (test with a "partial steal")
- *   TODO: option to make Stop "sticky" and ignore slider unless direction is selected
+ *   TODO: option to make Stop "sticky" and ignore slider unless direction is selected. (This is done for DCC-EX using the server feature.)
  *   TODO: avoid dup sends when function is non-latching (get from WiT)  e.g. HornSelect skips one
  *   TODO: add more info to Exit dialog, e.g. "2 locos will be stopped and released"
  *   TODO: re-arrangeable function buttons
@@ -1186,7 +1188,6 @@
  * DCC-EX screen
  *   TODO: Look into adding an 'Unjoin' button
  *   TODO: the number of tracks/outputs is not refreshed when the app is closed, opened again, and connected to a CS that has a different number of outputs
- *   TODO: Look at adding immersive mode to get extra screen space
  * preferences:
  *
  * children's timer:

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -20,7 +20,7 @@
      * Separate the CV19 button control for the DCC-EX In Command Station Consist button control.
      * Additional Google translations.
      * Disable the 'stop on phone call' preference if no sim card or don't have READ_PHONE_STATE permission.
-     * Gradle upgrade to 9.1.1
+     * Gradle upgrade to 9.2.0
      * Continued renaming of some files for consistency.
      * Linting. Mostly in ConnectionActivity.
 **Version 2.43.224


### PR DESCRIPTION
- Don't query the DCC-EX EStop Pause/Resume state unless the preference is set and the CS version is correct.
- typo in file name.