### PR TITLE
Removed need for READ_MEDIA_... Permissions.

### DIFF
--- a/EngineDriver/src/main/AndroidManifest.xml
+++ b/EngineDriver/src/main/AndroidManifest.xml
@@ -17,11 +17,11 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS"  tools:ignore="ProtectedPermissions"/>
 <!-- needed for API 33 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+<!--    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 <!-- needed for API 33 -->
 <!-- needed for API 34 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+<!--    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />-->
 <!-- needed for API 34 -->
     <supports-screens
         android:largeScreens="true"

--- a/EngineDriver/src/main/assets/about_page.html
+++ b/EngineDriver/src/main/assets/about_page.html
@@ -28,6 +28,7 @@
     <li>Added preference to hide the additional button text on the Select Screen</li>
     <li>New Throttle layout - Tablet Vertical Left - two function columns (1-6)</li>
     <li>Added preferences to customise the Thrown/Closed button labels for DCC-EX</li>
+    <li>Removed need for READ_MEDIA_IMAGES Permission. Will need to reslect a background if you have one</li>
 </ul>
 <p><em><a
         href="https://raw.githubusercontent.com/JMRI/EngineDriver/master/changelog-and-todo-list.txt"

--- a/EngineDriver/src/main/java/jmri/enginedriver/PreferencesActivity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/PreferencesActivity.java
@@ -75,8 +75,11 @@ import android.widget.Toast;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -855,11 +858,42 @@ public class PreferencesActivity extends AppCompatActivity implements Preference
                 cursor.moveToFirst();
 
                 int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
-                String imgpath = cursor.getString(columnIndex);
+                String imagePath = cursor.getString(columnIndex);
+
+                String outputFileName = "";
+                int cut = imagePath.lastIndexOf('/');
+                if (cut != -1) {
+                    outputFileName = imagePath.substring(cut + 1);
+                }
+
+                String outputFileExt = "";
+                cut = outputFileName.lastIndexOf('.');
+                if (cut != -1) {
+                    outputFileExt = outputFileName.substring(cut + 1);
+                }
+//                String outputFilePart = outputFileName;
+//                cut = outputFileName.lastIndexOf('.');
+//                if (cut != -1) {
+//                    outputFilePart = outputFileName.substring(0, cut);
+//                }
+                outputFileName = "background" + "." + outputFileExt;
+
+                File outputDir = getExternalFilesDir(null);
+                File outputFile = new File(outputDir, outputFileName);
+                String outputFullPath = outputFile.toString();
+
+                // Use ContentResolver to open the stream, which doesn't require storage permissions for picked Uris
+                try (InputStream in = getContentResolver().openInputStream(selectedImage);
+                     OutputStream out = new FileOutputStream(outputFile)) {
+                    if (in != null) {
+                        copyFile(in, out);
+                    }
+                }
+
                 cursor.close();
 
                 SharedPreferences.Editor edit=prefs.edit();
-                edit.putString("prefBackgroundImageFileName",imgpath);
+                edit.putString("prefBackgroundImageFileName",outputFullPath);
                 edit.commit();
 
                 forceRestartAppOnPreferencesClose = true;
@@ -870,6 +904,14 @@ public class PreferencesActivity extends AppCompatActivity implements Preference
             }
         } catch (Exception e) {
             Log.e(threaded_application.applicationName, activityName + ": onActivityResult(): Loading background image Failed: " + e.getMessage());
+        }
+    }
+
+    private void copyFile(InputStream in, OutputStream out) throws IOException {
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
         }
     }
 

--- a/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/intro/intro_activity.java
@@ -209,35 +209,35 @@ public class intro_activity extends AppIntro2 implements PermissionsHelper.Permi
             }
         }
 
-        if (android.os.Build.VERSION.SDK_INT < 33) {
-            if (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_IMAGES)) {
-                args = new Bundle();
-                args.putString("id", Integer.toString(PermissionsHelper.READ_IMAGES));
-                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_IMAGES));
-                fragment = new intro_permissions();
-                fragment.setArguments(args);
-                addSlide(fragment);
-            }
-        } else if (android.os.Build.VERSION.SDK_INT < 34) {
-            if (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_IMAGES)) {
-                args = new Bundle();
-                args.putString("id", Integer.toString(PermissionsHelper.READ_MEDIA_IMAGES));
-                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_MEDIA_IMAGES));
-                fragment = new intro_permissions();
-                fragment.setArguments(args);
-                addSlide(fragment);
-            }
-        } else { // needed for API 34
-            if ( (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_IMAGES))
-                && (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED)) ) {
-                args = new Bundle();
-                args.putString("id", Integer.toString(PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED));
-                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_MEDIA_VISUAL_USER_SELECTED));
-                fragment = new intro_permissions();
-                fragment.setArguments(args);
-                addSlide(fragment);
-            }
-        }
+//        if (android.os.Build.VERSION.SDK_INT < 33) {
+//            if (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_IMAGES)) {
+//                args = new Bundle();
+//                args.putString("id", Integer.toString(PermissionsHelper.READ_IMAGES));
+//                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_IMAGES));
+//                fragment = new intro_permissions();
+//                fragment.setArguments(args);
+//                addSlide(fragment);
+//            }
+//        } else if (android.os.Build.VERSION.SDK_INT < 34) {
+//            if (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_IMAGES)) {
+//                args = new Bundle();
+//                args.putString("id", Integer.toString(PermissionsHelper.READ_MEDIA_IMAGES));
+//                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_MEDIA_IMAGES));
+//                fragment = new intro_permissions();
+//                fragment.setArguments(args);
+//                addSlide(fragment);
+//            }
+//        } else { // needed for API 34
+//            if ( (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_IMAGES))
+//                && (!PermissionsHelper.getInstance().isPermissionGranted(intro_activity.this, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED)) ) {
+//                args = new Bundle();
+//                args.putString("id", Integer.toString(PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED));
+//                args.putString("label", getApplicationContext().getResources().getString(R.string.permissionsREAD_MEDIA_VISUAL_USER_SELECTED));
+//                fragment = new intro_permissions();
+//                fragment.setArguments(args);
+//                addSlide(fragment);
+//            }
+//        }
 
 
         if (!MobileControl2.isMobileControl2()) {

--- a/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/threaded_application.java
@@ -37,7 +37,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
@@ -175,9 +174,9 @@ public class threaded_application extends Application {
     public volatile boolean doFinish = false;  // when true, tells any Activities that are being created/resumed to finish()
     //shared variables returned from the withrottle server, stored here for easy access by other activities
     public volatile Consist[] consists;
-    public LinkedHashMap<Integer, String>[] function_labels;  //function#s and labels from roster for throttles
-    public LinkedHashMap<Integer, String> function_labels_default;  //function#s and labels from local settings
-    LinkedHashMap<Integer, String> function_labels_default_for_roster;  //function#s and labels from local settings for roster entries with no function labels
+    public LinkedHashMap<Integer, String>[] function_labels;  //function(s) and labels from roster for throttles
+    public LinkedHashMap<Integer, String> function_labels_default;  //function(s) and labels from local settings
+    LinkedHashMap<Integer, String> function_labels_default_for_roster;  //function(s) and labels from local settings for roster entries with no function labels
     public LinkedHashMap<Integer, String> function_consist_locos; // used for the 'special' consists function label string matching
     public LinkedHashMap<Integer, String> function_consist_latching; // used for the 'special' consists function label string matching
 
@@ -595,7 +594,7 @@ public class threaded_application extends Application {
     /**
      * Display OnGoing Notification that indicates EngineDriver is Running.
      * Should only be called when ED is going into the background.
-     * Currently call this from each activity onPause, passing the current intent
+     * Currently, call this from each activity onPause, passing the current intent
      * to return to when reopening.
      */
 
@@ -1051,10 +1050,10 @@ public class threaded_application extends Application {
 //            Log.d(applicationName, "t_a: Background loading metadata from " + metaUrl);
 //
 //            HttpClient Client = new DefaultHttpClient();
-//            HttpGet httpget = new HttpGet(metaUrl);
+//            HttpGet httpGet = new HttpGet(metaUrl);
 //            ResponseHandler<String> responseHandler = new BasicResponseHandler();
 //            String jsonResponse;
-//            jsonResponse = Client.execute(httpget, responseHandler);
+//            jsonResponse = Client.execute(httpGet, responseHandler);
 //            Log.d(applicationName, "t_a: Raw metadata retrieved: " + jsonResponse);
 //
 //            HashMap<String, String> metadataTemp = new HashMap<>();
@@ -1221,14 +1220,14 @@ public class threaded_application extends Application {
     /* handle server-specific settings here */
     public void setServerType(String serverType) {
         this.serverType = serverType;
-        if (serverType.equals("MRC")) {
-            web_server_port = 80; //hardcode web port for MRC
-        } else if (serverType.equals("Digitrax")) {
-            wifi_send_interval = 200; //increase the interval for LnWi
-        } else if (serverType.equals("DCC-EX")) {
-            if ( (mainapp.getDccexVersionNumeric() >= threaded_application.DCCEX_VERSION_MINIMUM_FOR_WEB_SERVER)
-            && ((threaded_application.dccexProcessorString.equals("EXCSB1")) || (threaded_application.dccexProcessorString.equals("ESP32"))) )
-                web_server_port = 80; //hardcode web port for DCC-EX
+        switch (serverType) {
+            case "MRC" -> web_server_port = 80; //hardcode web port for MRC
+            case "Digitrax" -> wifi_send_interval = 200; //increase the interval for LnWi
+            case "DCC-EX" -> {
+                if ((mainapp.getDccexVersionNumeric() >= threaded_application.DCCEX_VERSION_MINIMUM_FOR_WEB_SERVER)
+                        && ((threaded_application.dccexProcessorString.equals("EXCSB1")) || (threaded_application.dccexProcessorString.equals("ESP32"))))
+                    web_server_port = 80; //hardcode web port for DCC-EX
+            }
         }
     }
 
@@ -1327,7 +1326,7 @@ public class threaded_application extends Application {
         to_system_names = null;
         to_user_names = null;
         to_state_names = null;
-        turnout_states = new HashMap<String, String>();
+        turnout_states = new HashMap<>();
         routeStates = null;
         routeSystemNames = null;
         rt_user_names = null;
@@ -1354,9 +1353,6 @@ public class threaded_application extends Application {
         dccexScreenIsOpen = false;
         witScreenIsOpen = false;
 
-//        dccexRosterString = "";
-//        dccexTurnoutString = "";
-//        dccexRouteString = "";
         dccexRosterProcessed = false;
         dccexTurnoutsProcessed = false;
         dccexRoutesListReceived = false;
@@ -1368,15 +1364,15 @@ public class threaded_application extends Application {
 
             for (int i = 0; i < maxThrottles; i++) {
                 consists[i] = new Consist();
-                function_labels[i] = new LinkedHashMap<Integer, String>();
+                function_labels[i] = new LinkedHashMap<>();
                 function_states[i] = new boolean[MAX_FUNCTION_NUMBER+1]; // also allocated in onCreate() ???
 
                 dccexLastKnownSpeed[i] = 0;
                 dccexLastKnownDirection[i] = 1;
             }
 
-            consist_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
-            roster_entries = Collections.synchronizedMap(new LinkedHashMap<String, String>());
+            consist_entries = Collections.synchronizedMap(new LinkedHashMap<>());
+            roster_entries = Collections.synchronizedMap(new LinkedHashMap<>());
         } catch (Exception e) {
             Log.d(applicationName, "t_a: initShared object create exception");
         }
@@ -1388,53 +1384,6 @@ public class threaded_application extends Application {
     //
     // utilities
     //
-
-    /**
-     * ------ copied from jmri util code -------------------
-     * Split a string into an array of Strings, at a particular
-     * divider.  This is similar to the new String.split method,
-     * except that this does not provide regular expression
-     * handling; the divider string is just a string.
-     *
-     * @param input   String to split
-     * @param divider Where to divide the input; this does not appear in output
-     */
-    static public String[] splitByString(String input, String divider) {
-
-        //bail on empty input string, return input as single element
-        if (input == null || input.isEmpty()) return new String[]{input};
-
-        int size = 0;
-        String temp = input;
-
-        // count entries
-        while (!temp.isEmpty()) {
-            size++;
-            int index = temp.indexOf(divider);
-            if (index < 0) break;    // break not found
-            temp = temp.substring(index + divider.length());
-            if (temp.isEmpty()) {  // found at end
-                size++;
-                break;
-            }
-        }
-
-        String[] result = new String[size];
-
-        // find entries
-        temp = input;
-        size = 0;
-        while (!temp.isEmpty()) {
-            int index = temp.indexOf(divider);
-            if (index < 0) break;    // done with all but last
-            result[size] = temp.substring(0, index);
-            temp = temp.substring(index + divider.length());
-            size++;
-        }
-        result[size] = temp;
-
-        return result;
-    }
 
     public void powerStateMenuButton() {
         int newState = 1;
@@ -1496,6 +1445,69 @@ public class threaded_application extends Application {
                 }
             }
         }
+    }
+
+    /**
+     * ------ copied from jmri util code -------------------
+     * Split a string into an array of Strings, at a particular
+     * divider.  This is similar to the new String.split() method,
+     * except that this does not provide regular expression
+     * handling; the divider string is just a string.
+     *
+     * @param input   String to split
+     * @param divider Where to divide the input; this does not appear in output
+     */
+//    static public String[] splitByString(String input, String divider) {
+//
+//        //bail on empty input string, return input as single element
+//        if (input == null || input.isEmpty()) return new String[]{input};
+//
+//        int size = 0;
+//        String temp = input;
+//
+//        // count entries
+//        while (!temp.isEmpty()) {
+//            size++;
+//            int index = temp.indexOf(divider);
+//            if (index < 0) break;    // break not found
+//            temp = temp.substring(index + divider.length());
+//            if (temp.isEmpty()) {  // found at end
+//                size++;
+//                break;
+//            }
+//        }
+//
+//        String[] result = new String[size];
+//
+//        // find entries
+//        temp = input;
+//        size = 0;
+//        while (!temp.isEmpty()) {
+//            int index = temp.indexOf(divider);
+//            if (index < 0) break;    // done with all but last
+//            result[size] = temp.substring(0, index);
+//            temp = temp.substring(index + divider.length());
+//            size++;
+//        }
+//        result[size] = temp;
+//
+//        return result;
+//    }
+
+    static public String[] splitByString(String input, String divider) {
+        String tempInput = input;
+
+        boolean blankAtEnd = false;
+        // Unlike .split() the old splitByString(), that this method replaces, added an additional element if the string ended in the divider. So check and add if necessary.
+        if (input.lastIndexOf(divider) == (input.length()-divider.length())) {
+            blankAtEnd = true;
+            tempInput = input + " ";
+        }
+
+        String[] tempString = tempInput.split(Pattern.quote(divider));
+        if (blankAtEnd) tempString[tempString.length-1] = "";
+
+        return tempString;
     }
 
     /**
@@ -2200,21 +2212,19 @@ public class threaded_application extends Application {
         b.setTitle(R.string.exit_title);
         b.setMessage(R.string.exit_text);
         b.setCancelable(true);
-        b.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                Log.d(applicationName, "t_a: checkAskExit(): onClick() ");
-                exitConfirmed = true;
-                if (!forceFastDisconnect) { //trigger disconnect / shutdown sequence
-                    mainapp.alertCommHandlerWithBundle(message_type.SHUTDOWN);
+        b.setPositiveButton(R.string.yes, (dialog, id) -> {
+            Log.d(applicationName, "t_a: checkAskExit(): onClick() ");
+            exitConfirmed = true;
+            if (!forceFastDisconnect) { //trigger disconnect / shutdown sequence
+                mainapp.alertCommHandlerWithBundle(message_type.SHUTDOWN);
 
-                } else { //trigger fast disconnect / shutdown sequence
+            } else { //trigger fast disconnect / shutdown sequence
 
-                    Bundle bundle = new Bundle();
-                    bundle.putInt(alert_bundle_tag_type.URGENT, 1);
-                    mainapp.alertCommHandlerWithBundle(message_type.SHUTDOWN, bundle);
-                }
-                buttonVibration();
+                Bundle bundle = new Bundle();
+                bundle.putInt(alert_bundle_tag_type.URGENT, 1);
+                mainapp.alertCommHandlerWithBundle(message_type.SHUTDOWN, bundle);
             }
+            buttonVibration();
         });
         b.setNegativeButton(R.string.no, null);
         AlertDialog alert = b.create();
@@ -2621,12 +2631,7 @@ public class threaded_application extends Application {
         Log.d(applicationName, "t_a: safeToast: " + msg_txt);
         //need to do Toast() on the main thread so create a handler
         Handler h = new Handler(Looper.getMainLooper());
-        h.post(new Runnable() {
-            @Override
-            public void run() {
-                Toast.makeText(getApplicationContext(), msg_txt, length).show();
-            }
-        });
+        h.post(() -> Toast.makeText(getApplicationContext(), msg_txt, length).show());
     }
 
     public int getMaxThrottlesForScreen(String throttleScreenType) {
@@ -2637,9 +2642,8 @@ public class threaded_application extends Application {
                     -> max_throttles_current_screen_type.VERTICAL;
             case throttle_screen_type.VERTICAL_LEFT, throttle_screen_type.VERTICAL_RIGHT
                     ->  max_throttles_current_screen_type.VERTICAL_LEFT_OR_RIGHT;
-            case throttle_screen_type.TABLET_VERTICAL_LEFT
-                    -> max_throttles_current_screen_type.VERTICAL_TABLET;
-            case throttle_screen_type.TABLET_VERTICAL_LEFT_TWO_FUNCTION_COLUMNS
+            case throttle_screen_type.TABLET_VERTICAL_LEFT,
+                 throttle_screen_type.TABLET_VERTICAL_LEFT_TWO_FUNCTION_COLUMNS
                     -> max_throttles_current_screen_type.VERTICAL_TABLET;
             case throttle_screen_type.SWITCHING
                     -> max_throttles_current_screen_type.SWITCHING;
@@ -2959,7 +2963,7 @@ public class threaded_application extends Application {
     public void updateConnectionList(String retrievedServerName) {
         // if I don't have permissions, don't ask, just ignore
 
-//  commented out as I had not ide why this was being done.. Did not seem to achieve anything
+//  commented out as I have no idea why this was being done. Did not seem to achieve anything
 //        if ((context.checkCallingOrSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
 //                && (context.checkCallingOrSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) == PackageManager.PERMISSION_GRANTED) {
 
@@ -3216,8 +3220,8 @@ public class threaded_application extends Application {
         return whichGamepad;
     }
 
-    // work out a) if we need to look for multiple gamepads b) workout which gamepad we received the key event from
-    public int findWhichGamePadEventIsFrom(String eventDeviceDescriptor, String eventDeviceName, int eventKeyCode) {
+    // work out: a) if we need to look for multiple gamepads, b) workout which gamepad we received the key event from
+    public int findWhichGamePadEventIsFrom(String eventDeviceDescriptor, String eventDeviceName, int ignoredEventKeyCode) {
 //    public int findWhichGamePadEventIsFrom(int eventDeviceId, String eventDeviceName, int eventKeyCode) {
         int whichGamePad = -2;  // default to the event not from a gamepad
         int whichGamePadDeviceId = -1;
@@ -3364,9 +3368,8 @@ public class threaded_application extends Application {
         if (dev == null) { // unclear why, but some phones/tables don't seem to return a device for the internal keyboard
             return false;
         }
-        String eventDeviceName = dev.getName();
+//        String eventDeviceName = dev.getName();
         boolean isExternal = false;
-//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
         InputDevice iDev = getDevice(event.getDeviceId());
         if (iDev != null && iDev.toString().contains("Location: external")) {
             isExternal = true;
@@ -3379,7 +3382,6 @@ public class threaded_application extends Application {
                 }
             }
         }
-//        }
 
         if (isExternal) { // is from a external device (otherwise if it has come from the phone itself, generally don't try to process it here)
             if (!prefGamePadType.equals(threaded_application.WHICH_GAMEPAD_MODE_NONE)) { // respond to the gamepad and keyboard inputs only if the preference is set
@@ -3830,18 +3832,18 @@ public class threaded_application extends Application {
 //                        Log.d(threaded_application.applicationName, activityName + " : " +System.currentTimeMillis() + ":" + pair.second + ": showCustomToast(): keeping: " + pair.first);
                     }
                 }
-                customToastPairList.add(new Pair(message, endTime));
+                customToastPairList.add(new Pair<>(message, endTime));
                 Log.d(threaded_application.applicationName, activityName + " : " +System.currentTimeMillis() + ":" + endTime + ": showCustomToast(): adding: " + message);
             }
         } else {
             clearCustomToastPairList();
-            customToastPairList.add(new Pair(message, endTime));
+            customToastPairList.add(new Pair<>(message, endTime));
             Log.d(threaded_application.applicationName, activityName + " : " +System.currentTimeMillis() + ":" + endTime + ": showCustomToast(): adding: " + message);
         }
         tempToastText.append(message);
 
         //adjust the inter-paragraph spacing
-        String text = tempToastText.toString().replace("\n","\n\0");;
+        String text = tempToastText.toString().replace("\n","\n\0");
         Spannable spannable = new SpannableString(text);
         for (int i = 0; i < text.length()-1; i++) {
             if (text.charAt(i) == '\n') {
@@ -3865,7 +3867,7 @@ public class threaded_application extends Application {
         if (!title.isEmpty()) {
             ((TextView) layout.findViewById(R.id.title)).setText(title);
         } else {
-            ((TextView) layout.findViewById(R.id.title)).setVisibility(View.GONE);
+            layout.findViewById(R.id.title).setVisibility(View.GONE);
         }
 //        ((TextView) layout.findViewById(R.id.message)).setText(tempToastText.toString());
         ((TextView) layout.findViewById(R.id.message)).setText(spannable, TextView.BufferType.SPANNABLE);
@@ -3878,38 +3880,28 @@ public class threaded_application extends Application {
         toastPopupWindow.setFocusable(false);
 
         // handle toastPopupWindow click event
-        layout.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                toastPopupWindow.dismiss();
-            }
-        });
+        layout.setOnClickListener(view -> toastPopupWindow.dismiss());
 
         // Use post to ensure the Activity's window is ready and we have a window token
         final View decorView = activity.getWindow().getDecorView();
         if (decorView != null) {
-            decorView.post(new Runnable() {
-                @Override
-                public void run() {
-                    if (!activity.isFinishing() && !activity.isDestroyed()) {
-                        try {
-                            // Use decorView as the parent to provide the window token
-                            toastPopupWindow.showAtLocation(decorView, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, yOffset);
+            decorView.post(() -> {
+                if (!activity.isFinishing() && !activity.isDestroyed()) {
+                    try {
+                        // Use decorView as the parent to provide the window token
+                        toastPopupWindow.showAtLocation(decorView, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 0, yOffset);
 
-                            // dismiss the popup window after specified period
-                            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
-                                public void run() {
-                                    try {
-                                        if (toastPopupWindow.isShowing()) {
-                                            toastPopupWindow.dismiss();
-                                        }
-                                    } catch (Exception ignored) {
-                                    }
+                        // dismiss the popup window after specified period
+                        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                            try {
+                                if (toastPopupWindow.isShowing()) {
+                                    toastPopupWindow.dismiss();
                                 }
-                            }, durationMs);
-                        } catch (Exception e) {
-                            Log.e(threaded_application.applicationName, activityName + ": showCustomToast(): Error showing custom toast: " + e.getMessage());
-                        }
+                            } catch (Exception ignored) {
+                            }
+                        }, durationMs);
+                    } catch (Exception e) {
+                        Log.e(threaded_application.applicationName, activityName + ": showCustomToast(): Error showing custom toast: " + e.getMessage());
                     }
                 }
             });
@@ -3937,7 +3929,6 @@ public class threaded_application extends Application {
     public static int getRgbColorFromThemeAttribute(Context context, int attribute) {
         TypedValue typedValue = new TypedValue();
         context.getTheme().resolveAttribute(attribute, typedValue, true);
-        int color = typedValue.data;
-        return color;
+        return typedValue.data;
     }
 }

--- a/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/throttle.java
@@ -2599,7 +2599,7 @@ public class throttle extends AppCompatActivity implements
         showDirectionIndication(whichThrottle, direction);
     }
 
-    boolean changeActualOrTargetDirectionIfAllowed(int whichThrottle, int ignoredDirection, boolean ignoredButtonsAreReversed) {
+    boolean toggleActualOrTargetDirectionIfAllowed(int whichThrottle, int ignoredDirection, boolean ignoredButtonsAreReversed) {
         boolean result;
         if (!isSemiRealisticThrottle) {
             if ((getDirection(whichThrottle) == direction_type.FORWARD)) {
@@ -2613,6 +2613,17 @@ public class throttle extends AppCompatActivity implements
             } else {
                 result = !changeTargetDirectionIfAllowed(whichThrottle, direction_type.FORWARD);
             }
+            showTargetDirectionIndication(whichThrottle);
+        }
+        return result;
+    }
+
+    boolean changeActualOrTargetDirectionIfAllowed(int whichThrottle, int direction, boolean ignoredButtonsAreReversed) {
+        boolean result;
+        if (!isSemiRealisticThrottle) {
+            result = !changeDirectionIfAllowed(whichThrottle, direction);
+        } else {
+            result = !changeTargetDirectionIfAllowed(whichThrottle, direction);
             showTargetDirectionIndication(whichThrottle);
         }
         return result;
@@ -3453,7 +3464,7 @@ public class throttle extends AppCompatActivity implements
                 break;
             }
             case gamepad_or_keyboard_event_type.TOGGLE_DIRECTION: {
-                boolean  dirChangeFailed = !changeActualOrTargetDirectionIfAllowed(whichThrottle,
+                boolean  dirChangeFailed = !toggleActualOrTargetDirectionIfAllowed(whichThrottle,
                         getDirection(whichThrottle) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD,
                         false);
                 playFeedbackSound = (dirChangeFailed ? 2 : 1);
@@ -4231,7 +4242,7 @@ public class throttle extends AppCompatActivity implements
                     Log.d(threaded_application.applicationName, activityName + ": ThrottleListener(): onButtonDown(): ESU_MCII: Knob disabled - direction change ignored");
                 } else if (prefEsuMc2EndStopDirectionChange) {
                     threaded_application.extendedLogging(activityName + ": ThrottleListener(): onButtonDown(): ESU_MCII: Attempting to switch direction");
-                    changeActualOrTargetDirectionIfAllowed(whichVolume,
+                    toggleActualOrTargetDirectionIfAllowed(whichVolume,
                             getDirection(whichVolume) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD,
                             false);
                     speedUpdateAndNotify(whichVolume, 0, false);
@@ -4572,7 +4583,7 @@ public class throttle extends AppCompatActivity implements
                     break;
                 case DIRECTION_TOGGLE:
                     if (!isScreenLocked && (action == ACTION_DOWN) && (repeatCnt == 0)) {
-                        boolean dirChangeFailed = !changeActualOrTargetDirectionIfAllowed(whichThrottle,
+                        boolean dirChangeFailed = !toggleActualOrTargetDirectionIfAllowed(whichThrottle,
                                 getDirection(whichThrottle) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD,
                                 gamepadDirectionButtonsAreCurrentlyReversed(whichThrottle));
                     }

--- a/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/turnouts.java
@@ -1047,13 +1047,10 @@ public class turnouts extends AppCompatActivity implements android.gesture.Gestu
                 mainapp.alertCommHandlerWithBundle(message_type.DISCONNECT);
 
                 final Handler handler = new Handler(Looper.getMainLooper());
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        Intent in1 = new Intent().setClass(turnouts.this, ConnectionActivity.class);
-                        startActivity(in1);
-                        ConnectionActivity.overridePendingTransition(turnouts.this, R.anim.fade_in, R.anim.fade_out);
-                    }
+                handler.postDelayed(() -> {
+                    Intent in1 = new Intent().setClass(turnouts.this, ConnectionActivity.class);
+                    startActivity(in1);
+                    ConnectionActivity.overridePendingTransition(turnouts.this, R.anim.fade_in, R.anim.fade_out);
                 }, 2000);
             });
             b.setNegativeButton(R.string.no, null);

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/Consist.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/Consist.java
@@ -265,7 +265,7 @@ public final class Consist {
     }
 
     public boolean isEmpty() {
-        return con.size() == 0;
+        return con.isEmpty();
     }
 
     public boolean isMulti() {
@@ -308,7 +308,7 @@ public final class Consist {
 
     private String formatConsist() {
         StringBuilder formatCon;
-        if (con.size() > 0) {
+        if (!con.isEmpty()) {
             formatCon = new StringBuilder();
             String sep = "";
             for (Map.Entry<String, ConLoco> l : con.entrySet()) {        // loop through locos in consist
@@ -325,7 +325,7 @@ public final class Consist {
 
     private String formatConsistHtml() {
         StringBuilder formatCon;
-        if (con.size() > 0) {
+        if (!con.isEmpty()) {
             formatCon = new StringBuilder();
             String sep = "";
             for (Map.Entry<String, ConLoco> l : con.entrySet()) {        // loop through locos in consist
@@ -342,7 +342,7 @@ public final class Consist {
 
     public String formatConsistAddr() {
         StringBuilder formatCon;
-        if (con.size() > 0) {
+        if (!con.isEmpty()) {
             formatCon = new StringBuilder();
             String sep = "";
             for (Map.Entry<String, ConLoco> l : con.entrySet()) {        // loop through locos in consist

--- a/EngineDriver/src/main/java/jmri/enginedriver/type/Loco.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/type/Loco.java
@@ -165,7 +165,7 @@ public class Loco {
     @NonNull
     @Override
     public String toString() {
-        return (this.desc.length() > 0 ? this.desc : this.formatAddr);
+        return (!this.desc.isEmpty() ? this.desc : this.formatAddr);
     }
 
     private String formatAddress() {
@@ -173,7 +173,7 @@ public class Loco {
     }
 
     public String toHtml() {
-        return (this.desc.length() > 0 ? this.desc : this.formatAddrHtml);
+        return (!this.desc.isEmpty() ? this.desc : this.formatAddrHtml);
     }
 
     private String formatAddressHtml() {
@@ -311,7 +311,7 @@ public class Loco {
             }
 
             // if no matching rule was found, the default rule applies
-            if (functionList.size() == 0) {
+            if (functionList.isEmpty()) {
                 if (((prefConsistFollowDefaultAction.equals(consist_function_action.SAME_F_NUMBER_LEAD))
                         && (isLead))
                         || ((prefConsistFollowDefaultAction.equals(consist_function_action.SAME_F_NUMBER_LEAD_AND_TRAIL))

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/BackgroundImageLoader.java
@@ -28,27 +28,27 @@ public class BackgroundImageLoader {
     }
 
     public void loadBackgroundImage() {
-        if (prefBackgroundImage) {
-            boolean result = false;
-            if (android.os.Build.VERSION.SDK_INT < 33) {
-                if (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_IMAGES)) {
-                    result = true;
-                }
-            } else if (android.os.Build.VERSION.SDK_INT < 34) {
-                if (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_IMAGES)) {
-                    result = true;
-                }
-            } else {
-                if ((PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED))
-                   || (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED)) ) {
-                    result = true;
-                }
-            }
-            if (result) loadBackgroundImageImpl();
-        }
-    }
-
-    protected void loadBackgroundImageImpl() {
+//        if (prefBackgroundImage) {
+//            boolean result = false;
+//            if (android.os.Build.VERSION.SDK_INT < 33) {
+//                if (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_IMAGES)) {
+//                    result = true;
+//                }
+//            } else if (android.os.Build.VERSION.SDK_INT < 34) {
+//                if (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_IMAGES)) {
+//                    result = true;
+//                }
+//            } else {
+//                if ((PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED))
+//                   || (PermissionsHelper.getInstance().isPermissionGranted(mainapp, PermissionsHelper.READ_MEDIA_VISUAL_USER_SELECTED)) ) {
+//                    result = true;
+//                }
+//            }
+//            if (result) loadBackgroundImageImpl();
+//        }
+//    }
+//
+//    protected void loadBackgroundImageImpl() {
         try {
 //            File sdcard_path = Environment.getExternalStorageDirectory();
             File image_file = new File(prefBackgroundImageFileName);

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/GamepadEventHandler.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/GamepadEventHandler.java
@@ -90,7 +90,7 @@ public class GamepadEventHandler {
                                 gamepad_or_keyboard_event_type.STOP_ALL, 0, repeatCnt,
                                 gamepadThrottle, isActive, whichGamePadIsEventFrom);
                     } else if (prefGamePadDoublePressStop.equals(pref_gamepad_button_option_type.FORWARD_REVERSE_TOGGLE)) {
-//                        boolean dirChangeFailed = !changeActualOrTargetDirectionIfAllowed(whichThrottle,
+//                        boolean dirChangeFailed = !toggleActualOrTargetDirectionIfAllowed(whichThrottle,
 //                                getDirection(whichThrottle) == direction_type.FORWARD ? direction_type.REVERSE : direction_type.FORWARD,
 //                                gamepadDirectionButtonsAreCurrentlyReversed(whichThrottle));
                         keyboardNotifierInterface.keyboardEventNotificationHandler(

--- a/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
+++ b/EngineDriver/src/main/java/jmri/enginedriver/util/PermissionsHelper.java
@@ -41,8 +41,8 @@ public class PermissionsHelper {
             VIBRATE,
             READ_IMAGES,
 //            NEARBY_WIFI_DEVICES,
-            READ_MEDIA_IMAGES,
-            READ_MEDIA_VISUAL_USER_SELECTED,
+//            READ_MEDIA_IMAGES,
+//            READ_MEDIA_VISUAL_USER_SELECTED,
             POST_NOTIFICATIONS,
             ACCESS_COARSE_LOCATION,
             ACCESS_WIFI_STATE,
@@ -62,11 +62,11 @@ public class PermissionsHelper {
 
 //<!-- needed for API 33 -->
 //    public static final int NEARBY_WIFI_DEVICES = 49;
-    public static final int READ_MEDIA_IMAGES = 50;
+//    public static final int READ_MEDIA_IMAGES = 50;
     public static final int POST_NOTIFICATIONS = 51;
 //<!-- needed for API 33 -->
 //<!-- needed for API 34 -->
-    public static final int READ_MEDIA_VISUAL_USER_SELECTED = 52;
+//    public static final int READ_MEDIA_VISUAL_USER_SELECTED = 52;
 //<!-- needed for API 34 -->
 
     public static final int ACCESS_COARSE_LOCATION = 53;
@@ -153,10 +153,10 @@ public class PermissionsHelper {
                 return context.getResources().getString(R.string.permissionsACCESS_FINE_LOCATION);
             case VIBRATE:
                 return context.getResources().getString(R.string.permissionsVIBRATE);
-            case READ_MEDIA_IMAGES: // needed for API 33
-                return context.getResources().getString(R.string.permissionsREAD_MEDIA_IMAGES);
-            case READ_MEDIA_VISUAL_USER_SELECTED: // needed for API 34
-                return context.getResources().getString(R.string.permissionsREAD_MEDIA_VISUAL_USER_SELECTED);
+//            case READ_MEDIA_IMAGES: // needed for API 33
+//                return context.getResources().getString(R.string.permissionsREAD_MEDIA_IMAGES);
+//            case READ_MEDIA_VISUAL_USER_SELECTED: // needed for API 34
+//                return context.getResources().getString(R.string.permissionsREAD_MEDIA_VISUAL_USER_SELECTED);
 //            case NEARBY_WIFI_DEVICES:
 //                return context.getResources().getString(R.string.permissionsNEARBY_WIFI_DEVICES);
             case POST_NOTIFICATIONS:
@@ -227,20 +227,20 @@ public class PermissionsHelper {
                             requestCode);
                     break;
 
-                case READ_MEDIA_IMAGES: // needed for API 33
-                    if (Build.VERSION.SDK_INT >= 33) {
-                        activity.requestPermissions(new String[]{
-                                        Manifest.permission.READ_MEDIA_IMAGES},
-                                requestCode);
-                    }
-                    break;
-                case READ_MEDIA_VISUAL_USER_SELECTED: // needed for API 34
-                    if (Build.VERSION.SDK_INT >= 34) {
-                        activity.requestPermissions(new String[]{
-                                        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED},
-                                requestCode);
-                    }
-                    break;
+//                case READ_MEDIA_IMAGES: // needed for API 33
+//                    if (Build.VERSION.SDK_INT >= 33) {
+//                        activity.requestPermissions(new String[]{
+//                                        Manifest.permission.READ_MEDIA_IMAGES},
+//                                requestCode);
+//                    }
+//                    break;
+//                case READ_MEDIA_VISUAL_USER_SELECTED: // needed for API 34
+//                    if (Build.VERSION.SDK_INT >= 34) {
+//                        activity.requestPermissions(new String[]{
+//                                        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED},
+//                                requestCode);
+//                    }
+//                    break;
 //                case NEARBY_WIFI_DEVICES:
 //                    activity.requestPermissions(new String[]{
 //                                    Manifest.permission.NEARBY_WIFI_DEVICES},
@@ -400,15 +400,15 @@ public class PermissionsHelper {
                 return ContextCompat.checkSelfPermission(context, Manifest.permission.VIBRATE) == PackageManager.PERMISSION_GRANTED;
 
 //<!-- needed for API 33 -->
-            case READ_MEDIA_IMAGES:
-                if (Build.VERSION.SDK_INT >= 33) {
-                    return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED;
-                }
+//            case READ_MEDIA_IMAGES:
+//                if (Build.VERSION.SDK_INT >= 33) {
+//                    return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_IMAGES) == PackageManager.PERMISSION_GRANTED;
+//                }
 //<!-- needed for API 34 -->
-            case READ_MEDIA_VISUAL_USER_SELECTED:
-                if (Build.VERSION.SDK_INT >= 34) {
-                    return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED) == PackageManager.PERMISSION_GRANTED;
-                }
+//            case READ_MEDIA_VISUAL_USER_SELECTED:
+//                if (Build.VERSION.SDK_INT >= 34) {
+//                    return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED) == PackageManager.PERMISSION_GRANTED;
+//                }
 //            case NEARBY_WIFI_DEVICES :
 //                return ContextCompat.checkSelfPermission(context, Manifest.permission.NEARBY_WIFI_DEVICES ) == PackageManager.PERMISSION_GRANTED;
             case POST_NOTIFICATIONS:
@@ -451,14 +451,14 @@ public class PermissionsHelper {
             case WRITE_SETTINGS:
                 return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_SETTINGS);
 
-            case READ_MEDIA_IMAGES:
-                if (Build.VERSION.SDK_INT >= 33) {
-                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_IMAGES);
-                }
-            case READ_MEDIA_VISUAL_USER_SELECTED:
-                if (Build.VERSION.SDK_INT >= 34) {
-                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED);
-                }
+//            case READ_MEDIA_IMAGES:
+//                if (Build.VERSION.SDK_INT >= 33) {
+//                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_IMAGES);
+//                }
+//            case READ_MEDIA_VISUAL_USER_SELECTED:
+//                if (Build.VERSION.SDK_INT >= 34) {
+//                    return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED);
+//                }
 //            case NEARBY_WIFI_DEVICES:
 //                return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.NEARBY_WIFI_DEVICES);
             case POST_NOTIFICATIONS:
@@ -494,14 +494,14 @@ public class PermissionsHelper {
                 return Manifest.permission.ACCESS_FINE_LOCATION;
             case WRITE_SETTINGS:
                 return Manifest.permission.WRITE_SETTINGS;
-            case READ_MEDIA_IMAGES:
-                if (Build.VERSION.SDK_INT >= 33) {
-                    return Manifest.permission.READ_MEDIA_IMAGES;
-                } else { return "";}
-            case READ_MEDIA_VISUAL_USER_SELECTED:
-                if (Build.VERSION.SDK_INT >= 34) {
-                    return Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED;
-                } else { return "";}
+//            case READ_MEDIA_IMAGES:
+//                if (Build.VERSION.SDK_INT >= 33) {
+//                    return Manifest.permission.READ_MEDIA_IMAGES;
+//                } else { return "";}
+//            case READ_MEDIA_VISUAL_USER_SELECTED:
+//                if (Build.VERSION.SDK_INT >= 34) {
+//                    return Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED;
+//                } else { return "";}
             case POST_NOTIFICATIONS:
                 if (Build.VERSION.SDK_INT >= 33) {
                     return Manifest.permission.POST_NOTIFICATIONS;

--- a/EngineDriver/src/main/java/jmri/jmrit/roster/RosterEntry.java
+++ b/EngineDriver/src/main/java/jmri/jmrit/roster/RosterEntry.java
@@ -117,7 +117,7 @@ public class RosterEntry {
     }
 
     public String getImagePath() {
-        if ((_imageFilePath != null) && (_imageFilePath.length() > 0))
+        if ((_imageFilePath != null) && (!_imageFilePath.isEmpty()))
             try {
                 return resourcesURL + URLEncoder.encode(_imageFilePath, "UTF-8");
             } catch (UnsupportedEncodingException ignored) {
@@ -126,7 +126,7 @@ public class RosterEntry {
     }
 
     public String getIconPath() {
-        if ((_iconFilePath != null) && (_iconFilePath.length() > 0) && (!_iconFilePath.equals("__noIcon.jpg"))) {
+        if ((_iconFilePath != null) && (!_iconFilePath.isEmpty()) && (!_iconFilePath.equals("__noIcon.jpg"))) {
             try {
                 //decide which icon path to use, path was changed with jetty upgrade, 2.99.5
 //                HashMap<String, String> metadata = threaded_application.jmriMetadata;  //reference global metadata
@@ -191,11 +191,11 @@ public class RosterEntry {
                 _dccAddress = nm.item(k).getNodeValue();
                 continue;
             }
-            if (("imageFilePath".compareTo(nm.item(k).getNodeName()) == 0) && (nm.item(k).getNodeValue().length() > 0)) {
+            if (("imageFilePath".compareTo(nm.item(k).getNodeName()) == 0) && (!nm.item(k).getNodeValue().isEmpty())) {
                 _imageFilePath = nm.item(k).getNodeValue();
                 continue;
             }
-            if (("iconFilePath".compareTo(nm.item(k).getNodeName()) == 0) && (nm.item(k).getNodeValue().length() > 0)) {
+            if (("iconFilePath".compareTo(nm.item(k).getNodeName()) == 0) && (!nm.item(k).getNodeValue().isEmpty())) {
                 _iconFilePath = nm.item(k).getNodeValue();
                 continue;
             }
@@ -305,11 +305,11 @@ public class RosterEntry {
                         lockable = ("true".compareTo(nm.item(k).getNodeValue()) == 0);
                         continue;
                     }
-                    if (("functionImage".compareTo(nm.item(k).getNodeName()) == 0) && (nm.item(k).getNodeValue().length() > 0)) {
+                    if (("functionImage".compareTo(nm.item(k).getNodeName()) == 0) && (!nm.item(k).getNodeValue().isEmpty())) {
                         imOff = nm.item(k).getNodeValue();
                         continue;
                     }
-                    if (("functionImageSelected".compareTo(nm.item(k).getNodeName()) == 0) && (nm.item(k).getNodeValue().length() > 0)) {
+                    if (("functionImageSelected".compareTo(nm.item(k).getNodeName()) == 0) && (!nm.item(k).getNodeValue().isEmpty())) {
                         imOn = nm.item(k).getNodeValue();
                         continue;
                     }
@@ -380,7 +380,7 @@ public class RosterEntry {
     }
 
     public String getFunctionImage(int fn) {
-        if ((functionImages != null) && (functionImages.length > fn) && (functionImages[fn] != null) && (functionImages[fn].length() > 0))
+        if ((functionImages != null) && (functionImages.length > fn) && (functionImages[fn] != null) && (!functionImages[fn].isEmpty()))
             return resourcesURL + functionImages[fn];
         return null;
     }
@@ -394,7 +394,7 @@ public class RosterEntry {
     }
 
     public String getFunctionSelectedImage(int fn) {
-        if ((functionSelectedImages != null) && (functionSelectedImages.length > fn) && (functionSelectedImages[fn] != null) && (functionSelectedImages[fn].length() > 0))
+        if ((functionSelectedImages != null) && (functionSelectedImages.length > fn) && (functionSelectedImages[fn] != null) && (!functionSelectedImages[fn].isEmpty()))
             return resourcesURL + functionSelectedImages[fn];
         return null;
     }

--- a/EngineDriver/src/main/res/values-ca/strings.xml
+++ b/EngineDriver/src/main/res/values-ca/strings.xml
@@ -902,7 +902,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">No s\'ha seleccionat cap imatge</string>
     <string name="prefBackgroundImageFileNameSummary">Introduïu el nom de l\'arxiu d\'imatge de fons</string>
     <string name="prefBackgroundImageFileNameTitle">Nom de l\'arxiu de la imatge de fons</string>
-    <string name="prefBackgroundImageSummary">Mostrar una imatge de fons a la pàgina del Controlador</string>
+    <string name="prefBackgroundImageSummary">Mostra una imatge de fons a la majoria de pàgines</string>
     <string name="prefBackgroundImageTitle">Imatge de fons</string>
     <string name="prefBackgroundImagePositionSummary">Selecciona com es col·locarà a la pantalla la imatge de fons</string>
     <string name="prefBackgroundImagePositionTitle">Posició de la imatge de fons</string>
@@ -1159,8 +1159,8 @@
     <string name="dccexWriteCvValueLabel">Valorar</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignora les accions de joystick</string>
     <string name="prefGamePadIgnoreJoystickSummary">Seleccioneu -ho si teniu problemes amb el DPAD produint tant codes com a esdeveniments de joystick</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessita els permisos READ_MEDIA_IMAGES per carregar imatges de fons.\n\nEngine Driver funcionarà sense ell.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessita els permisos READ_MEDIA_VISUAL_USER_SELECTED per carregar imatges de fons.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessita els permisos READ_MEDIA_IMAGES per carregar imatges de fons.\n\nEngine Driver funcionarà sense ell.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessita els permisos READ_MEDIA_VISUAL_USER_SELECTED per carregar imatges de fons.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver necessita els permisos propers_wifi_Devices per recuperar WiFi SSID actual.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver necessita permisos de notificació per avisar -vos quan empenyeu -vos al fons.</string>
     <string name="prefDccexPreferencesTitle">preferències DCC-EX - EX-CommandStation</string>

--- a/EngineDriver/src/main/res/values-cs/strings.xml
+++ b/EngineDriver/src/main/res/values-cs/strings.xml
@@ -1000,7 +1000,7 @@
     
     <string name="prefBackgroundImagePreferencesTitle">Předvolby obrázku pozadí</string>
     <string name="prefBackgroundImageTitle">Obrázek pozadí</string>
-    <string name="prefBackgroundImageSummary">Zobrazit obrázek pozadí na stránce Ovladače</string>
+    <string name="prefBackgroundImageSummary">Zobrazit obrázek na pozadí na většině stránek</string>
 
     <string name="prefBackgroundImageFileNameTitle">Název souboru obrázku pozadí</string>
     <string name="prefBackgroundImageFileNameSummary">Zadejte název souboru pro obrázek pozadí.</string>
@@ -1248,8 +1248,8 @@
     <string name="dccexWriteCvValueLabel">Hodnota</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignorujte akce joysticku</string>
     <string name="prefGamePadIgnoreJoystickSummary">Vyberte to, pokud máte problémy s DPAD produkujícími jak události klíčových kódů, tak joysticků</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver potřebuje read_media_images oprávnění k načtení obrázků na pozadí.\n\nEngine Driver bude fungovat i bez něj.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver potřebuje READ_MEDIA_VISUAL_USER_SELECTED oprávnění k načtení obrázků na pozadí.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver potřebuje read_media_images oprávnění k načtení obrázků na pozadí.\n\nEngine Driver bude fungovat i bez něj.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver potřebuje READ_MEDIA_VISUAL_USER_SELECTED oprávnění k načtení obrázků na pozadí.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver potřebuje oprávnění nedalekých_wifi_devices k načtení aktuálního WiFi SSID.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver potřebuje oprávnění k oznámení, aby vás varovala, když se tlačí na pozadí.</string>
     <string name="prefDccexPreferencesTitle">DCC-EX - EX-CommandStation preference</string>

--- a/EngineDriver/src/main/res/values-de/strings.xml
+++ b/EngineDriver/src/main/res/values-de/strings.xml
@@ -858,7 +858,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">Kein Bild ausgewählt wurde</string>
     <string name="prefBackgroundImageFileNameSummary">Wählen Sie den Namen der Hintergrundbilddatei.</string>
     <string name="prefBackgroundImageFileNameTitle">Hintergrund Bilddateinamen</string>
-    <string name="prefBackgroundImageSummary">Zeigen Sie ein Hintergrundbild auf der Fahrreglerseite</string>
+    <string name="prefBackgroundImageSummary">Auf den meisten Seiten ein Hintergrundbild anzeigen</string>
     <string name="prefBackgroundImageTitle">Hintergrundbild</string>
     <string name="prefBackgroundImagePositionSummary">Wählen Sie, wie das Hintergrundbild auf dem Bildschirm positioniert werden soll.</string>
     <string name="prefBackgroundImagePositionTitle">Hintergrund Bildposition</string>
@@ -1111,8 +1111,8 @@
     <string name="dccexWriteCvValueLabel">Wert</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignorieren Sie Joystick -Handlungen</string>
     <string name="prefGamePadIgnoreJoystickSummary">Wählen Sie dies aus, wenn Sie Probleme mit dem DPAD haben, der sowohl Schlüsselcodes als auch Joystick -Ereignisse erstellt</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver benötigt Read_Media_images -Berechtigungen, um Hintergrundbilder zu laden.\n\nEngine Driver funktioniert auch ohne.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver benötigt READ_MEDIA_VISUAL_USER_SELECTED -Berechtigungen, um Hintergrundbilder zu laden.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver benötigt Read_Media_images -Berechtigungen, um Hintergrundbilder zu laden.\n\nEngine Driver funktioniert auch ohne.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver benötigt READ_MEDIA_VISUAL_USER_SELECTED -Berechtigungen, um Hintergrundbilder zu laden.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver benötigt die Berechtigungen in der Nähe_WIFI_Devices, um die aktuelle WLAN -SSID abzurufen.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver benötigt Benachrichtigungsberechtigungen, um Sie zu warnen, wenn Sie in den Hintergrund drücken.</string>
     <string name="prefDccexPreferencesTitle">DCC-EX - EX-CommandStation Einstellungen</string>

--- a/EngineDriver/src/main/res/values-es/strings.xml
+++ b/EngineDriver/src/main/res/values-es/strings.xml
@@ -892,7 +892,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">No se seleccionó ninguna imagen</string>
     <string name="prefBackgroundImageFileNameSummary">Introduzca el nombre del archivo de imagen de fondo</string>
     <string name="prefBackgroundImageFileNameTitle">Nombre del archivo de la imagen de fondo</string>
-    <string name="prefBackgroundImageSummary">Mostrar una imagen de fondo en la página del Controlador</string>
+    <string name="prefBackgroundImageSummary">Mostrar una imagen de fondo en la mayoría de las páginas.</string>
     <string name="prefBackgroundImageTitle">Imagen de fondo</string>
     <string name="prefBackgroundImagePositionSummary">Selecciona como se colocará en la pantalla la imagen de fondo</string>
     <string name="prefBackgroundImagePositionTitle">Posición de la imagen de fondo</string>
@@ -1149,8 +1149,8 @@
     <string name="dccexWriteCvValueLabel">Valor</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignorar acciones de joystick</string>
     <string name="prefGamePadIgnoreJoystickSummary">Seleccione esto si tiene problemas con el DPAD que produce códigos clave y eventos de joystick</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necesita permisos Read_media_Images para cargar imágenes de fondo.\n\nEngine Driver funcionará sin él.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necesita permisos READ_MEDIA_VISUAL_USER_SELECTED para cargar imágenes de fondo.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necesita permisos Read_media_Images para cargar imágenes de fondo.\n\nEngine Driver funcionará sin él.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necesita permisos READ_MEDIA_VISUAL_USER_SELECTED para cargar imágenes de fondo.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver necesita permisos cercanos_wifi_devices para recuperar el SSID WiFi actual.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver necesita permisos de notificación para advertirle cuando empuje en el fondo.</string>
     <string name="prefDccexPreferencesTitle">Preferencias DCC-EX - EX-CommandStation</string>

--- a/EngineDriver/src/main/res/values-fr-rCA/strings.xml
+++ b/EngineDriver/src/main/res/values-fr-rCA/strings.xml
@@ -333,8 +333,8 @@
 
 
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver nécessite la permission NOTIFICATION pour vous aviser avec des notifications lorsque l\'application est basculée en arrière plan.</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver nécessite la permission READ_MEDIA_IMAGES pour afficher les images en arrière plan.\n\nEngine Driver fonctionnera sans lui.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver nécessite la permission READ_MEDIA_VISUAL_USER_SELECTED pour afficher les images en arrière plan.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver nécessite la permission READ_MEDIA_IMAGES pour afficher les images en arrière plan.\n\nEngine Driver fonctionnera sans lui.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver nécessite la permission READ_MEDIA_VISUAL_USER_SELECTED pour afficher les images en arrière plan.</string>-->
 
 
 
@@ -394,7 +394,7 @@
     <string name="prefBackgroundImagePositionSummary">Spécifier l\'emplacement de l\'image d\'arrière plan sur l\'écran.</string>
     <string name="prefBackgroundImagePositionTitle">Emplacement de l\'image d\'arrière plan</string>
     <string name="prefBackgroundImagePreferencesTitle">Préférences de l\'image d\'arrière plan</string>
-    <string name="prefBackgroundImageSummary">Afficher une image d\'arrière plan sur l\'écran du régulateur</string>
+    <string name="prefBackgroundImageSummary">Afficher une image de fond sur la plupart des pages</string>
     <string name="prefBackgroundImageTitle">Image d\'arrière plan</string>
     <string name="prefCategoryDevicePageTitle">Préférences de l\'appareil</string>
     <string name="prefConnectTimeoutMsSummary">Delai de connexion initiale par défaut.</string>

--- a/EngineDriver/src/main/res/values-fr/strings.xml
+++ b/EngineDriver/src/main/res/values-fr/strings.xml
@@ -911,7 +911,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">Aucune image selectionnee</string>
     <string name="prefBackgroundImageFileNameSummary">Entrer le nom de l image d Arriere Plan</string>
     <string name="prefBackgroundImageFileNameTitle">Nom du fichier d Arriere Plan</string>
-    <string name="prefBackgroundImageSummary">Affichage Arriere Plan sur régulateur?</string>
+    <string name="prefBackgroundImageSummary">Afficher une image de fond sur la plupart des pages</string>
     <string name="prefBackgroundImageTitle">Image d Arriere Plan</string>
     <string name="prefBackgroundImagePositionSummary">Choisir position de l Arriere Plan</string>
     <string name="prefBackgroundImagePositionTitle">Position image Arriere Plan</string>
@@ -1157,8 +1157,8 @@
     <string name="dccexWriteCvValueLabel">Valeur</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignorer les actions du joystick</string>
     <string name="prefGamePadIgnoreJoystickSummary">A selectionner en cas de probleme si le DPAD cree des codes cles et des evenements Joystick</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessite la permission d acces aux IMAGES pour charger celles-ci en arriere plan.\n\nEngineDriver fonctionnera sans lui.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessite la permission d acces aux READ_MEDIA_VISUAL_USER_SELECTED pour charger celles-ci en arriere plan.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessite la permission d acces aux IMAGES pour charger celles-ci en arriere plan.\n\nEngineDriver fonctionnera sans lui.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessite la permission d acces aux READ_MEDIA_VISUAL_USER_SELECTED pour charger celles-ci en arriere plan.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver necessite la permission d acces aux reseaux WiFi proches pour detecter le SSID WiFi.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver necessite la permission d acces aux NOTIFICATIONS pour indiquer son passage en arriere plan</string>
     <string name="prefDccexPreferencesTitle">Preferences DCC-EX - EX-CommandStation</string>

--- a/EngineDriver/src/main/res/values-it/strings.xml
+++ b/EngineDriver/src/main/res/values-it/strings.xml
@@ -826,7 +826,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">Nessun immagine è stata selezionata</string>
     <string name="prefBackgroundImageFileNameSummary">Immettere il nome del file di immagine di sfondo.</string>
     <string name="prefBackgroundImageFileNameTitle">Background Image File Name</string>
-    <string name="prefBackgroundImageSummary">Mostra un\'immagine di sfondo sulla pagina Throttle</string>
+    <string name="prefBackgroundImageSummary">Mostra un\'immagine di sfondo nella maggior parte delle pagine</string>
     <string name="prefBackgroundImageTitle">Immagine di sfondo</string>
     <string name="prefBackgroundImagePositionSummary">Selezionare come l\'immagine di sfondo sarà posizionato sullo schermo.</string>
     <string name="prefBackgroundImagePositionTitle">Immagine di sfondo di posizione</string>
@@ -1089,8 +1089,8 @@
     <string name="dccexWriteCvValueLabel">Valore</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignora le azioni del joystick</string>
     <string name="prefGamePadIgnoreJoystickSummary">Seleziona questo se hai problemi con il DPAD che produce sia i codici chiave che gli eventi del joystick</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessita di READ_MEDIA_IMAGES autorizzazioni per caricare le immagini di sfondo.\n\nEngine Driver funzionerà senza di esso.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessita di READ_MEDIA_VISUAL_USER_SELECTED autorizzazioni per caricare le immagini di sfondo.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver necessita di READ_MEDIA_IMAGES autorizzazioni per caricare le immagini di sfondo.\n\nEngine Driver funzionerà senza di esso.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver necessita di READ_MEDIA_VISUAL_USER_SELECTED autorizzazioni per caricare le immagini di sfondo.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver ha bisogno di vicinanze_wifi_devices autorizzazioni per recuperare l\'attuale SSID WiFi.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver ha bisogno di autorizzazioni di notifica per avvertirti quando si spinge in background.</string>
     <string name="prefDccexPreferencesTitle">Preferenze DCC-EX - EX-CommandStation</string>

--- a/EngineDriver/src/main/res/values-ja/strings.xml
+++ b/EngineDriver/src/main/res/values-ja/strings.xml
@@ -370,8 +370,8 @@
 
 
     <string name="permissionsPOST_NOTIFICATIONS">エンジン ドライバーには、バックグラウンドにプッシュされたときに警告を表示する NOTIFICATION 権限が必要です。</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">エンジン ドライバーには、背景画像を読み込むための READ_MEDIA_IMAGES 権限が必要です。\n\nEngineDriver はこれなしでも動作します。</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">エンジン ドライバーには、背景画像を読み込むための READ_MEDIA_VISUAL_USER_SELECTED 権限が必要です。</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">エンジン ドライバーには、背景画像を読み込むための READ_MEDIA_IMAGES 権限が必要です。\n\nEngineDriver はこれなしでも動作します。</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">エンジン ドライバーには、背景画像を読み込むための READ_MEDIA_VISUAL_USER_SELECTED 権限が必要です。</string>-->
 
 
 
@@ -433,7 +433,7 @@
     <string name="prefBackgroundImagePositionSummary">背景画像を画面上にどのように配置するかを選択します。</string>
     <string name="prefBackgroundImagePositionTitle">背景画像の位置</string>
     <string name="prefBackgroundImagePreferencesTitle">背景画像の設定</string>
-    <string name="prefBackgroundImageSummary">スロットルページに背景画像を表示します</string>
+    <string name="prefBackgroundImageSummary">ほとんどのページに背景画像を表示する</string>
     <string name="prefBackgroundImageTitle">背景画像</string>
     <string name="prefCategoryDevicePageTitle">デバイスの設定</string>
     <string name="prefConnectTimeoutMsSummary">初期接続タイムアウトをミリ秒単位で設定します</string>

--- a/EngineDriver/src/main/res/values-pt/strings.xml
+++ b/EngineDriver/src/main/res/values-pt/strings.xml
@@ -828,7 +828,7 @@
     <string name="prefBackgroundImageFileNameNoImageSelected">Nenhuma imagem foi selecionada</string>
     <string name="prefBackgroundImageFileNameSummary">Digite o nome do arquivo de imagem de fundo.</string>
     <string name="prefBackgroundImageFileNameTitle">Fundo Nome do Arquivo de Imagem</string>
-    <string name="prefBackgroundImageSummary">Mostrar uma imagem de fundo na página do acelerador</string>
+    <string name="prefBackgroundImageSummary">Exibir uma imagem de fundo na maioria das páginas.</string>
     <string name="prefBackgroundImageTitle">Imagem de fundo</string>
     <string name="prefBackgroundImagePositionSummary">Selecione como a imagem de fundo será posicionado na tela.</string>
     <string name="prefBackgroundImagePositionTitle">Fundo Posição da Imagem</string>
@@ -1097,8 +1097,8 @@
     <string name="dccexWriteCvValueLabel">Valor</string>
     <string name="prefGamePadIgnoreJoystickTitle">Ignore as ações do joystick</string>
     <string name="prefGamePadIgnoreJoystickSummary">Selecione isso se tiver problemas com o DPAD produzindo códigos -chave e eventos de joystick</string>
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver precisa de permissões READ_MEDIA_IMAGES para carregar imagens em segundo plano.\n\nO EngineDriver funcionará sem ele.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver precisa de permissões READ_MEDIA_VISUAL_USER_SELECTED para carregar imagens em segundo plano.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver precisa de permissões READ_MEDIA_IMAGES para carregar imagens em segundo plano.\n\nO EngineDriver funcionará sem ele.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver precisa de permissões READ_MEDIA_VISUAL_USER_SELECTED para carregar imagens em segundo plano.</string>-->
 <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver precisa de permissões nas proximidades de recuperar o WiFi SSID atual.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver precisa de permissões de notificação para avisá -lo quando formar em segundo plano.</string>
     <string name="prefDccexPreferencesTitle">DCC-EX - EX-CommandStation Preferências</string>

--- a/EngineDriver/src/main/res/values-zh-rCN/strings.xml
+++ b/EngineDriver/src/main/res/values-zh-rCN/strings.xml
@@ -976,8 +976,8 @@ T0 - T5 = 为下一个命令指定一个限制
     <string name="permissionsConnectToServer">Engine Driver需要存储权限来保存最近连接，以及电话权限以在通话时暂停操作。</string>
 
 <!-- needed for API 33 -->
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver需要读取媒体图片权限来加载背景图片。\n\n即使没有此权限，Engine Driver仍可运行。</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver需要读取用户选择的媒体视觉内容权限来加载背景图片。  即使没有此权限，Engine Driver仍可运行。</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver需要读取媒体图片权限来加载背景图片。\n\n即使没有此权限，Engine Driver仍可运行。</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver需要读取用户选择的媒体视觉内容权限来加载背景图片。  即使没有此权限，Engine Driver仍可运行。</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver需要通知权限以在应用进入后台时向您发出警告。</string>
 <!-- needed for API 33 -->
 
@@ -1070,7 +1070,7 @@ T0 - T5 = 为下一个命令指定一个限制
 
     <string name="prefBackgroundImagePreferencesTitle">背景图片偏好设置</string>
     <string name="prefBackgroundImageTitle">背景图片</string>
-    <string name="prefBackgroundImageSummary">在节流阀屏幕上显示背景图片</string>
+    <string name="prefBackgroundImageSummary">大多数页面显示背景图片</string>
 
     <string name="prefBackgroundImageFileNameTitle">背景图片文件名</string>
     <string name="prefBackgroundImageFileNameSummary">输入背景图片文件的名称。</string>

--- a/EngineDriver/src/main/res/values/arrays.xml
+++ b/EngineDriver/src/main/res/values/arrays.xml
@@ -2760,10 +2760,9 @@
     <!-- only include top level preferences in this list.  Use the 'advancedSubPreferences' list for second level ones-->
     <string-array name="advancedPreferences" translatable="false">
         <!-- Device Preferences -->
-<!--        <item>prefLocale</item>-->
         <item>prefDoubleBackButtonToExit</item>
         <item>ToastsOptionsPreferences</item>
-<!--        <item>prefHideInstructionalToasts</item>-->
+        <item>prefBackgroundImageGroup</item>  <!-- PreferenceScreen -->
         <item>prefLeftRightSwipeChangesSpeed</item>
 
         <!-- Throttle Screen Appearance Preferences -->
@@ -2778,7 +2777,6 @@
         <item>default_function_preferences</item>  <!-- PreferenceScreen -->
         <item>prefHideFunctionButtonsOfNonSelectedThrottle</item>
         <item>prefSimpleThrottleLayoutShowFunctionButtonCount</item>
-<!--        <item>prefBackgroundImageGroup</item>--> <!-- PreferenceScreen -->
         <item>prefCategoryHapticFeedbackScreen</item> <!-- PreferenceScreen -->
 
         <!-- Status Row Preferences -->

--- a/EngineDriver/src/main/res/values/strings.xml
+++ b/EngineDriver/src/main/res/values/strings.xml
@@ -1316,8 +1316,8 @@
     <string name="permissionsConnectToServer">Engine Driver needs STORAGE permissions to store recent connections and PHONE permissions to pause operations when on a call.</string>
 
     <!-- needed for API 33 -->
-    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver needs READ_MEDIA_IMAGES permissions to load background images.\n\nEngine Driver will work without it.</string>
-    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver needs READ_MEDIA_VISUAL_USER_SELECTED permissions to load background images.\n\nEngine Driver will work without it.</string>
+<!--    <string name="permissionsREAD_MEDIA_IMAGES">Engine Driver needs READ_MEDIA_IMAGES permissions to load background images.\n\nEngine Driver will work without it.</string>-->
+<!--    <string name="permissionsREAD_MEDIA_VISUAL_USER_SELECTED">Engine Driver needs READ_MEDIA_VISUAL_USER_SELECTED permissions to load background images.\n\nEngine Driver will work without it.</string>-->
     <!--    <string name="permissionsNEARBY_WIFI_DEVICES">Engine Driver needs NEARBY_WIFI_DEVICES permissions to retrieve current wifi SSID.</string>-->
     <string name="permissionsPOST_NOTIFICATIONS">Engine Driver needs NOTIFICATION permissions to warn you when push into background.</string>
     <!-- needed for API 33 -->
@@ -1438,7 +1438,7 @@
 
     <string name="prefBackgroundImagePreferencesTitle">Background Image Preferences</string>
     <string name="prefBackgroundImageTitle">Background Image</string>
-    <string name="prefBackgroundImageSummary">Show a background image on the Throttle screen</string>
+    <string name="prefBackgroundImageSummary">Show a background image on most pages</string>
 
     <string name="prefBackgroundImageFileNameTitle">Background Image File Name</string>
     <string name="prefBackgroundImageFileNameSummary">Enter the name of the background image file.</string>

--- a/EngineDriver/src/main/res/xml/preferences.xml
+++ b/EngineDriver/src/main/res/xml/preferences.xml
@@ -49,6 +49,47 @@
             android:summary="@string/prefThemeSummary"
             android:title="@string/prefThemeTitle" />
 
+        <PreferenceScreen
+            android:icon="?attr/ed_folder_background"
+            android:key="prefBackgroundImageGroup"
+            android:layout="@layout/preference_item_common_icon_left"
+            android:persistent="false"
+            android:summary="@string/prefBackgroundImageSummary"
+            android:title="@string/prefBackgroundImagePreferencesTitle">
+
+            <PreferenceCategory
+                android:icon="@drawable/glyph_preference_category_background"
+                android:layout="@layout/preference_category_icon_left"
+                android:title="@string/prefBackgroundImagePreferencesTitle">
+
+                <SwitchPreferenceCompat
+                    android:defaultValue="@bool/prefBackgroundImageDefaultValue"
+                    android:key="prefBackgroundImage"
+                    android:layout="@layout/preference_item_switch_no_icon"
+                    android:summary="@string/prefBackgroundImageSummary"
+                    android:title="@string/prefBackgroundImageTitle" />
+
+                <Preference
+                    android:key="prefBackgroundImageFileNameImagePicker"
+                    android:layout="@layout/preference_item_common_no_icon"
+                    android:summary="@string/prefBackgroundImageFileNameSummary"
+                    android:title="@string/prefBackgroundImageFileNameTitle" />
+
+                <ListPreference
+                    android:defaultValue="@string/prefBackgroundImagePositionDefaultValue"
+                    android:entries="@array/prefBackgroundImagePositionEntries"
+                    android:entryValues="@array/prefBackgroundImagePositionEntryValues"
+                    android:key="prefBackgroundImagePosition"
+                    android:layout="@layout/preference_item_common_no_icon"
+                    android:summary="@string/prefBackgroundImagePositionSummary"
+                    android:title="@string/prefBackgroundImagePositionTitle" />
+            </PreferenceCategory>
+        </PreferenceScreen>
+
+        <PreferenceCategory
+            android:title="divider"
+            android:layout="@layout/preference_category_divider"/>
+
         <ListPreference
             android:defaultValue="@string/prefLocaleDefaultValue"
             android:entries="@array/prefLocaleEntries"
@@ -58,6 +99,10 @@
             android:icon="?attr/ed_preferences_localisation"
             android:summary="@string/prefLocaleSummary"
             android:title="@string/prefLocaleTitle" />
+
+        <PreferenceCategory
+            android:title="divider"
+            android:layout="@layout/preference_category_divider"/>
 
         <PreferenceScreen
             android:icon="?attr/ed_folder_left_right_swipe"
@@ -139,18 +184,22 @@
             android:summary="@string/prefDoubleBackButtonToExitSummary"
             android:title="@string/prefDoubleBackButtonToExitTitle" />
 
-            <PreferenceScreen
-                android:icon="?attr/ed_folder_hint"
-                android:key="ToastsOptionsPreferences"
-                android:layout="@layout/preference_item_common_icon_left"
-                android:persistent="false"
-                android:summary="@string/ToastsOptionsSummary"
-                android:title="@string/ToastsOptionsTitle">
+        <PreferenceCategory
+            android:title="divider"
+            android:layout="@layout/preference_category_divider"/>
 
-                <PreferenceCategory
-                    android:icon="@drawable/glyph_preference_category_hint"
-                    android:layout="@layout/preference_category_icon_left"
-                    android:title="@string/ToastsOptionsTitle">
+        <PreferenceScreen
+            android:icon="?attr/ed_folder_hint"
+            android:key="ToastsOptionsPreferences"
+            android:layout="@layout/preference_item_common_icon_left"
+            android:persistent="false"
+            android:summary="@string/ToastsOptionsSummary"
+            android:title="@string/ToastsOptionsTitle">
+
+            <PreferenceCategory
+                android:icon="@drawable/glyph_preference_category_hint"
+                android:layout="@layout/preference_category_icon_left"
+                android:title="@string/ToastsOptionsTitle">
 
                 <SwitchPreferenceCompat
                     android:defaultValue="@bool/prefHideInstructionalToastsDefaultValue"
@@ -712,47 +761,6 @@
                     android:layout="@layout/preference_item_common_no_icon"
                     android:summary="@string/prefAccelerometerShakeThresholdSummary"
                     android:title="@string/prefAccelerometerShakeThresholdTitle" />
-            </PreferenceCategory>
-        </PreferenceScreen>
-
-        <PreferenceCategory
-            android:title="divider"
-            android:layout="@layout/preference_category_divider"/>
-
-        <PreferenceScreen
-            android:icon="?attr/ed_folder_background"
-            android:key="prefBackgroundImageGroup"
-            android:layout="@layout/preference_item_common_icon_left"
-            android:persistent="false"
-            android:summary="@string/prefBackgroundImageSummary"
-            android:title="@string/prefBackgroundImagePreferencesTitle">
-
-            <PreferenceCategory
-                android:icon="@drawable/glyph_preference_category_background"
-                android:layout="@layout/preference_category_icon_left"
-                android:title="@string/prefBackgroundImagePreferencesTitle">
-
-                <SwitchPreferenceCompat
-                    android:defaultValue="@bool/prefBackgroundImageDefaultValue"
-                    android:key="prefBackgroundImage"
-                    android:layout="@layout/preference_item_switch_no_icon"
-                    android:summary="@string/prefBackgroundImageSummary"
-                    android:title="@string/prefBackgroundImageTitle" />
-
-                <Preference
-                    android:key="prefBackgroundImageFileNameImagePicker"
-                    android:layout="@layout/preference_item_common_no_icon"
-                    android:summary="@string/prefBackgroundImageFileNameSummary"
-                    android:title="@string/prefBackgroundImageFileNameTitle" />
-
-                <ListPreference
-                    android:defaultValue="@string/prefBackgroundImagePositionDefaultValue"
-                    android:entries="@array/prefBackgroundImagePositionEntries"
-                    android:entryValues="@array/prefBackgroundImagePositionEntryValues"
-                    android:key="prefBackgroundImagePosition"
-                    android:layout="@layout/preference_item_common_no_icon"
-                    android:summary="@string/prefBackgroundImagePositionSummary"
-                    android:title="@string/prefBackgroundImagePositionTitle" />
             </PreferenceCategory>
         </PreferenceScreen>
 

--- a/changelog-and-todo-list.txt
+++ b/changelog-and-todo-list.txt
@@ -4,6 +4,7 @@
      * Support for the new DCC-EX WiFi commands in the drop list.
      * Set web port to 80 for DCC-EX. (version and processor dependant)
      * Added preferences to customise the Thrown/Closed button labels for DCC-EX.
+     * Removed need for READ_MEDIA_VISUAL_USER_SELECTED and READ_MEDIA_IMAGES Permissions.
  * Bug Fixes
      * Clock not displaying initially, and not updating consistently.
      * Layout swap button was not refreshing the screen.
@@ -11,6 +12,7 @@
      * Don't query the DCC-EX EStop Pause/Resume state unless the preference is set and the CS version is correct.
      * Recent Locos and Recent consists being duplicated.
      * Locos acquired by Address and Roster not being recorded separately in the Recents.
+     * Keyboard commands for Forward/Reverse acted as a toggle rather than the specified direction.
  * Other
      * Reworking of the custom toast popup.
      * Reworking of most of the images in the intro/wizard
@@ -26,6 +28,7 @@
      * Continued renaming of some files for consistency.
      * Linting.
      * Rethink of the way ED requests the Consist (CV19) value after requesting the decoder address for DCC-EX.
+     * Moved the prefBackgroundImage group to the device section of the preferences as it now impacts more than the throttle screen.
 **Version 2.43.224
  * New Features
      * Added notching on the throttle sliders when using other than 126 or percent options.
@@ -1172,6 +1175,7 @@
  *   TODO: work out when to play the engine shut down sounds
  *   TODO: link each loco address to a specific Sound Profile / remember Sound Profile used for each loco address
  *   TODO: load and play the intermediate step/notch engine sounds
+ *   TODO: change the arrays of sound files names to arrays of resource IDs
  * select_loco:
  *   TODO: allow user to specify which loco to get labels from
  *   TODO: manually create roster entries (function labels) and store on device - In Phone Roster


### PR DESCRIPTION
- Bug fix - Keyboard commands for Forward/Reverse acted as a toggle rather than the specified direction.
- some more simple linting.
- Moved the prefBackgroundImage group to the device section of the preferences as it now impacts more than the throttle screen.
- Removed need for READ_MEDIA_VISUAL_USER_SELECTED and READ_MEDIA_IMAGES Permissions.

Hit a major road block when trying to publish EX-Toolbox with the READ_MEDIA_IMAGES Permission included.  ED will have the same issue.
Turns out you don't need any permission to use any Image Picker. So I now take the result from the picker and copy the file to scoped storage, which needs no permissions to access ongoing.
